### PR TITLE
Fix ClaimModifiedEvent

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimModifiedEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimModifiedEvent.java
@@ -13,7 +13,12 @@ import org.bukkit.event.HandlerList;
  */
 public class ClaimModifiedEvent extends Event {
 
-    private final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
+    
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+    
     private final Claim claim;
     private CommandSender modifier;
 


### PR DESCRIPTION
This event was missing the static handler list call, which is required to be able to register an EventHandler for it.