### PR TITLE
Account for when a players hand is empty

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/listener/ClaimTool.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/listener/ClaimTool.java
@@ -87,7 +87,7 @@ public class ClaimTool implements Listener
             return;
 
         //TODO: configurable.
-        if (event.getItem().getType() != Material.GOLDEN_SHOVEL)
+        if (event.getItem() == null || event.getItem().getType() != Material.GOLDEN_SHOVEL)
             return;
 
         //TODO: ClaimToolEvent


### PR DESCRIPTION
A null pointer exception was thrown if the players hand was empty