### PR TITLE
Fix waterlogged blocks

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1565,10 +1565,13 @@ class PlayerEventHandler implements Listener
 		{
 		    //exemption for cow milking (permissions will be handled by player interact with entity event instead)
 		    Material blockType = block.getType();
-		    if(blockType == Material.AIR || blockType.isSolid()) return;
-		    
-			instance.sendMessage(player, TextMode.Err, noBuildReason);
-			bucketEvent.setCancelled(true);
+			if(block.getBlockData().getAsString().contains("waterlogged=true")){
+				instance.sendMessage(player, TextMode.Err, noBuildReason);
+				bucketEvent.setCancelled(true);
+				return;
+			} else if((blockType == Material.AIR || blockType.isSolid())) {
+				return;
+			}
 			return;
 		}
 	}


### PR DESCRIPTION
A quick fix to stop players removing water from waterlogged blocks. Since only certain blocks can be waterlogged ```isWaterlogged​()``` wouldn't be helpful as you would need to check if the block can be waterlogged so instead check if the block has the `waterlogged=true` property

Ref: #473 