### PR TITLE
Protecting Wolves in Claims

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -27,27 +27,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Block;
-import org.bukkit.entity.Animals;
-import org.bukkit.entity.Creature;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Explosive;
-import org.bukkit.entity.FallingBlock;
-import org.bukkit.entity.Horse;
-import org.bukkit.entity.Item;
-import org.bukkit.entity.LightningStrike;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Monster;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Projectile;
-import org.bukkit.entity.Rabbit;
-import org.bukkit.entity.Tameable;
-import org.bukkit.entity.ThrownPotion;
-import org.bukkit.entity.Vehicle;
-import org.bukkit.entity.WaterMob;
-import org.bukkit.entity.Llama;
-import org.bukkit.entity.Donkey;
-import org.bukkit.entity.Mule;
+import org.bukkit.entity.*;
 import org.bukkit.entity.minecart.ExplosiveMinecart;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -988,6 +968,22 @@ public class EntityEventHandler implements Listener
                                 if(sendErrorMessagesToPlayers) GriefPrevention.sendMessage(attacker, TextMode.Err, Messages.CantFightWhileImmune);
                                 return;
                             }
+                            // disallow players attacking tamed wolves (dogs) unless under attack by said wolf
+							else if (tameable instanceof Wolf) {
+								if (!tameable.getOwner().equals(attacker)) {
+									if (((Wolf) tameable).getTarget() != null) {
+										if (((Wolf) tameable).getTarget() == attacker) return;
+									}
+									event.setCancelled(true);
+									String ownerName = GriefPrevention.instance.getServer().getOfflinePlayer(ownerID).getName();
+									String message = GriefPrevention.instance.dataStore.getMessage(Messages.NoDamageClaimedEntity, ownerName);
+									if (attacker.hasPermission("griefprevention.ignoreclaims"))
+										message += "  " + GriefPrevention.instance.dataStore.getMessage(Messages.IgnoreClaimsAdvertisement);
+									if (sendErrorMessagesToPlayers)
+										GriefPrevention.sendMessage(attacker, TextMode.Err, message);
+									return;
+								}
+							}
                         }
                     }
                 }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -992,7 +992,7 @@ public class EntityEventHandler implements Listener
                             // disallow players attacking tamed wolves (dogs) unless under attack by said wolf
                             else if (tameable.getType() == EntityType.WOLF)
                             {
-                                if (!tameable.getOwner().equals(attacker))
+                                if (!tameable.getOwner().getUniqueId().equals(attacker.getUniqueId()))
                                 {
                                     if (((Wolf) tameable).getTarget() != null)
                                     {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -27,7 +27,28 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Block;
-import org.bukkit.entity.*;
+import org.bukkit.entity.Animals;
+import org.bukkit.entity.Creature;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Explosive;
+import org.bukkit.entity.FallingBlock;
+import org.bukkit.entity.Horse;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.LightningStrike;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Monster;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.entity.Rabbit;
+import org.bukkit.entity.Tameable;
+import org.bukkit.entity.ThrownPotion;
+import org.bukkit.entity.Vehicle;
+import org.bukkit.entity.WaterMob;
+import org.bukkit.entity.Llama;
+import org.bukkit.entity.Donkey;
+import org.bukkit.entity.Mule;
+import org.bukkit.entity.Wolf;
 import org.bukkit.entity.minecart.ExplosiveMinecart;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -969,9 +990,12 @@ public class EntityEventHandler implements Listener
                                 return;
                             }
                             // disallow players attacking tamed wolves (dogs) unless under attack by said wolf
-                            else if (tameable instanceof Wolf) {
-                                if (!tameable.getOwner().equals(attacker)) {
-                                    if (((Wolf) tameable).getTarget() != null) {
+                            else if (tameable.getType() == EntityType.WOLF)
+                            {
+                                if (!tameable.getOwner().equals(attacker))
+                                {
+                                    if (((Wolf) tameable).getTarget() != null)
+                                    {
                                         if (((Wolf) tameable).getTarget() == attacker) return;
                                     }
                                     event.setCancelled(true);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -992,7 +992,7 @@ public class EntityEventHandler implements Listener
                             // disallow players attacking tamed wolves (dogs) unless under attack by said wolf
                             else if (tameable.getType() == EntityType.WOLF)
                             {
-                                if (!tameable.getOwner().getUniqueId().equals(attacker.getUniqueId()))
+                                if (!tameable.getOwner().equals(attacker))
                                 {
                                     if (((Wolf) tameable).getTarget() != null)
                                     {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -969,21 +969,21 @@ public class EntityEventHandler implements Listener
                                 return;
                             }
                             // disallow players attacking tamed wolves (dogs) unless under attack by said wolf
-							else if (tameable instanceof Wolf) {
-								if (!tameable.getOwner().equals(attacker)) {
-									if (((Wolf) tameable).getTarget() != null) {
-										if (((Wolf) tameable).getTarget() == attacker) return;
-									}
-									event.setCancelled(true);
-									String ownerName = GriefPrevention.instance.getServer().getOfflinePlayer(ownerID).getName();
-									String message = GriefPrevention.instance.dataStore.getMessage(Messages.NoDamageClaimedEntity, ownerName);
-									if (attacker.hasPermission("griefprevention.ignoreclaims"))
-										message += "  " + GriefPrevention.instance.dataStore.getMessage(Messages.IgnoreClaimsAdvertisement);
-									if (sendErrorMessagesToPlayers)
-										GriefPrevention.sendMessage(attacker, TextMode.Err, message);
-									return;
-								}
-							}
+                            else if (tameable instanceof Wolf) {
+                                if (!tameable.getOwner().equals(attacker)) {
+                                    if (((Wolf) tameable).getTarget() != null) {
+                                        if (((Wolf) tameable).getTarget() == attacker) return;
+                                    }
+                                    event.setCancelled(true);
+                                    String ownerName = GriefPrevention.instance.getServer().getOfflinePlayer(ownerID).getName();
+                                    String message = GriefPrevention.instance.dataStore.getMessage(Messages.NoDamageClaimedEntity, ownerName);
+                                    if (attacker.hasPermission("griefprevention.ignoreclaims"))
+                                        message += "  " + GriefPrevention.instance.dataStore.getMessage(Messages.IgnoreClaimsAdvertisement);
+                                    if (sendErrorMessagesToPlayers)
+                                        GriefPrevention.sendMessage(attacker, TextMode.Err, message);
+                                    return;
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR is to help protect wolves tamed by players (dogs).
A player will only be able to attack a wolf that is currently attacking/targeting the player, otherwise the wolf (dog) will be safe.

This fixes issue #454 
