### PR TITLE
1.15.1: BEE_NEST/BEEHIVE protection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
                 <groupId>org.bukkit</groupId>
                 <artifactId>bukkit</artifactId>
-                <version>1.14.4-R0.1-SNAPSHOT</version>
+                <version>1.15.1-R0.1-SNAPSHOT</version>
                 <scope>provided</scope>
         </dependency>
          <!--Worldguard dependency-->

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1634,7 +1634,8 @@ class PlayerEventHandler implements Listener
 						clickedBlockType == Material.CHIPPED_ANVIL ||
 						clickedBlockType == Material.DAMAGED_ANVIL ||
 						clickedBlockType == Material.CAKE ||
-						clickedBlockType == Material.SWEET_BERRY_BUSH)))
+						clickedBlockType == Material.SWEET_BERRY_BUSH||
+						((clickedBlockType == Material.BEE_NEST || clickedBlockType == Material.BEEHIVE)) && event.getItem().getType() == Material.SHEARS )))
 		{			
                         if(playerData == null) playerData = this.dataStore.getPlayerData(player.getUniqueId());
 		    


### PR DESCRIPTION
Update to 1.15.1. Prevent honey being taken from BEE_NEST and BEEHIVE using shears within other players claim. Must have container trust to access honey.

Tested in paper, but I don't foresee any issues in Spigot. 

Closes #677 