### PR TITLE
Improve block ignition handling

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -33,6 +33,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.Hopper;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Dispenser;
+import org.bukkit.entity.Fireball;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -59,6 +60,7 @@ import org.bukkit.event.world.StructureGrowEvent;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.MetadataValue;
+import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.projectiles.ProjectileSource;
 
 import java.util.ArrayList;
@@ -673,10 +675,25 @@ public class BlockEventHandler implements Listener
 //			}
         }
 
+        // If a fire is started by a fireball from a dispenser, require the dispenser to be in the same claim.
+        if (igniteEvent.getCause() == IgniteCause.FIREBALL && igniteEvent.getIgnitingEntity() instanceof Fireball)
+        {
+            ProjectileSource shooter = ((Fireball) igniteEvent.getIgnitingEntity()).getShooter();
+            if (shooter instanceof BlockProjectileSource)
+            {
+                Claim claim = GriefPrevention.instance.dataStore.getClaimAt(igniteEvent.getBlock().getLocation(), false, null);
+                if (claim != null && GriefPrevention.instance.dataStore.getClaimAt(((BlockProjectileSource) shooter).getBlock().getLocation(), false, claim) != claim)
+                {
+                    igniteEvent.setCancelled(true);
+                    return;
+                }
+            }
+        }
+
         // Handle arrows igniting TNT.
         if (igniteEvent.getCause() == IgniteCause.ARROW)
         {
-            Claim claim = GriefPrevention.instance.dataStore.getClaimAt(igniteEvent.getIgnitingEntity().getLocation(), false, null);
+            Claim claim = GriefPrevention.instance.dataStore.getClaimAt(igniteEvent.getBlock().getLocation(), false, null);
 
             if (claim == null)
             {
@@ -686,11 +703,17 @@ public class BlockEventHandler implements Listener
                 return;
             }
 
-            // Allow ignition if arrow was shot by a player with build permission.
             if (igniteEvent.getIgnitingEntity() instanceof Projectile)
             {
                 ProjectileSource shooter = ((Projectile) igniteEvent.getIgnitingEntity()).getShooter();
+
+                // Allow ignition if arrow was shot by a player with build permission.
                 if (shooter instanceof Player && claim.allowBuild((Player) shooter, Material.TNT) == null) return;
+
+                // Allow ignition if arrow was shot by a dispenser in the same claim.
+                if (shooter instanceof BlockProjectileSource &&
+                        GriefPrevention.instance.dataStore.getClaimAt(((BlockProjectileSource) shooter).getBlock().getLocation(), false, claim) == claim)
+                    return;
             }
 
             // Block all other ignition by arrows in claims.

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -675,16 +675,15 @@ public class BlockEventHandler implements Listener
 //			}
         }
 
-        // If a fire is started by a fireball from a dispenser, require the dispenser to be in the same claim.
+        // If a fire is started by a fireball from a dispenser, allow it if the dispenser is in the same claim.
         if (igniteEvent.getCause() == IgniteCause.FIREBALL && igniteEvent.getIgnitingEntity() instanceof Fireball)
         {
             ProjectileSource shooter = ((Fireball) igniteEvent.getIgnitingEntity()).getShooter();
             if (shooter instanceof BlockProjectileSource)
             {
                 Claim claim = GriefPrevention.instance.dataStore.getClaimAt(igniteEvent.getBlock().getLocation(), false, null);
-                if (claim != null && GriefPrevention.instance.dataStore.getClaimAt(((BlockProjectileSource) shooter).getBlock().getLocation(), false, claim) != claim)
+                if (claim != null && GriefPrevention.instance.dataStore.getClaimAt(((BlockProjectileSource) shooter).getBlock().getLocation(), false, claim) == claim)
                 {
-                    igniteEvent.setCancelled(true);
                     return;
                 }
             }


### PR DESCRIPTION
Old behavior:
* If fire can spread globally, arrows and fireballs can ignite TNT.

New behavior:
* Fireballs, if shot out of a dispenser, require that the dispenser be in the same claim as the block ignited if it is also claimed. If these requirements are not met (i.e. shot by a blaze or other hostile mob) global fire spread settings are used.
* If unclaimed, ignition requires both global fire spread and global fire block consumption.
  * Since only TNT can currently be ignited by arrows, ignition guarantees block destruction.
* If claimed, ignition requires the shooter to be a player with build trust or a dispenser in the same claim.

Closes #912 