### PR TITLE
Add several hostile non-monsters

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -40,12 +40,14 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Llama;
+import org.bukkit.entity.Mob;
 import org.bukkit.entity.Monster;
 import org.bukkit.entity.Mule;
 import org.bukkit.entity.Panda;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.entity.Rabbit;
+import org.bukkit.entity.Slime;
 import org.bukkit.entity.Tameable;
 import org.bukkit.entity.ThrownPotion;
 import org.bukkit.entity.Vehicle;
@@ -658,15 +660,20 @@ public class EntityEventHandler implements Listener
         if (entity instanceof Monster) return true;
 
         EntityType type = entity.getType();
-        if (type == EntityType.GHAST || type == EntityType.MAGMA_CUBE || type == EntityType.SLIME
-                || type == EntityType.SHULKER || type == EntityType.POLAR_BEAR || type == EntityType.HOGLIN)
+        if (type == EntityType.GHAST || type == EntityType.MAGMA_CUBE || type == EntityType.SHULKER)
             return true;
+
+        if (type == EntityType.SLIME)
+            return ((Slime) entity).getSize() > 0;
 
         if (type == EntityType.RABBIT)
             return ((Rabbit) entity).getRabbitType() == Rabbit.Type.THE_KILLER_BUNNY;
 
         if (type == EntityType.PANDA)
             return ((Panda) entity).getMainGene() == Panda.Gene.AGGRESSIVE;
+
+        if (type == EntityType.POLAR_BEAR || type == EntityType.HOGLIN)
+            return ((Mob) entity).getTarget() != null;
 
         return false;
     }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -42,6 +42,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Llama;
 import org.bukkit.entity.Monster;
 import org.bukkit.entity.Mule;
+import org.bukkit.entity.Panda;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.entity.Rabbit;
@@ -657,14 +658,15 @@ public class EntityEventHandler implements Listener
         if (entity instanceof Monster) return true;
 
         EntityType type = entity.getType();
-        if (type == EntityType.GHAST || type == EntityType.MAGMA_CUBE || type == EntityType.SHULKER || type == EntityType.POLAR_BEAR)
+        if (type == EntityType.GHAST || type == EntityType.MAGMA_CUBE || type == EntityType.SLIME
+                || type == EntityType.SHULKER || type == EntityType.POLAR_BEAR || type == EntityType.HOGLIN)
             return true;
 
         if (type == EntityType.RABBIT)
-        {
-            Rabbit rabbit = (Rabbit) entity;
-            if (rabbit.getRabbitType() == Rabbit.Type.THE_KILLER_BUNNY) return true;
-        }
+            return ((Rabbit) entity).getRabbitType() == Rabbit.Type.THE_KILLER_BUNNY;
+
+        if (type == EntityType.PANDA)
+            return ((Panda) entity).getMainGene() == Panda.Gene.AGGRESSIVE;
 
         return false;
     }


### PR DESCRIPTION
I split this into two commits. The first is what GP already does, so if that's the desired behavior, that can be cherry picked out and the second can be ignored. Both add support for slimes (which for some reason were missed even though magma cubes were included), aggressive pandas, and hoglins.

The second commit adds specific protections for entities that are non-threatening.
* Size 0 slimes deal 0 damage no matter the difficulty
* Polar bears only enrage when players are too close to cubs or if attacked.
* Hoglins [can be pacified](https://minecraft.gamepedia.com/Hoglin#Farming) by the presence of certain blocks.

This may be a little inconvenient in some cases (it's way easier to just potshot an entity before it sees you) but it would allow players to set up breeding farms or zoos more easily.
My only reservation about the second approach is that I believe it could be bypassed by luring - the player would be targeted, just not in a hostile manner - so it might lull players into a false sense of security. I don't think there's a way to check with the API whether the mob is targeting a player because it's lured or hostile specifically.

Closes #885 