### PR TITLE
Change worldguard-checking behaviour.

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/WorldGuardWrapper.java
+++ b/src/me/ryanhamshire/GriefPrevention/WorldGuardWrapper.java
@@ -12,6 +12,7 @@ import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.flags.DefaultFlag;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedCuboidRegion;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 
 class WorldGuardWrapper
 {
@@ -38,7 +39,12 @@ class WorldGuardWrapper
                 new BlockVector(greaterCorner.getX(), world.getMaxHeight(), greaterCorner.getZ()));
             ApplicableRegionSet overlaps = manager.getApplicableRegions(tempRegion);
             LocalPlayer localPlayer = worldGuard.wrapPlayer(creatingPlayer);
-            return overlaps.testState(localPlayer, DefaultFlag.BUILD);
+            for (ProtectedRegion r : overlaps.getRegions()) {
+                if (!manager.getApplicableRegions(r).testState(localPlayer, DefaultFlag.BUILD)) {
+                    return false;
+                }
+            }
+            return true;
         }
         
         return true;


### PR DESCRIPTION
With the current setting, a player can create a claim if he can build on ANY region that intersects with the wished area, even if he can not build on every region that is on the wished area.