### PR TITLE
Fix wrapper for WG/WE 7.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,10 @@
             <url>http://maven.sk89q.com/repo/</url>
         </repository>
         <repository>
+            <id>codemc-repo</id>
+            <url>https://repo.codemc.org/repository/maven-public/</url>
+        </repository>
+        <repository>
             <id>vault-repo</id>
             <url>http://nexus.hc.to/content/repositories/pub_releases</url>
         </repository>
@@ -66,15 +70,15 @@
         </dependency>
          <!--Worldguard dependency-->
         <dependency>
-                <groupId>com.sk89q</groupId>
-                <artifactId>worldguard</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <groupId>com.sk89q.worldguard</groupId>
+                <artifactId>worldguard-legacy</artifactId>
+                <version>7.0.0-SNAPSHOT</version>
         </dependency>
         <!--WorldGuard depends on WorldEdit-->
         <dependency>
                 <groupId>com.sk89q.worldedit</groupId>
                 <artifactId>worldedit-bukkit</artifactId>
-                <version>6.1.4-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
         </dependency>
          <!--Vault dependency-->
         <dependency>

--- a/src/main/java/me/ryanhamshire/GriefPrevention/WorldGuardWrapper.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/WorldGuardWrapper.java
@@ -1,15 +1,16 @@
 package me.ryanhamshire.GriefPrevention;
 
 import org.bukkit.Location;
-import org.bukkit.World;
 import org.bukkit.entity.Player;
 
 import com.sk89q.worldedit.BlockVector;
-import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldedit.world.World;
+import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
-import com.sk89q.worldguard.bukkit.permission.RegionPermissionModel;
+import com.sk89q.worldguard.bukkit.BukkitPlayer;
+import com.sk89q.worldguard.internal.permission.RegionPermissionModel;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
-import com.sk89q.worldguard.protection.flags.DefaultFlag;
+import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedCuboidRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
@@ -25,28 +26,29 @@ class WorldGuardWrapper
     
     public boolean canBuild(Location lesserCorner, Location greaterCorner, Player creatingPlayer)
     {
-        World world = lesserCorner.getWorld();
-
         if (worldGuard == null)
         {
             GriefPrevention.AddLogEntry("WorldGuard is out of date and not enabled. Please update or remove WorldGuard.", CustomLogEntryTypes.Debug, false);
             return true;
         }
 
-        if(new RegionPermissionModel(this.worldGuard, creatingPlayer).mayIgnoreRegionProtection(world)) return true;
-        
-        RegionManager manager = this.worldGuard.getRegionManager(world);
-        
+        BukkitPlayer localPlayer = new BukkitPlayer(this.worldGuard, creatingPlayer);
+        World world = WorldGuard.getInstance().getPlatform().getWorldByName(lesserCorner.getWorld().getName());
+
+        RegionManager manager =  WorldGuard.getInstance().getPlatform().getRegionContainer().get(world);
+
+        if(new RegionPermissionModel(localPlayer).mayIgnoreRegionProtection(world)) return true;
+
         if(manager != null)
         {
             ProtectedCuboidRegion tempRegion = new ProtectedCuboidRegion(
                 "GP_TEMP",
                 new BlockVector(lesserCorner.getX(), 0, lesserCorner.getZ()),
-                new BlockVector(greaterCorner.getX(), world.getMaxHeight(), greaterCorner.getZ()));
+                new BlockVector(greaterCorner.getX(), world.getMaxY(), greaterCorner.getZ()));
+
             ApplicableRegionSet overlaps = manager.getApplicableRegions(tempRegion);
-            LocalPlayer localPlayer = worldGuard.wrapPlayer(creatingPlayer);
             for (ProtectedRegion r : overlaps.getRegions()) {
-                if (!manager.getApplicableRegions(r).testState(localPlayer, DefaultFlag.BUILD)) {
+                if (!manager.getApplicableRegions(r).testState(localPlayer, Flags.BUILD)) {
                     return false;
                 }
             }


### PR DESCRIPTION
This should fix the crashes with WorldGuard. The request adds the newest WG/WE 7.0.0-SNAPSHOT. 

Keep in mind sk89q repo have some issue in bukkit section and fails to download bukkit 1.6.2-R0.1 with error 500. To workaround this download a copy of the jar and add it locally with:

http://maven.sk89q.com/repo/org/bukkit/bukkit/1.6.2-R0.1-SNAPSHOT/

mvn install:install-file -Dfile=bukkit-1.6.2-R0.1-20130804.014923-14.jar -DgroupId=org.bukkit -DartifactId=bukkit -Dversion=1.6.2-R0.1-SNAPSHOT -Dpackaging=jar -DgeneratePom=true

Please test if it works as expected.