### PR TITLE
Small improvements to the API

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -341,13 +341,13 @@ public class BlockEventHandler implements Listener
                                     null, null,
                                     player);
 
-                            if (result.succeeded) break;
+                            if (result.value == CreateClaimResult.Value.SUCCEEDED) break;
                         }
 
                         radius--;
                     }
 
-                    if (result != null && result.succeeded)
+                    if (result != null && result.value == CreateClaimResult.Value.SUCCEEDED)
                     {
                         //notify and explain to player
                         GriefPrevention.sendMessage(player, TextMode.Success, Messages.AutomaticClaimNotification);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -976,11 +976,21 @@ public class Claim
 
     ArrayList<Long> getChunkHashes()
     {
-        ArrayList<Long> hashes = new ArrayList<Long>();
-        int smallX = this.getLesserBoundaryCorner().getBlockX() >> 4;
-        int smallZ = this.getLesserBoundaryCorner().getBlockZ() >> 4;
-        int largeX = this.getGreaterBoundaryCorner().getBlockX() >> 4;
-        int largeZ = this.getGreaterBoundaryCorner().getBlockZ() >> 4;
+        return getChunkHashes(this);
+    }
+
+    public static ArrayList<Long> getChunkHashes(Claim claim)
+    {
+        return getChunkHashes(claim.lesserBoundaryCorner, claim.greaterBoundaryCorner);
+    }
+
+    public static ArrayList<Long> getChunkHashes(Location min, Location max)
+    {
+        ArrayList<Long> hashes = new ArrayList<>();
+        int smallX = min.getBlockX() >> 4;
+        int smallZ = min.getBlockZ() >> 4;
+        int largeX = max.getBlockX() >> 4;
+        int largeZ = max.getBlockZ() >> 4;
 
         for (int x = smallX; x <= largeX; x++)
         {
@@ -991,5 +1001,39 @@ public class Claim
         }
 
         return hashes;
+    }
+
+    //returns a copy of a claim
+    protected Claim clone()
+    {
+        List<String> build = new ArrayList<>();
+        List<String> access = new ArrayList<>();
+        List<String> container = new ArrayList<>();
+        List<String> manager = new ArrayList<>(managers);
+        for (Map.Entry<String, ClaimPermission> entry : playerIDToClaimPermissionMap.entrySet())
+        {
+            String uuid = entry.getKey();
+            switch (entry.getValue())
+            {
+                case Build:
+                    build.add(uuid);
+                    break;
+                case Access:
+                    access.add(uuid);
+                    break;
+                case Inventory:
+                    container.add(uuid);
+                    break;
+            }
+        }
+
+        return new Claim(lesserBoundaryCorner.clone(),
+                greaterBoundaryCorner.clone(),
+                ownerID,
+                build,
+                container,
+                access,
+                manager,
+                id);
     }
 }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -976,31 +976,7 @@ public class Claim
 
     ArrayList<Long> getChunkHashes()
     {
-        return getChunkHashes(this);
-    }
-
-    public static ArrayList<Long> getChunkHashes(Claim claim)
-    {
-        return getChunkHashes(claim.lesserBoundaryCorner, claim.greaterBoundaryCorner);
-    }
-
-    public static ArrayList<Long> getChunkHashes(Location min, Location max)
-    {
-        ArrayList<Long> hashes = new ArrayList<>();
-        int smallX = min.getBlockX() >> 4;
-        int smallZ = min.getBlockZ() >> 4;
-        int largeX = max.getBlockX() >> 4;
-        int largeZ = max.getBlockZ() >> 4;
-
-        for (int x = smallX; x <= largeX; x++)
-        {
-            for (int z = smallZ; z <= largeZ; z++)
-            {
-                hashes.add(DataStore.getChunkHash(x, z));
-            }
-        }
-
-        return hashes;
+        return DataStore.getChunkHashes(this);
     }
 
     //returns a copy of a claim

--- a/src/main/java/me/ryanhamshire/GriefPrevention/CreateClaimResult.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/CreateClaimResult.java
@@ -21,9 +21,15 @@ package me.ryanhamshire.GriefPrevention;
 public class CreateClaimResult
 {
     //whether or not the creation succeeded (it would fail if the new claim overlapped another existing claim)
-    public boolean succeeded;
+    public Value value;
 
     //when succeeded, this is a reference to the new claim
     //when failed, this is a reference to the pre-existing, conflicting claim
     public Claim claim;
+
+    public enum Value {
+        SUCCEEDED,
+        FAILED,
+        CANCELLED
+    }
 }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -796,6 +796,30 @@ public abstract class DataStore
         return getChunkHash(location.getBlockX() >> 4, location.getBlockZ() >> 4);
     }
 
+    public static ArrayList<Long> getChunkHashes(Claim claim)
+    {
+        return getChunkHashes(claim.lesserBoundaryCorner, claim.greaterBoundaryCorner);
+    }
+
+    public static ArrayList<Long> getChunkHashes(Location min, Location max)
+    {
+        ArrayList<Long> hashes = new ArrayList<>();
+        int smallX = min.getBlockX() >> 4;
+        int smallZ = min.getBlockZ() >> 4;
+        int largeX = max.getBlockX() >> 4;
+        int largeZ = max.getBlockZ() >> 4;
+
+        for (int x = smallX; x <= largeX; x++)
+        {
+            for (int z = smallZ; z <= largeZ; z++)
+            {
+                hashes.add(DataStore.getChunkHash(x, z));
+            }
+        }
+
+        return hashes;
+    }
+
     /*
      * Creates a claim and flags it as being new....throwing a create claim event;
      */

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1106,7 +1106,7 @@ public class GriefPrevention extends JavaPlugin
                     gc.getWorld().getHighestBlockYAt(gc) - GriefPrevention.instance.config_claims_claimsExtendIntoGroundDistance - 1,
                     lc.getBlockZ(), gc.getBlockZ(),
                     player.getUniqueId(), null, null, player);
-            if (!result.succeeded)
+            if (result.value == CreateClaimResult.Value.FAILED)
             {
                 if (result.claim != null)
                 {
@@ -1120,7 +1120,7 @@ public class GriefPrevention extends JavaPlugin
                     GriefPrevention.sendMessage(player, TextMode.Err, Messages.CreateClaimFailOverlapRegion);
                 }
             }
-            else
+            else if (result.value == CreateClaimResult.Value.SUCCEEDED)
             {
                 GriefPrevention.sendMessage(player, TextMode.Success, Messages.CreateClaimSuccess);
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -2371,7 +2371,7 @@ class PlayerEventHandler implements Listener
                                     null, player);
 
                             //if it didn't succeed, tell the player why
-                            if (!result.succeeded)
+                            if (result.value == CreateClaimResult.Value.FAILED)
                             {
                                 instance.sendMessage(player, TextMode.Err, Messages.CreateSubdivisionOverlap);
 
@@ -2385,8 +2385,8 @@ class PlayerEventHandler implements Listener
                                 return;
                             }
 
-                            //otherwise, advise him on the /trust command and show him his new subdivision
-                            else
+                            //if it succeeded, advise him on the /trust command and show him his new subdivision
+                            else if (result.value == CreateClaimResult.Value.SUCCEEDED)
                             {
                                 instance.sendMessage(player, TextMode.Success, Messages.SubdivisionSuccess);
                                 Visualization visualization = Visualization.FromClaim(result.claim, clickedBlock.getY(), VisualizationType.Claim, player.getLocation());
@@ -2540,7 +2540,7 @@ class PlayerEventHandler implements Listener
                         player);
 
                 //if it didn't succeed, tell the player why
-                if (!result.succeeded)
+                if (result.value == CreateClaimResult.Value.FAILED)
                 {
                     if (result.claim != null)
                     {
@@ -2561,8 +2561,8 @@ class PlayerEventHandler implements Listener
                     return;
                 }
 
-                //otherwise, advise him on the /trust command and show him his new claim
-                else
+                //if it succeeded, advise him on the /trust command and show him his new claim
+                else if (result.value == CreateClaimResult.Value.SUCCEEDED)
                 {
                     instance.sendMessage(player, TextMode.Success, Messages.CreateClaimSuccess);
                     Visualization visualization = Visualization.FromClaim(result.claim, clickedBlock.getY(), VisualizationType.Claim, player.getLocation());

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1957,7 +1957,7 @@ class PlayerEventHandler implements Listener
                     Set<Claim> claims = this.dataStore.getNearbyClaims(player.getLocation());
 
                     // alert plugins of a visualization
-                    Bukkit.getPluginManager().callEvent(new VisualizationEvent(player, claims));
+                    Bukkit.getPluginManager().callEvent(new VisualizationEvent(player, claims, true));
 
                     //visualize boundaries
                     Visualization visualization = Visualization.fromClaims(claims, player.getEyeLocation().getBlockY(), VisualizationType.Claim, player.getLocation());

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Visualization.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Visualization.java
@@ -131,7 +131,6 @@ public class Visualization
     //adds a claim's visualization to the current visualization
     //handy for combining several visualizations together, as when visualization a top level claim with several subdivisions inside
     //locality is a performance consideration.  only create visualization blocks for around 100 blocks of the locality
-
     private void addClaimElements(Claim claim, int height, VisualizationType visualizationType, Location locality)
     {
         BlockData cornerBlockData;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Visualization.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Visualization.java
@@ -167,7 +167,8 @@ public class Visualization
         addClaimElements(claim.getLesserBoundaryCorner(), claim.getGreaterBoundaryCorner(), locality, height, cornerBlockData, accentBlockData, 10);
     }
 
-    public void addClaimElements(Location min, Location max, Location locality, int height, BlockData cornerBlockData, BlockData accentBlockData, int STEP) {
+    public void addClaimElements(Location min, Location max, Location locality, int height, BlockData cornerBlockData, BlockData accentBlockData, int STEP)
+    {
         World world = min.getWorld();
         boolean waterIsTransparent = locality.getBlock().getType() == Material.WATER;
 
@@ -253,7 +254,8 @@ public class Visualization
         this.elements.addAll(newElements);
     }
 
-    private boolean containsIncludingIgnoringHeight(BoundingBox box, Vector vector) {
+    private boolean containsIncludingIgnoringHeight(BoundingBox box, Vector vector)
+    {
         return vector.getBlockX() >= box.getMinX()
                 && vector.getBlockX() <= box.getMaxX()
                 && vector.getBlockZ() >= box.getMinZ()

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Visualization.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Visualization.java
@@ -27,6 +27,8 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Lightable;
 import org.bukkit.entity.Player;
+import org.bukkit.util.BoundingBox;
+import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
 
@@ -132,20 +134,8 @@ public class Visualization
 
     private void addClaimElements(Claim claim, int height, VisualizationType visualizationType, Location locality)
     {
-        Location smallXsmallZ = claim.getLesserBoundaryCorner();
-        Location bigXbigZ = claim.getGreaterBoundaryCorner();
-        World world = smallXsmallZ.getWorld();
-        boolean waterIsTransparent = locality.getBlock().getType() == Material.WATER;
-
-        int smallx = smallXsmallZ.getBlockX();
-        int smallz = smallXsmallZ.getBlockZ();
-        int bigx = bigXbigZ.getBlockX();
-        int bigz = bigXbigZ.getBlockZ();
-
         BlockData cornerBlockData;
         BlockData accentBlockData;
-
-        ArrayList<VisualizationElement> newElements = new ArrayList<VisualizationElement>();
 
         if (visualizationType == VisualizationType.Claim)
         {
@@ -174,6 +164,20 @@ public class Visualization
             accentBlockData = Material.NETHERRACK.createBlockData();
         }
 
+        addClaimElements(claim.getLesserBoundaryCorner(), claim.getGreaterBoundaryCorner(), locality, height, cornerBlockData, accentBlockData, 10);
+    }
+
+    public void addClaimElements(Location min, Location max, Location locality, int height, BlockData cornerBlockData, BlockData accentBlockData, int STEP) {
+        World world = min.getWorld();
+        boolean waterIsTransparent = locality.getBlock().getType() == Material.WATER;
+
+        int smallx = min.getBlockX();
+        int smallz = min.getBlockZ();
+        int bigx = max.getBlockX();
+        int bigz = max.getBlockZ();
+
+        ArrayList<VisualizationElement> newElements = new ArrayList<>();
+
         //initialize visualization elements without Y values and real data
         //that will be added later for only the visualization elements within visualization range
 
@@ -182,8 +186,6 @@ public class Visualization
         int minz = locality.getBlockZ() - 75;
         int maxx = locality.getBlockX() + 75;
         int maxz = locality.getBlockZ() + 75;
-
-        final int STEP = 10;
 
         //top line
         newElements.add(new VisualizationElement(new Location(world, smallx, 0, bigz), cornerBlockData, Material.AIR.createBlockData()));
@@ -229,10 +231,11 @@ public class Visualization
         this.removeElementsOutOfRange(newElements, minx, minz, maxx, maxz);
 
         //remove any elements outside the claim
+        BoundingBox box = BoundingBox.of(min, max);
         for (int i = 0; i < newElements.size(); i++)
         {
             VisualizationElement element = newElements.get(i);
-            if (!claim.contains(element.location, true, false))
+            if (!containsIncludingIgnoringHeight(box, element.location.toVector()))
             {
                 newElements.remove(i--);
             }
@@ -248,6 +251,13 @@ public class Visualization
         }
 
         this.elements.addAll(newElements);
+    }
+
+    private boolean containsIncludingIgnoringHeight(BoundingBox box, Vector vector) {
+        return vector.getBlockX() >= box.getMinX()
+                && vector.getBlockX() <= box.getMaxX()
+                && vector.getBlockZ() >= box.getMinZ()
+                && vector.getBlockZ() <= box.getMaxZ();
     }
 
     //removes any elements which are out of visualization range

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimModifiedEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimModifiedEvent.java
@@ -3,15 +3,17 @@ package me.ryanhamshire.GriefPrevention.events;
 
 import me.ryanhamshire.GriefPrevention.Claim;
 import org.bukkit.command.CommandSender;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 /**
- * This Event is thrown when a claim is changed....it is not modifiable or cancellable and only serves as a notification
- * a claim has changed. The CommandSender can be null in the event that the modification is called by the plugin itself.
+ * This Event is thrown when a claim is changed....it serves as a notification.
+ * The event is cancellable, in which case it will restore values back and cancels the modification.
+ * The CommandSender can be null in the event that the modification is called by the plugin itself.
  * Created by Narimm on 5/08/2018.
  */
-public class ClaimModifiedEvent extends Event
+public class ClaimModifiedEvent extends Event implements Cancellable
 {
 
     private static final HandlerList handlers = new HandlerList();
@@ -21,12 +23,15 @@ public class ClaimModifiedEvent extends Event
         return handlers;
     }
 
-    private final Claim claim;
+    private final Claim from;
+    private final Claim to;
     private CommandSender modifier;
+    private boolean cancelled;
 
-    public ClaimModifiedEvent(Claim claim, CommandSender modifier)
+    public ClaimModifiedEvent(Claim from, Claim to, CommandSender modifier)
     {
-        this.claim = claim;
+        this.from = from;
+        this.to = to;
         this.modifier = modifier;
     }
 
@@ -40,10 +45,22 @@ public class ClaimModifiedEvent extends Event
      * The claim
      *
      * @return the claim
+     * @deprecated Use the {@link #getTo() getTo} method.
      */
+    @Deprecated
     public Claim getClaim()
     {
-        return claim;
+        return to;
+    }
+
+    public Claim getFrom()
+    {
+        return from;
+    }
+
+    public Claim getTo()
+    {
+        return to;
     }
 
     /**
@@ -54,5 +71,17 @@ public class ClaimModifiedEvent extends Event
     public CommandSender getModifier()
     {
         return modifier;
+    }
+
+    @Override
+    public boolean isCancelled()
+    {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled)
+    {
+        this.cancelled = cancelled;
     }
 }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/VisualizationEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/VisualizationEvent.java
@@ -16,6 +16,7 @@ public class VisualizationEvent extends PlayerEvent
     private static final HandlerList handlers = new HandlerList();
     private final Collection<Claim> claims;
     private final boolean showSubdivides;
+    private final boolean nearbyClaims;
 
     /**
      * New visualization being sent to player
@@ -28,6 +29,7 @@ public class VisualizationEvent extends PlayerEvent
         super(player);
         this.claims = Collections.singleton(claim);
         this.showSubdivides = true;
+        this.nearbyClaims = false;
     }
 
     /**
@@ -38,9 +40,22 @@ public class VisualizationEvent extends PlayerEvent
      */
     public VisualizationEvent(Player player, Collection<Claim> claims)
     {
+        this(player, claims, false);
+    }
+
+    /**
+     * New visualization being sent to player
+     *
+     * @param player Player receiving visuals
+     * @param claims Claims being visualized (without subdivides)
+     * @param nearbyClaims If the event is called on nearby claims (shift inspecting)
+     */
+    public VisualizationEvent(Player player, Collection<Claim> claims, boolean nearbyClaims)
+    {
         super(player);
         this.claims = claims;
         this.showSubdivides = false;
+        this.nearbyClaims = nearbyClaims;
     }
 
     /**
@@ -61,6 +76,15 @@ public class VisualizationEvent extends PlayerEvent
     public boolean showSubdivides()
     {
         return showSubdivides;
+    }
+
+    /**
+     * Check if event was called through shift-inspecting with the inspection tool.
+     * @return True if shift-inspecting
+     */
+    public boolean isNearbyClaims()
+    {
+        return nearbyClaims;
     }
 
     @Override


### PR DESCRIPTION
- Makes Claim#getChunkHashes() accessible to the outside world
- Implements Claim#clone()
- Refactors Visualisation to allow claim visualisations from outside of GP, with custom blocks.
- Adds a shift-inspecting flag to VisualizationEvent, to check if the event was called when a player shift-clicked with the inspection tool.