### PR TITLE
Randomize unused claim check

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/FindUnusedClaimsTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/FindUnusedClaimsTask.java
@@ -15,13 +15,15 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
- package me.ryanhamshire.GriefPrevention;
 
-import java.util.HashSet;
+package me.ryanhamshire.GriefPrevention;
+
+import java.util.Collections;
 import java.util.Iterator;
-import java.util.Set;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
 
@@ -33,7 +35,7 @@ import org.bukkit.Bukkit;
 //runs every 1 minute in the main thread
 class FindUnusedClaimsTask implements Runnable 
 {
-	private Set<UUID> claimOwnerUUIDs = new HashSet<>();
+	private List<UUID> claimOwnerUUIDs;
 	private Iterator<UUID> claimOwnerIterator;
 	
 	FindUnusedClaimsTask()
@@ -57,12 +59,16 @@ class FindUnusedClaimsTask implements Runnable
 		Bukkit.getScheduler().runTaskAsynchronously(GriefPrevention.instance, new CleanupUnusedClaimPreTask(claimOwnerIterator.next()));
 	}
 
-	public void refreshUUIDs()
-	{
-		claimOwnerUUIDs.clear();
-		for (Claim claim : GriefPrevention.instance.dataStore.claims)
-			claimOwnerUUIDs.add(claim.ownerID);
-		claimOwnerUUIDs.remove(null);
+	public void refreshUUIDs() {
+		// Fetch owner UUIDs from list of claims
+		claimOwnerUUIDs = GriefPrevention.instance.dataStore.claims.stream().filter(Objects::nonNull)
+						.distinct().map(claim -> claim.ownerID).collect(Collectors.toList());
+
+		if (!claimOwnerUUIDs.isEmpty()) {
+			// Randomize order
+			Collections.shuffle(claimOwnerUUIDs);
+		}
+
 		claimOwnerIterator = claimOwnerUUIDs.iterator();
 	}
 }


### PR DESCRIPTION
While checking unused claims by claim owner is far more efficient, due to the way the new system works owners are always checked in the same order. For servers with an active or dedicated player base larger than their minutes between scheduled restarts, this means that certain players will never be checked for activity. By randomizing order, we retain the benefits of UUID-based checks while returning to the old "eventual correctness" of the previous check.

Closes #496.