### PR TITLE
Add config option to ignore piston movements - Fixes #481

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.ryanhamshire</groupId>
     <artifactId>GriefPrevention</artifactId>
-    <version>16.8</version>
+    <version>16.8a</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -414,6 +414,9 @@ public class BlockEventHandler implements Listener
 	@EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
 	public void onBlockPistonExtend (BlockPistonExtendEvent event)
 	{		
+	    //return if piston checks are not enabled
+	    if(!GriefPrevention.instance.config_checkPistonMovement) return;
+	    
 	    //pushing down is ALWAYS safe
 	    if(event.getDirection() == BlockFace.DOWN) return;
 	    
@@ -536,7 +539,10 @@ public class BlockEventHandler implements Listener
 	@EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
 	public void onBlockPistonRetract (BlockPistonRetractEvent event)
 	{
-		//pulling up is always safe
+	    //return if piston checks are not enabled
+        if(!GriefPrevention.instance.config_checkPistonMovement) return;
+        
+	    //pulling up is always safe
 		if(event.getDirection() == BlockFace.UP) return;
 		
 		try

--- a/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -198,6 +198,7 @@ public class GriefPrevention extends JavaPlugin
 	public HashMap<String, Integer> config_seaLevelOverride;		//override for sea level, because bukkit doesn't report the right value for all situations
 	
 	public boolean config_limitTreeGrowth;                          //whether trees should be prevented from growing into a claim from outside
+	public boolean config_checkPistonMovement;                      //whether to check piston movement
 	public boolean config_pistonsInClaimsOnly;                      //whether pistons are limited to only move blocks located within the piston's land claim
 
 	public boolean config_advanced_fixNegativeClaimblockAmounts;					//whether to attempt to fix negative claim block amounts (some addons cause/assume players can go into negative amounts)
@@ -600,6 +601,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_blockSurfaceOtherExplosions = config.getBoolean("GriefPrevention.BlockSurfaceOtherExplosions", true);
         this.config_blockSkyTrees = config.getBoolean("GriefPrevention.LimitSkyTrees", true);
         this.config_limitTreeGrowth = config.getBoolean("GriefPrevention.LimitTreeGrowth", false);
+        this.config_checkPistonMovement = config.getBoolean("GriefPrevention.CheckPistonMovement", true);
         this.config_pistonsInClaimsOnly = config.getBoolean("GriefPrevention.LimitPistonsToLandClaims", true);
                 
         this.config_fireSpreads = config.getBoolean("GriefPrevention.FireSpreads", false);
@@ -870,6 +872,7 @@ public class GriefPrevention extends JavaPlugin
         outConfig.set("GriefPrevention.BlockSurfaceOtherExplosions", this.config_blockSurfaceOtherExplosions);
         outConfig.set("GriefPrevention.LimitSkyTrees", this.config_blockSkyTrees);
         outConfig.set("GriefPrevention.LimitTreeGrowth", this.config_limitTreeGrowth);
+        outConfig.set("GriefPrevention.CheckPistonMovement",  this.config_checkPistonMovement);
         outConfig.set("GriefPrevention.LimitPistonsToLandClaims", this.config_pistonsInClaimsOnly);
         
         outConfig.set("GriefPrevention.FireSpreads", this.config_fireSpreads);


### PR DESCRIPTION
Some servers with a lot of piston movements are seeing performance impacts from BlockPistonExtendEvent and BlockPistonRetractEvent. The current workaround is to set LimitPistonsToLandClaims to true, but this prevents pistons from working in unclaimed areas.

This pull request creates a new config file entry CheckPistonMovement.  The default value of true maintains the current GP behavior. Setting CheckPistonMovement to false bypasses the piston movement checks entirely, avoiding the performance problems *and* allowing pistons to be used in unclaimed areas.

This gives affected server owners another choice in how GP will handle pistons.  Fixes #481 