### PR TITLE
Add API allowing addons to check trust levels for offline players

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -208,26 +208,17 @@ public class Claim
 		//other permissions
 		for(String builderID : builderIDs)
 		{
-			if(builderID != null && !builderID.isEmpty())
-			{
-				this.playerIDToClaimPermissionMap.put(builderID, ClaimPermission.Build);
-			}
+			this.setPermission(builderID, ClaimPermission.Build);
 		}
 		
 		for(String containerID : containerIDs)
 		{
-			if(containerID != null && !containerID.isEmpty())
-			{
-				this.playerIDToClaimPermissionMap.put(containerID, ClaimPermission.Inventory);
-			}
+			this.setPermission(containerID, ClaimPermission.Inventory);
 		}
 		
 		for(String accessorID : accessorIDs)
 		{
-			if(accessorID != null && !accessorID.isEmpty())
-			{
-				this.playerIDToClaimPermissionMap.put(accessorID, ClaimPermission.Access);
-			}
+			this.setPermission(accessorID, ClaimPermission.Access);
 		}
 		
 		for(String managerID : managerIDs)
@@ -381,8 +372,7 @@ public class Claim
 		if(this.hasExplicitPermission(player, ClaimPermission.Build)) return null;
 		
 		//also everyone is a member of the "public", so check for public permission
-		ClaimPermission permissionLevel = this.playerIDToClaimPermissionMap.get("public");
-		if(ClaimPermission.Build == permissionLevel) return null;
+		if(ClaimPermission.Build.isGrantedBy(this.playerIDToClaimPermissionMap.get("public"))) return null;
 		
 		//allow for farming with /containertrust permission
 		if(this.allowContainers(player) == null)
@@ -410,31 +400,36 @@ public class Claim
 		
 		return reason;
 	}
-	
-	private boolean hasExplicitPermission(Player player, ClaimPermission level)
+
+	public boolean hasExplicitPermission(UUID uuid, ClaimPermission level)
 	{
-		String playerID = player.getUniqueId().toString();
-		Set<String> keys = this.playerIDToClaimPermissionMap.keySet();
-		Iterator<String> iterator = keys.iterator();
-		while(iterator.hasNext())
+		return level.isGrantedBy(this.playerIDToClaimPermissionMap.get(uuid.toString()));
+	}
+
+	public boolean hasExplicitPermission(Player player, ClaimPermission level)
+	{
+		// Check explicit ClaimPermission for UUID
+		if (this.hasExplicitPermission(player.getUniqueId(), level)) return true;
+
+		// Check permission-based ClaimPermission
+		for (Map.Entry<String, ClaimPermission> stringToPermission : this.playerIDToClaimPermissionMap.entrySet())
 		{
-			String identifier = iterator.next();
-			if(playerID.equalsIgnoreCase(identifier) && this.playerIDToClaimPermissionMap.get(identifier) == level) return true;
-			
-			else if(identifier.startsWith("[") && identifier.endsWith("]"))
+			String node = stringToPermission.getKey();
+			// Ensure valid permission format for permissions - [permission.node]
+			if (node.length() < 3 || node.charAt(0) != '[' || node.charAt(node.length() -1) != ']')
 			{
-				//drop the brackets
-				String permissionIdentifier = identifier.substring(1, identifier.length() - 1);
-				
-				//defensive coding
-				if(permissionIdentifier == null || permissionIdentifier.isEmpty()) continue;
-				
-				//check permission
-				if(player.hasPermission(permissionIdentifier) && this.playerIDToClaimPermissionMap.get(identifier) == level) return true;
+				continue;
+			}
+
+			// Check if level is high enough and player has node
+			if (level.isGrantedBy(stringToPermission.getValue())
+					&& player.hasPermission(node.substring(1, node.length() - 1)))
+			{
+				return true;
 			}
 		}
-		
-		return false;			
+
+		return false;
 	}
 	
 	//break permission check
@@ -492,12 +487,9 @@ public class Claim
 		
 		//look for explicit individual access, inventory, or build permission
 		if(this.hasExplicitPermission(player, ClaimPermission.Access)) return null;
-		if(this.hasExplicitPermission(player, ClaimPermission.Inventory)) return null;
-		if(this.hasExplicitPermission(player, ClaimPermission.Build)) return null;
-		
+
 		//also check for public permission
-		ClaimPermission permissionLevel = this.playerIDToClaimPermissionMap.get("public");
-		if(ClaimPermission.Build == permissionLevel || ClaimPermission.Inventory == permissionLevel || ClaimPermission.Access == permissionLevel) return null;		
+		if(ClaimPermission.Access.isGrantedBy(this.playerIDToClaimPermissionMap.get("public"))) return null;
 		
 		//permission inheritance for subdivisions
 		if(this.parent != null)
@@ -541,11 +533,9 @@ public class Claim
 		
 		//check for explicit individual container or build permission 
 		if(this.hasExplicitPermission(player, ClaimPermission.Inventory)) return null;
-		if(this.hasExplicitPermission(player, ClaimPermission.Build)) return null;
 		
 		//check for public container or build permission
-		ClaimPermission permissionLevel = this.playerIDToClaimPermissionMap.get("public");
-		if(ClaimPermission.Build == permissionLevel || ClaimPermission.Inventory == permissionLevel) return null;
+		if(ClaimPermission.Inventory.isGrantedBy(this.playerIDToClaimPermissionMap.get("public"))) return null;
 		
 		//permission inheritance for subdivisions
 		if(this.parent != null)
@@ -605,7 +595,12 @@ public class Claim
 	//grants a permission for a player or the public
 	public void setPermission(String playerID, ClaimPermission permissionLevel)
 	{
-		this.playerIDToClaimPermissionMap.put(playerID.toLowerCase(),  permissionLevel);
+		if (playerID == null || playerID.isEmpty())
+		{
+			return;
+		}
+
+		this.playerIDToClaimPermissionMap.put(playerID.toLowerCase(), permissionLevel);
 	}
 	
 	//revokes a permission for a player or the public

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -370,7 +370,7 @@ public class Claim
 		
 		//anyone with explicit build permission can make changes
 		if(this.hasExplicitPermission(player, ClaimPermission.Build)) return null;
-		
+
 		//also everyone is a member of the "public", so check for public permission
 		if(ClaimPermission.Build.isGrantedBy(this.playerIDToClaimPermissionMap.get("public"))) return null;
 		
@@ -591,6 +591,16 @@ public class Claim
 			reason += "  " + GriefPrevention.instance.dataStore.getMessage(Messages.IgnoreClaimsAdvertisement);
 		return reason;
 	}
+
+	public ClaimPermission getPermission(String playerID)
+	{
+		if (playerID == null || playerID.isEmpty())
+		{
+			return null;
+		}
+
+		return this.playerIDToClaimPermissionMap.get(playerID.toLowerCase());
+	}
 	
 	//grants a permission for a player or the public
 	public void setPermission(String playerID, ClaimPermission permissionLevel)
@@ -631,11 +641,11 @@ public class Claim
 	public void getPermissions(ArrayList<String> builders, ArrayList<String> containers, ArrayList<String> accessors, ArrayList<String> managers)
 	{
 		//loop through all the entries in the hash map
-		Iterator<Map.Entry<String, ClaimPermission>> mappingsIterator = this.playerIDToClaimPermissionMap.entrySet().iterator(); 
+		Iterator<Map.Entry<String, ClaimPermission>> mappingsIterator = this.playerIDToClaimPermissionMap.entrySet().iterator();
 		while(mappingsIterator.hasNext())
 		{
 			Map.Entry<String, ClaimPermission> entry = mappingsIterator.next();
-			
+
 			//build up a list for each permission level
 			if(entry.getValue() == ClaimPermission.Build)
 			{
@@ -648,7 +658,7 @@ public class Claim
 			else
 			{
 				accessors.add(entry.getKey());
-			}			
+			}
 		}
 		
 		//managers are handled a little differently

--- a/src/main/java/me/ryanhamshire/GriefPrevention/ClaimPermission.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/ClaimPermission.java
@@ -23,5 +23,18 @@ public enum ClaimPermission
 {
 	Build,
 	Inventory,
-	Access
+	Access;
+
+	/**
+	 * Check if a ClaimPermission is granted by another ClaimPermission.
+	 *
+	 * @param other the ClaimPermission to compare against
+	 * @return true if this ClaimPermission is equal or lesser than the provided ClaimPermission
+	 */
+	public boolean isGrantedBy(ClaimPermission other)
+	{
+		// As this uses declaration order to compare, if trust levels are reordered this method must be rewritten.
+		return other != null && other.ordinal() <= this.ordinal();
+	}
+
 }


### PR DESCRIPTION
Addresses #756 

* Added `Claim#hasExplicitPermission(UUID, ClaimPermission)`
* Exposes `Claim#hasExplicitPermission(Player, ClaimPermission)`
* Added `Claim#getPermission(String)`
   * Matches the existing set/drop
   * Addresses not being able to check "public" trust with the previous changes.
* Added `ClaimPermission#isGrantedBy(ClaimPermission)`
   * Reduces a lot of duplicate code, checks, and object creation.
   * Due to the usefulness for addons and volatile nature of enum ordinals used in its implementation, it is included it `ClaimPermission` instead of a `Claim` helper method.

I have not tested this thoroughly yet, I wanted feedback on the API changes before finalizing. As a result, I've marked the pull as a draft, but I would appreciate comments.

I toyed with adding `OfflinePlayer` overloads to `Claim#allow*`, but ultimately decided against it because it forcibly restricts addons' decision making capability based on GP's state - siege and whatnot - instead of allowing them to make their own choices under all circumstances.