### PR TITLE
Clearer response when abandoning another's claim.

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1471,6 +1471,7 @@ public abstract class DataStore
 		this.addDefault(defaults, Messages.NotYourClaim, "This isn't your claim.", null);
 		this.addDefault(defaults, Messages.DeleteTopLevelClaim, "To delete a subdivision, stand inside it.  Otherwise, use /AbandonTopLevelClaim to delete this claim and all subdivisions.", null);		
 		this.addDefault(defaults, Messages.AbandonSuccess, "Claim abandoned.  You now have {0} available claim blocks.", "0: remaining claim blocks");
+		this.addDefault(defaults, Messages.AbandonOthersSuccess, "Claim abandoned. {1} now has {0} available claim blocks.", "0: remaining claim blocks, 1: claim owner name");
 		this.addDefault(defaults, Messages.CantGrantThatPermission, "You can't grant a permission you don't have yourself.", null);
 		this.addDefault(defaults, Messages.GrantPermissionNoClaim, "Stand inside the claim where you want to grant permission.", null);
 		this.addDefault(defaults, Messages.GrantPermissionConfirmation, "Granted {0} permission to {1} {2}.", "0: target player; 1: permission description; 2: scope (changed claims)");

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -2882,7 +2882,12 @@ public class GriefPrevention extends JavaPlugin
 			
 			//tell the player how many claim blocks he has left
 			int remainingBlocks = playerData.getRemainingClaimBlocks();
-			GriefPrevention.sendMessage(player, TextMode.Success, Messages.AbandonSuccess, String.valueOf(remainingBlocks));
+                        if (player.getName().equals(claim.getOwnerName())) {
+			    GriefPrevention.sendMessage(player, TextMode.Success, Messages.AbandonSuccess, String.valueOf(remainingBlocks));
+                        } else {
+			    GriefPrevention.sendMessage(player, TextMode.Success, Messages.AbandonOthersSuccess, String.valueOf(remainingBlocks), String.valueOf(claim.getOwnerName()));
+                        }
+
 			
 			//revert any current visualization
 			Visualization.Revert(player);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
@@ -78,6 +78,7 @@ public enum Messages
     NotYourClaim,
     DeleteTopLevelClaim,
     AbandonSuccess,
+    AbandonOthersSuccess,
     CantGrantThatPermission,
     GrantPermissionNoClaim,
     GrantPermissionConfirmation,


### PR DESCRIPTION
Before, if you use /abandonclaim on someone else's claim (e.g. one you have
trust perms on, or you're an admin using ignoreclaims), you'd get the standard
message back, of e.g.:

 Claim abandoned. You now have 171108 available claim blocks.

In that case, "You" is wrong, it's the claim owner who now has that many blocks,
not the person who abandoned it.

So, this adds a new message used in cases where a player is abandoning a claim
which isn't theirs, clarifying *who* now has the new block count.

TODO: should it compare the player's UUID against the claim owner's UUID
instead, in case they've changed their name in the meantime?  IIRC, we store the
UUID in the claim and Claim.getOwnerName() would just return the current name
anyway, so it shouldn't be a problem?

Not yet tested, will try to get it on my test server later, but wanted to see if the approach is desired first.

See also Issue #322 which prompted this.