### PR TITLE
1.15.1: Protect bees wandering outside of their hive's claim.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
                 <groupId>org.bukkit</groupId>
                 <artifactId>bukkit</artifactId>
-                <version>1.14.4-R0.1-SNAPSHOT</version>
+                <version>1.15.1-R0.1-SNAPSHOT</version>
                 <scope>provided</scope>
         </dependency>
          <!--Worldguard dependency-->

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -1142,25 +1142,28 @@ public class EntityEventHandler implements Listener
 		if (hiveLocation != null)
 		{
 		    Claim claim = this.dataStore.getClaimAt(hiveLocation, false, playerData.lastClaim); // claim at bee's hive location
-
-		    String noContainersReason = claim.allowContainers(attacker);
-		    if(noContainersReason != null)
+		    
+		    if (claim != null)
 		    {
-			if(sendErrorMessagesToPlayers)
+			String noContainersReason = claim.allowContainers(attacker);
+			if(noContainersReason != null)
 			{
-			    String message = GriefPrevention.instance.dataStore.getMessage(Messages.NoDamageClaimedEntity, claim.getOwnerName());
-			    if(attacker.hasPermission("griefprevention.ignoreclaims"))
-				message += "  " + GriefPrevention.instance.dataStore.getMessage(Messages.IgnoreClaimsAdvertisement);
-			    GriefPrevention.sendMessage(attacker, TextMode.Err, message);
+			    if(sendErrorMessagesToPlayers)
+			    {
+				String message = GriefPrevention.instance.dataStore.getMessage(Messages.NoDamageClaimedEntity, claim.getOwnerName());
+				if(attacker.hasPermission("griefprevention.ignoreclaims"))
+				    message += "  " + GriefPrevention.instance.dataStore.getMessage(Messages.IgnoreClaimsAdvertisement);
+				GriefPrevention.sendMessage(attacker, TextMode.Err, message);
+			    }
+			    event.setCancelled(true);
 			}
-			event.setCancelled(true);
-		    }
 
-		    // Cache claim for later, but note player may not be in or near the claim the bee belongs to;
-		    // We may not want to override the previously cached claim here.
-		    if(playerData != null)
-		    {
-			playerData.lastClaim = claim;
+			// Cache claim for later, but note player may not be in or near the claim the bee belongs to;
+			// We may not want to override the previously cached claim here.
+			if(playerData != null)
+			{
+			    playerData.lastClaim = claim;
+			}
 		    }
 		}
 	    }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -1137,9 +1137,11 @@ public class EntityEventHandler implements Listener
 	    {
 		PlayerData playerData = this.dataStore.getPlayerData(attacker.getUniqueId());
 		
-		Location hiveLocation = ((Bee) subEvent.getEntity()).getHive();
+		
+		Bee bee = (Bee) subEvent.getEntity();
+		Location hiveLocation = bee.getHive();
                 
-		if (hiveLocation != null)
+		if (hiveLocation != null && bee.getAnger() == 0)
 		{
 		    Claim claim = this.dataStore.getClaimAt(hiveLocation, false, playerData.lastClaim); // claim at bee's hive location
 		    

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -95,6 +95,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
+import org.bukkit.entity.Bee;
 
 //handles events related to entities
 public class EntityEventHandler implements Listener
@@ -1130,6 +1131,39 @@ public class EntityEventHandler implements Listener
                     }
                 }
             }
+	    
+	    // Protect bees which wander outside of the claim their nest/hive is in
+	    if (subEvent.getEntity().getType() == EntityType.BEE && attacker != null && attacker instanceof Player)
+	    {
+		PlayerData playerData = this.dataStore.getPlayerData(attacker.getUniqueId());
+		
+		Location hiveLocation = ((Bee) subEvent.getEntity()).getHive();
+                
+		if (hiveLocation != null)
+		{
+		    Claim claim = this.dataStore.getClaimAt(hiveLocation, false, playerData.lastClaim); // claim at bee's hive location
+
+		    String noContainersReason = claim.allowContainers(attacker);
+		    if(noContainersReason != null)
+		    {
+			if(sendErrorMessagesToPlayers)
+			{
+			    String message = GriefPrevention.instance.dataStore.getMessage(Messages.NoDamageClaimedEntity, claim.getOwnerName());
+			    if(attacker.hasPermission("griefprevention.ignoreclaims"))
+				message += "  " + GriefPrevention.instance.dataStore.getMessage(Messages.IgnoreClaimsAdvertisement);
+			    GriefPrevention.sendMessage(attacker, TextMode.Err, message);
+			}
+			event.setCancelled(true);
+		    }
+
+		    // Cache claim for later, but note player may not be in or near the claim the bee belongs to;
+		    // We may not want to override the previously cached claim here.
+		    if(playerData != null)
+		    {
+			playerData.lastClaim = claim;
+		    }
+		}
+	    }
         }
 	}
 	


### PR DESCRIPTION
Bees can easily wander outside of the claim their hive resides in, and are difficult to contain as they can fly. This PR protects them even if they are outside of their claim, but will not protect bees which have no hive or have a hive which is not in a claim.

Attackers must have container trust in the claim the bee's hive resides in.

Test with paper, but I do not foresee any issue with Spigot.
Should be paired with #698 for complete 1.15 bee protection.