### PR TITLE
Feature/disable chat filter when spam disabled

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -142,11 +142,12 @@ class PlayerEventHandler implements Listener
 		String message = event.getMessage();
 		
 		educatePlayer(player, message, event);
-		
+
+		Set<Player> recipients = event.getRecipients();
+
 		if(instance.config_spam_enabled)
 		{
-			boolean muted = this.handlePlayerChat(player, message, event);
-			Set<Player> recipients = event.getRecipients();
+			boolean muted = this.handlePlayerSpam(player, message, event);
 			
 			//muted messages go out to only the sender
 			if(muted)
@@ -299,7 +300,7 @@ class PlayerEventHandler implements Listener
 	}
 	
 	//returns true if the message should be muted, true if it should be sent 
-	private boolean handlePlayerChat(Player player, String message, PlayerEvent event)
+	private boolean handlePlayerSpam(Player player, String message, PlayerEvent event)
 	{
 		//FEATURE: monitor for chat and command spam
 		if(!instance.config_spam_enabled) return false;
@@ -487,7 +488,7 @@ class PlayerEventHandler implements Listener
 		    //if anti spam enabled, check for spam
 	        if(instance.config_spam_enabled)
 		    {
-		        event.setCancelled(this.handlePlayerChat(event.getPlayer(), event.getMessage(), event));
+		        event.setCancelled(this.handlePlayerSpam(event.getPlayer(), event.getMessage(), event));
 		    }
 	        
 	        if(!player.hasPermission("griefprevention.spam") && this.bannedWordFinder.hasMatch(message))

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -141,6 +141,8 @@ class PlayerEventHandler implements Listener
 		
 		String message = event.getMessage();
 		
+		educatePlayer(player, message, event);
+		
 		if(instance.config_spam_enabled)
 		{
 			boolean muted = this.handlePlayerChat(player, message, event);
@@ -251,8 +253,7 @@ class PlayerEventHandler implements Listener
 		}
 	}
 	
-	//returns true if the message should be muted, true if it should be sent 
-	private boolean handlePlayerChat(Player player, String message, PlayerEvent event)
+	private void educatePlayer(Player player, String message, PlayerEvent event)
 	{
 		//FEATURE: automatically educate players about claiming land
 		//watching for message format how*claim*, and will send a link to the basics video
@@ -295,9 +296,12 @@ class PlayerEventHandler implements Listener
 			}
 		    }
 		}
-		
+	}
+	
+	//returns true if the message should be muted, true if it should be sent 
+	private boolean handlePlayerChat(Player player, String message, PlayerEvent event)
+	{
 		//FEATURE: monitor for chat and command spam
-		
 		if(!instance.config_spam_enabled) return false;
 		
 		//if the player has permission to spam, don't bother even examining the message


### PR DESCRIPTION
changed it to not apply any filtering/muting unless SPAM is turned ON, and also refactored to move the 'educate user about claims/trapped' code into own function so it is no longer nested inside mute check code

the logic seems to flow because:

- the config check for SPAM already causes mute check to return false
- all but the final of the if/else blocks were related to spam checking

note that the final if/else block which has been moved outside of spam check entirely: code for social logging and ignore check is below spam config check, and will happen regardless if spam feature is enabled, but not if spam is caught (to conform with the previous if/else style flow)