### PR TITLE
Clarify use of /accesstrust

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -35,7 +35,7 @@ commands:
       aliases: ct
       permission: griefprevention.claims
     accesstrust:
-      description: Grants a player entry to your claim(s) and use of your bed.
+      description: Grants a player entry to your claim(s) and use of your bed, buttons, and levers.
       usage: /AccessTrust <player>.  Grants a player access to your bed, buttons, and levers.
       aliases: at
       permission: griefprevention.claims


### PR DESCRIPTION
`/help trust` misled me into thinking that I had to use /containertrust to allow access to buttons instead of just `/accesstrust`. I've changed part of the help text to prevent further confusion.