### PR TITLE
BlockEventHandler - Lectern fix

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -243,7 +243,7 @@ public class BlockEventHandler implements Listener
 			// Allow players with container trust to place books in lecterns
 			PlayerData playerData = this.dataStore.getPlayerData(player.getUniqueId());
 			Claim claim = this.dataStore.getClaimAt(block.getLocation(), true, playerData.lastClaim);
-			if (block.getType() == Material.LECTERN && placeEvent.getBlockReplacedState() instanceof Lectern)
+			if (block.getType() == Material.LECTERN && placeEvent.getBlockReplacedState().getType() == Material.LECTERN)
 			{
 				if (claim != null)
 				{


### PR DESCRIPTION
This is in reference to #613 

For some reason on Spigot, when a player with the appropriate trust level attempts to place a book in a lectern, the check is being ignored. 
This is not evident on Paper.

Im replacing the instance of check to just comparing the type of the state.