### PR TITLE
add /restrictsubclaim

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -48,6 +48,11 @@ commands:
       usage: /SubdivideClaims
       aliases: [sc, subdivideclaim]
       permission: griefprevention.claims
+    restrictsubclaim:
+      description: Restricts a subclaim, so that it inherits no permissions from the parent claim
+      usage: /restrictsubclaim
+      aliases: rsc
+      permission: griefprevention.claims
     adjustbonusclaimblocks:
       description: Adds or subtracts bonus claim blocks for a player.
       usage: /AdjustBonusClaimBlocks <player> <amount>

--- a/src/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1589,6 +1589,7 @@ public abstract class DataStore
 		this.addDefault(defaults, Messages.Build, "Build", null);
 		this.addDefault(defaults, Messages.Containers, "Containers", null);
 		this.addDefault(defaults, Messages.Access, "Access", null);
+		this.addDefault(defaults, Messages.HasSubclaimRestriction, "This subclaim does not inherit permissions from the parent", null);
 		this.addDefault(defaults, Messages.StartBlockMath, "{0} blocks from play + {1} bonus = {2} total.", null);
 		this.addDefault(defaults, Messages.ClaimsListHeader, "Claims:", null);
 		this.addDefault(defaults, Messages.ContinueBlockMath, " (-{0} blocks)", null);
@@ -1619,7 +1620,11 @@ public abstract class DataStore
 		this.addDefault(defaults, Messages.ConsoleOnlyCommand, "That command may only be executed from the server console.", null);
 		this.addDefault(defaults, Messages.WorldNotFound, "World not found.", null);
 		this.addDefault(defaults, Messages.TooMuchIpOverlap, "Sorry, there are too many players logged in with your IP address.", null);
-		
+
+		this.addDefault(defaults, Messages.StandInSubclaim, "You need to be standing in a subclaim to restrict it", null);
+		this.addDefault(defaults, Messages.SubclaimRestricted, "This subclaim's permissions will no longer inherit from the parent claim", null);
+		this.addDefault(defaults, Messages.SubclaimUnrestricted, "This subclaim's permissions will now inherit from the parent claim", null);
+
 		//load the config file
 		FileConfiguration config = YamlConfiguration.loadConfiguration(new File(messagesFilePath));
 		

--- a/src/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -72,7 +72,7 @@ public abstract class DataStore
 	final static String bannedWordsFilePath = dataLayerFolderPath + File.separator + "bannedWords.txt";
 
     //the latest version of the data schema implemented here
-	protected static final int latestSchemaVersion = 2;
+	protected static final int latestSchemaVersion = 3;
 	
 	//reading and writing the schema version to the data store
 	abstract int getSchemaVersionFromStorage();

--- a/src/me/ryanhamshire/GriefPrevention/FlatFileDataStore.java
+++ b/src/me/ryanhamshire/GriefPrevention/FlatFileDataStore.java
@@ -506,10 +506,12 @@ public class FlatFileDataStore extends DataStore
         
         List<String> managers = yaml.getStringList("Managers");
         
+        boolean inheritNothing = yaml.getBoolean("inheritNothing");
+
         out_parentID.add(yaml.getLong("Parent Claim ID", -1L));
         
         //instantiate
-        claim = new Claim(lesserBoundaryCorner, greaterBoundaryCorner, ownerID, builders, containers, accessors, managers, claimID);
+        claim = new Claim(lesserBoundaryCorner, greaterBoundaryCorner, ownerID, builders, containers, accessors, managers, inheritNothing, claimID);
         claim.modifiedDate = new Date(lastModifiedDate);
         claim.id = claimID;
         
@@ -548,6 +550,8 @@ public class FlatFileDataStore extends DataStore
         
         yaml.set("Parent Claim ID", parentID);
         
+        yaml.set("inheritNothing", claim.getSubclaimRestrictions());
+
         return yaml.saveToString();
 	}
 	

--- a/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1502,6 +1502,11 @@ public class GriefPrevention extends JavaPlugin
 		        ChatColor.GREEN + this.dataStore.getMessage(Messages.Containers) + " " + 
 		        ChatColor.BLUE + this.dataStore.getMessage(Messages.Access));
 			
+			if(claim.getSubclaimRestrictions())
+			{
+				GriefPrevention.sendMessage(player, TextMode.Err, Messages.HasSubclaimRestriction);
+			}
+
 			return true;
 		}
 		
@@ -1692,6 +1697,37 @@ public class GriefPrevention extends JavaPlugin
 			return true;
 		}
 		
+		//restrictsubclaim
+		else if (cmd.getName().equalsIgnoreCase("restrictsubclaim") && player != null)
+		{
+			PlayerData playerData = this.dataStore.getPlayerData(player.getUniqueId());
+			Claim claim = this.dataStore.getClaimAt(player.getLocation(), true, playerData.lastClaim);
+			if(claim == null || claim.parent == null)
+			{
+				GriefPrevention.sendMessage(player, TextMode.Err, Messages.StandInSubclaim);
+				return true;
+			}
+
+			if(claim.allowGrantPermission(player) != null)
+			{
+				GriefPrevention.sendMessage(player, TextMode.Err, Messages.NoPermissionTrust, claim.getOwnerName());
+				return true;
+			}
+
+			if(claim.getSubclaimRestrictions())
+			{
+				claim.setSubclaimRestrictions(false);
+				GriefPrevention.sendMessage(player, TextMode.Success, Messages.SubclaimUnrestricted);
+			}
+			else
+			{
+				claim.setSubclaimRestrictions(true);
+				GriefPrevention.sendMessage(player, TextMode.Success, Messages.SubclaimRestricted);
+			}
+			this.dataStore.saveClaim(claim);
+			return true;
+		}
+
 		//buyclaimblocks
 		else if(cmd.getName().equalsIgnoreCase("buyclaimblocks") && player != null)
 		{

--- a/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1708,9 +1708,9 @@ public class GriefPrevention extends JavaPlugin
 				return true;
 			}
 
-			if(claim.allowGrantPermission(player) != null)
+			if(!player.getUniqueId().equals(claim.parent.ownerID))
 			{
-				GriefPrevention.sendMessage(player, TextMode.Err, Messages.NoPermissionTrust, claim.getOwnerName());
+				GriefPrevention.sendMessage(player, TextMode.Err, Messages.OnlyOwnersModifyClaims, claim.getOwnerName());
 				return true;
 			}
 

--- a/src/me/ryanhamshire/GriefPrevention/Messages.java
+++ b/src/me/ryanhamshire/GriefPrevention/Messages.java
@@ -251,5 +251,5 @@ public enum Messages
     TooMuchIpOverlap,
     StandInSubclaim,
     SubclaimRestricted,
-    SubclaimUnrestricted,
+    SubclaimUnrestricted
 }

--- a/src/me/ryanhamshire/GriefPrevention/Messages.java
+++ b/src/me/ryanhamshire/GriefPrevention/Messages.java
@@ -216,6 +216,7 @@ public enum Messages
     Build,
     Containers,
     Access,
+    HasSubclaimRestriction,
     StartBlockMath,
     ClaimsListHeader,
     ContinueBlockMath,
@@ -247,5 +248,8 @@ public enum Messages
     ConsoleOnlyCommand,
     WorldNotFound,
     AdjustBlocksAllSuccess,
-    TooMuchIpOverlap
+    TooMuchIpOverlap,
+    StandInSubclaim,
+    SubclaimRestricted,
+    SubclaimUnrestricted,
 }


### PR DESCRIPTION
Right now you can add extra permissions to small areas in claims using subclaims, but there is no way to make more restrictive permissions. If you want to limit access to a certain chest on a shared base, for example, there is no way to do that.

This adds /restrictsubclaim (/rsc), which can be used to make a subclaim inherit no permissions from the parent claim. You can then add in the players you want to have access to the subclaim. It has been very useful on my server, for large team bases with 10+ members, and also for locking specific chests in public farms.

<del>Even though this PR has been in use on my server for a while, it is unfinished. It doesn't support database storage, support for that would need to be added before this is merged. There's also some unanswered questions about who exactly should be able to use /restrictsubclaim, right now anyone with permissiontrust can use it, even though only owners have any permissions on newly created restricted subclaims (this is probably a bug)</del>