### PR TITLE
Exempt creative/spectator gamemode from environmental PvP checks

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Tag;
@@ -208,6 +209,12 @@ public class BlockEventHandler implements Listener
 			for(int i = 0; i < players.size(); i++)
 			{
 				Player otherPlayer = players.get(i);
+
+				// Ignore players in creative or spectator mode to avoid users from checking if someone is spectating near them
+				if(otherPlayer.getGameMode().equals(GameMode.CREATIVE) || otherPlayer.getGameMode().equals(GameMode.SPECTATOR)) {
+					continue;
+				}
+
 				Location location = otherPlayer.getLocation();
 				if(!otherPlayer.equals(player) && location.distanceSquared(block.getLocation()) < 9)
 				{

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -211,12 +211,12 @@ public class BlockEventHandler implements Listener
 				Player otherPlayer = players.get(i);
 
 				// Ignore players in creative or spectator mode to avoid users from checking if someone is spectating near them
-				if(otherPlayer.getGameMode().equals(GameMode.CREATIVE) || otherPlayer.getGameMode().equals(GameMode.SPECTATOR)) {
+				if(otherPlayer.getGameMode() == GameMode.CREATIVE || otherPlayer.getGameMode() == GameMode.SPECTATOR) {
 					continue;
 				}
 
 				Location location = otherPlayer.getLocation();
-				if(!otherPlayer.equals(player) && location.distanceSquared(block.getLocation()) < 9)
+				if(!otherPlayer.equals(player) && location.distanceSquared(block.getLocation()) < 9 && player.canSee(otherPlayer))
 				{
 					GriefPrevention.sendMessage(player, TextMode.Err, Messages.PlayerTooCloseForFire2);
 					placeEvent.setCancelled(true);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1503,7 +1503,7 @@ class PlayerEventHandler implements Listener
 				{
 					Player otherPlayer = players.get(i);
 					Location location = otherPlayer.getLocation();
-					if(!otherPlayer.equals(player) && otherPlayer.getGameMode() == GameMode.SURVIVAL && block.getY() >= location.getBlockY() - 1 && location.distanceSquared(block.getLocation()) < minLavaDistance * minLavaDistance)
+					if(!otherPlayer.equals(player) && otherPlayer.getGameMode() == GameMode.SURVIVAL && player.canSee(otherPlayer) && block.getY() >= location.getBlockY() - 1 && location.distanceSquared(block.getLocation()) < minLavaDistance * minLavaDistance)
 					{
 						instance.sendMessage(player, TextMode.Err, Messages.NoLavaNearOtherPlayer, "another player");
 						bucketEvent.setCancelled(true);


### PR DESCRIPTION
…vP checks

So I noticed that one of my users was randomly using flint & steel while mining. Turns out he was using it to detect when I was around spectating, because whenever I'm around, he cannot use it. (we have PvP disabled and thus GP blocks flint&steel when there's another player less than 9 blocks from your position)