### PR TITLE
Support raid trigger prevention in claims

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -102,6 +102,7 @@ public class GriefPrevention extends JavaPlugin
     public boolean config_claims_lockTrapDoors;                        //whether trap doors should be locked by default (require /accesstrust)
     public boolean config_claims_lockFenceGates;                    //whether fence gates should be locked by default (require /accesstrust)
     public boolean config_claims_enderPearlsRequireAccessTrust;        //whether teleporting into a claim with a pearl requires access trust
+    public boolean config_claims_raidTriggersRequireBuildTrust;      //whether raids are triggered by a player that doesn't have build permission in that claim
     public int config_claims_maxClaimsPerPlayer;                    //maximum number of claims per player
     public boolean config_claims_respectWorldGuard;                 //whether claim creations requires WG build permission in creation area
     public boolean config_claims_villagerTradingRequiresTrust;      //whether trading with a claimed villager requires permission
@@ -559,6 +560,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_claims_lockTrapDoors = config.getBoolean("GriefPrevention.Claims.LockTrapDoors", false);
         this.config_claims_lockFenceGates = config.getBoolean("GriefPrevention.Claims.LockFenceGates", true);
         this.config_claims_enderPearlsRequireAccessTrust = config.getBoolean("GriefPrevention.Claims.EnderPearlsRequireAccessTrust", true);
+        this.config_claims_raidTriggersRequireBuildTrust = config.getBoolean("GriefPrevention.Claims.RaidTriggersRequireBuildTrust", true);
         this.config_claims_initialBlocks = config.getInt("GriefPrevention.Claims.InitialBlocks", 100);
         this.config_claims_blocksAccruedPerHour_default = config.getInt("GriefPrevention.Claims.BlocksAccruedPerHour", 100);
         this.config_claims_blocksAccruedPerHour_default = config.getInt("GriefPrevention.Claims.Claim Blocks Accrued Per Hour.Default", config_claims_blocksAccruedPerHour_default);
@@ -817,6 +819,7 @@ public class GriefPrevention extends JavaPlugin
         outConfig.set("GriefPrevention.Claims.LockTrapDoors", this.config_claims_lockTrapDoors);
         outConfig.set("GriefPrevention.Claims.LockFenceGates", this.config_claims_lockFenceGates);
         outConfig.set("GriefPrevention.Claims.EnderPearlsRequireAccessTrust", this.config_claims_enderPearlsRequireAccessTrust);
+        outConfig.set("GriefPrevention.Claims.RaidTriggersRequireBuildTrust", this.config_claims_raidTriggersRequireBuildTrust);
         outConfig.set("GriefPrevention.Claims.ProtectHorses", this.config_claims_protectHorses);
         outConfig.set("GriefPrevention.Claims.ProtectDonkeys", this.config_claims_protectDonkeys);
         outConfig.set("GriefPrevention.Claims.ProtectLlamas", this.config_claims_protectLlamas);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -80,6 +80,7 @@ import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerTakeLecternBookEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+import org.bukkit.event.raid.RaidTriggerEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -1126,6 +1127,27 @@ class PlayerEventHandler implements Listener
             event.setCancelled(true);
             return;
         }
+    }
+
+    //when a player triggers a raid (in a claim)
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerTriggerRaid(RaidTriggerEvent event)
+    {
+        if (!instance.config_claims_raidTriggersRequireBuildTrust)
+            return;
+
+        Player player = event.getPlayer();
+        PlayerData playerData = this.dataStore.getPlayerData(player.getUniqueId());
+
+        Claim toClaim = this.dataStore.getClaimAt(player.getLocation(), false, playerData.lastClaim);
+        if (toClaim == null)
+            return;
+
+        playerData.lastClaim = toClaim;
+        if (toClaim.allowBuild(player, Material.AIR) == null)
+            return;
+
+        event.setCancelled(true);
     }
 
     //when a player interacts with a specific part of entity...


### PR DESCRIPTION
As requested in issue #575

Raid triggers by players will then be cancelled if the player that triggers it doesn't have *build* permission in the claim they're in.