### PR TITLE
Item frames can now be rotated with container trust

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -52,6 +52,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Hanging;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Tameable;
 import org.bukkit.entity.Vehicle;
@@ -1162,8 +1163,8 @@ class PlayerEventHandler implements Listener
             }
         }
         
-        //don't allow interaction with item frames or armor stands in claimed areas without build permission
-		if(entity.getType() == EntityType.ARMOR_STAND || entity instanceof Hanging)
+                //don't allow interaction with armor stands in claimed areas without build permission
+		if(entity.getType() == EntityType.ARMOR_STAND)
 		{
 			String noBuildReason = instance.allowBuild(player, entity.getLocation(), Material.ITEM_FRAME); 
 			if(noBuildReason != null)
@@ -1173,6 +1174,17 @@ class PlayerEventHandler implements Listener
 				return;
 			}			
 		}
+                
+                //don't allow interaction with item frames in claimed areas without container permission
+                if (entity instanceof ItemFrame) {
+                    Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, playerData.lastClaim);
+                    String noContainerReason = claim.allowContainers(player);
+                    if (noContainerReason != null) {
+                        instance.sendMessage(player, TextMode.Err, noContainerReason);
+                        event.setCancelled(true);
+                        return;
+                    }
+                }
 		
 		//limit armor placements when entity count is too high
 		if(entity.getType() == EntityType.ARMOR_STAND && instance.creativeRulesApply(player.getLocation()))


### PR DESCRIPTION
In the _onPlayerInteractAtEntity_ event (player right clicks an entity), I updated the code so the player could right click the item frame and therefore rotate the item inside with a containertrust permission level.
You can't still break or place itemframes or other hanging entitys like paintings as that is handled in other events. You can't get the item inside the frame either.
