### PR TITLE
Change repository of VaultAPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
             <url>http://maven.sk89q.com/repo/</url>
         </repository>
         <repository>
-            <id>vault-repo</id>
+            <id>essx-repo</id>
             <url>https://ci.ender.zone/plugin/repository/everything/</url>
         </repository>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         </repository>
         <repository>
             <id>vault-repo</id>
-            <url>http://nexus.hc.to/content/repositories/pub_releases</url>
+            <url>https://ci.ender.zone/plugin/repository/everything/</url>
         </repository>
 
     </repositories>


### PR DESCRIPTION
Because the repository of VaultAPI has been offline for days.
And still no response from the author.
I suggest we can use the repository provided by EssentialsX Team instead.

Reference to  https://github.com/MilkBowl/VaultAPI/issues/69#issuecomment-464878181