### PR TITLE
Show claim size to everyone.

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -247,6 +247,7 @@ permissions:
             griefprevention.deleteclaimsinworld: true
             griefprevention.siegeteleport: true
             griefprevention.unlockothersdrops: true
+            griefprevention.seeclaimsize: true
     griefprevention.siegeimmune:
         description: Makes a player immune to /Siege.
         default: op
@@ -321,6 +322,9 @@ permissions:
         default: true
     griefprevention.visualizenearbyclaims:
         description: Allows a player to see all nearby claims at once.
+        default: op
+    griefprevention.seeclaimsize:
+        description: Allows a player to see claim size for other players claims when right clicking with investigation tool
         default: op
     griefprevention.gpblockinfo:
         description: Grants access to /GPBlockInfo.

--- a/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1891,9 +1891,9 @@ class PlayerEventHandler implements Listener
 
 					Visualization.Apply(player, visualization);
 
-                                        if (player.hasPermission('griefprevention.seeclaimsize')) {
-                                            instance.sendMessage(player, TextMode.Info, "  " + claim.getWidth() + "x" + claim.getHeight() + "=" + claim.getArea());
-                                        }
+					if (player.hasPermission('griefprevention.seeclaimsize')) {
+						instance.sendMessage(player, TextMode.Info, "  " + claim.getWidth() + "x" + claim.getHeight() + "=" + claim.getArea());
+					}
 
 					//if permission, tell about the player's offline time
 					if(!claim.isAdminClaim() && (player.hasPermission("griefprevention.deleteclaims") || player.hasPermission("griefprevention.seeinactivity")))

--- a/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1891,11 +1891,7 @@ class PlayerEventHandler implements Listener
 
 					Visualization.Apply(player, visualization);
 
-					//if can resize this claim, tell about the boundaries
-					if(claim.allowEdit(player) == null)
-					{
-						instance.sendMessage(player, TextMode.Info, "  " + claim.getWidth() + "x" + claim.getHeight() + "=" + claim.getArea());
-					}
+                                        instance.sendMessage(player, TextMode.Info, "  " + claim.getWidth() + "x" + claim.getHeight() + "=" + claim.getArea());
 
 					//if permission, tell about the player's offline time
 					if(!claim.isAdminClaim() && (player.hasPermission("griefprevention.deleteclaims") || player.hasPermission("griefprevention.seeinactivity")))

--- a/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1891,7 +1891,9 @@ class PlayerEventHandler implements Listener
 
 					Visualization.Apply(player, visualization);
 
-                                        instance.sendMessage(player, TextMode.Info, "  " + claim.getWidth() + "x" + claim.getHeight() + "=" + claim.getArea());
+                                        if (player.hasPermission('griefprevention.seeclaimsize')) {
+                                            instance.sendMessage(player, TextMode.Info, "  " + claim.getWidth() + "x" + claim.getHeight() + "=" + claim.getArea());
+                                        }
 
 					//if permission, tell about the player's offline time
 					if(!claim.isAdminClaim() && (player.hasPermission("griefprevention.deleteclaims") || player.hasPermission("griefprevention.seeinactivity")))

--- a/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1891,7 +1891,7 @@ class PlayerEventHandler implements Listener
 
 					Visualization.Apply(player, visualization);
 
-					if (player.hasPermission('griefprevention.seeclaimsize')) {
+					if (player.hasPermission("griefprevention.seeclaimsize")) {
 						instance.sendMessage(player, TextMode.Info, "  " + claim.getWidth() + "x" + claim.getHeight() + "=" + claim.getArea());
 					}
 


### PR DESCRIPTION
Show the claim size to everyone when right-clicking with the investigation tool
(stick by default) - it's not exactly private information, the claim boundaries
are visualised so it would be easy to just count the blocks or compare the
coords of the corners to find out.

This is for #106 - just close it if you don't think this is desirable :)