### PR TITLE
Fix DeleteUserClaimsInWorld command

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -2109,7 +2109,7 @@ public class GriefPrevention extends JavaPlugin
             return true;
         }
 		
-		else if(cmd.getName().equalsIgnoreCase("deleteclaimsinworld"))
+		else if(cmd.getName().equalsIgnoreCase("deleteuserclaimsinworld"))
         {
             //must be executed at the console
             if(player != null)


### PR DESCRIPTION
Closes #718

Turns out the fix is as simple as correcting the command name - the correct flag is passed to DataStore#deleteClaimsInWorld and the correct return message is sent, the code is just inaccessible.

L2086-L2110 for actual handling of DeleteClaimsInWorld