### PR TITLE
Configurable trapped words

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1497,7 +1497,7 @@ public abstract class DataStore
 		this.addDefault(defaults, Messages.RemainingBlocks, "You may claim up to {0} more blocks.", "0: remaining blocks");
 		this.addDefault(defaults, Messages.CreativeBasicsVideo2, "Click for Land Claim Help: {0}", "{0}: video URL");
 		this.addDefault(defaults, Messages.SurvivalBasicsVideo2, "Click for Land Claim Help: {0}", "{0}: video URL");
-		this.addDefault(defaults, Messages.TrappedChatKeyword, "trapped", "When mentioned in chat, players get information about the /trapped command.");
+		this.addDefault(defaults, Messages.TrappedChatKeyword, "trapped,stuck", "When mentioned in chat, players get information about the /trapped command (multiple words can be pipe-separated)");
 		this.addDefault(defaults, Messages.TrappedInstructions, "Are you trapped in someone's land claim?  Try the /trapped command.", null);
 		this.addDefault(defaults, Messages.PvPNoDrop, "You can't drop items while in PvP combat.", null);
 		this.addDefault(defaults, Messages.SiegeNoTeleport, "You can't teleport out of a besieged area.", null);

--- a/src/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1497,7 +1497,7 @@ public abstract class DataStore
 		this.addDefault(defaults, Messages.RemainingBlocks, "You may claim up to {0} more blocks.", "0: remaining blocks");
 		this.addDefault(defaults, Messages.CreativeBasicsVideo2, "Click for Land Claim Help: {0}", "{0}: video URL");
 		this.addDefault(defaults, Messages.SurvivalBasicsVideo2, "Click for Land Claim Help: {0}", "{0}: video URL");
-		this.addDefault(defaults, Messages.TrappedChatKeyword, "trapped,stuck", "When mentioned in chat, players get information about the /trapped command (multiple words can be comma-separated)");
+		this.addDefault(defaults, Messages.TrappedChatKeyword, "trapped;stuck", "When mentioned in chat, players get information about the /trapped command (multiple words can be separated with semi-colons)");
 		this.addDefault(defaults, Messages.TrappedInstructions, "Are you trapped in someone's land claim?  Try the /trapped command.", null);
 		this.addDefault(defaults, Messages.PvPNoDrop, "You can't drop items while in PvP combat.", null);
 		this.addDefault(defaults, Messages.SiegeNoTeleport, "You can't teleport out of a besieged area.", null);

--- a/src/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1497,7 +1497,7 @@ public abstract class DataStore
 		this.addDefault(defaults, Messages.RemainingBlocks, "You may claim up to {0} more blocks.", "0: remaining blocks");
 		this.addDefault(defaults, Messages.CreativeBasicsVideo2, "Click for Land Claim Help: {0}", "{0}: video URL");
 		this.addDefault(defaults, Messages.SurvivalBasicsVideo2, "Click for Land Claim Help: {0}", "{0}: video URL");
-		this.addDefault(defaults, Messages.TrappedChatKeyword, "trapped,stuck", "When mentioned in chat, players get information about the /trapped command (multiple words can be pipe-separated)");
+		this.addDefault(defaults, Messages.TrappedChatKeyword, "trapped,stuck", "When mentioned in chat, players get information about the /trapped command (multiple words can be comma-separated)");
 		this.addDefault(defaults, Messages.TrappedInstructions, "Are you trapped in someone's land claim?  Try the /trapped command.", null);
 		this.addDefault(defaults, Messages.PvPNoDrop, "You can't drop items while in PvP combat.", null);
 		this.addDefault(defaults, Messages.SiegeNoTeleport, "You can't teleport out of a besieged area.", null);

--- a/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -252,9 +252,25 @@ class PlayerEventHandler implements Listener
 		
 		//FEATURE: automatically educate players about the /trapped command
 		//check for "trapped" or "stuck" to educate players about the /trapped command
-		if(!message.contains("/trapped") && (message.contains("trapped") || message.contains("stuck") || message.contains(this.dataStore.getMessage(Messages.TrappedChatKeyword))))
-		{
-			instance.sendMessage(player, TextMode.Info, Messages.TrappedInstructions, 10L);
+		String trappedwords = this.dataStore.getMessage(
+		    Messages.TrappedChatKeyword
+		);
+		if (!trappedwords.isEmpty()) {
+		    String[] checkWords = trappedwords.split(",");
+
+		    for (String checkWord : checkWords) {
+			if (!message.contains("/trapped")
+			    && message.contains(checkWord))
+			{
+			    instance.sendMessage(
+				    player,
+				    TextMode.Info, 
+				    Messages.TrappedInstructions,
+				    10L
+			    );
+			    break;
+			}
+		    }
 		}
 		
 		//FEATURE: monitor for chat and command spam

--- a/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -256,7 +256,7 @@ class PlayerEventHandler implements Listener
 		    Messages.TrappedChatKeyword
 		);
 		if (!trappedwords.isEmpty()) {
-		    String[] checkWords = trappedwords.split(",");
+		    String[] checkWords = trappedwords.split(";");
 
 		    for (String checkWord : checkWords) {
 			if (!message.contains("/trapped")


### PR DESCRIPTION
Make trapped words fully configurable.
    
Before, it contained hardcoded checks; the value of `Messages.TrappedChatKeyword` was in addition to the hardcoded ones.
    
Make it more flexible, so you can override them entirely (and provide as many as you want, ~~comma~~ semi-colon-separated), and an empty value disables the message totally.
    
(Default value is '~~trapped,stuck~~trapped;stuck' to provide the same behaviour the hardcoded checks did.)

This is for Issue #182 
