### PR TITLE
Add ClaimInspectionEvent

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -18,6 +18,7 @@
 
 package me.ryanhamshire.GriefPrevention;
 
+import me.ryanhamshire.GriefPrevention.events.ClaimInspectionEvent;
 import me.ryanhamshire.GriefPrevention.events.VisualizationEvent;
 import org.bukkit.BanList;
 import org.bukkit.Bukkit;
@@ -1956,6 +1957,11 @@ class PlayerEventHandler implements Listener
                     //find nearby claims
                     Set<Claim> claims = this.dataStore.getNearbyClaims(player.getLocation());
 
+                    // alert plugins of a claim inspection, return if cancelled
+                    ClaimInspectionEvent inspectionEvent = new ClaimInspectionEvent(player, claims, true);
+                    Bukkit.getPluginManager().callEvent(inspectionEvent);
+                    if (inspectionEvent.isCancelled()) return;
+
                     // alert plugins of a visualization
                     Bukkit.getPluginManager().callEvent(new VisualizationEvent(player, claims, true));
 
@@ -2000,6 +2006,11 @@ class PlayerEventHandler implements Listener
                 //no claim case
                 if (claim == null)
                 {
+                    // alert plugins of a claim inspection, return if cancelled
+                    ClaimInspectionEvent inspectionEvent = new ClaimInspectionEvent(player, null);
+                    Bukkit.getPluginManager().callEvent(inspectionEvent);
+                    if (inspectionEvent.isCancelled()) return;
+
                     instance.sendMessage(player, TextMode.Info, Messages.BlockNotClaimed);
 
                     // alert plugins of a visualization
@@ -2011,6 +2022,11 @@ class PlayerEventHandler implements Listener
                 //claim case
                 else
                 {
+                    // alert plugins of a claim inspection, return if cancelled
+                    ClaimInspectionEvent inspectionEvent = new ClaimInspectionEvent(player, claim);
+                    Bukkit.getPluginManager().callEvent(inspectionEvent);
+                    if (inspectionEvent.isCancelled()) return;
+
                     playerData.lastClaim = claim;
                     instance.sendMessage(player, TextMode.Info, Messages.BlockClaimed, claim.getOwnerName());
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimInspectionEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimInspectionEvent.java
@@ -1,0 +1,77 @@
+package me.ryanhamshire.GriefPrevention.events;
+
+import me.ryanhamshire.GriefPrevention.Claim;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Event is called whenever a user inspects a block using the inspection tool.
+ * @author FrankHeijden
+ */
+public class ClaimInspectionEvent extends PlayerEvent implements Cancellable
+{
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlerList()
+    {
+        return handlers;
+    }
+
+    private final Collection<Claim> claims;
+    private final boolean inspectingNearbyClaims;
+    private boolean cancelled;
+
+    /**
+     * Constructs a new ClaimInspectionEvent with a player and claim instance.
+     * @param player The player actor
+     * @param claim The claim involved
+     */
+    public ClaimInspectionEvent(Player player, Claim claim) {
+        this(player, Collections.singleton(claim), false);
+    }
+
+    /**
+     * Constructs a new ClaimInspectionEvent with a player, list of claims and boolean flag inspectingNearbyClaims.
+     * @param player The player actor
+     * @param claims The list of claims involved
+     * @param inspectingNearbyClaims Whether or not the user is inspecting nearby claims ("shift-clicking")
+     */
+    public ClaimInspectionEvent(Player player, Collection<Claim> claims, boolean inspectingNearbyClaims) {
+        super(player);
+        this.claims = claims;
+        this.inspectingNearbyClaims = inspectingNearbyClaims;
+    }
+
+    public Collection<Claim> getClaims()
+    {
+        return claims;
+    }
+
+    public boolean isInspectingNearbyClaims()
+    {
+        return inspectingNearbyClaims;
+    }
+
+    @Override
+    public HandlerList getHandlers()
+    {
+        return handlers;
+    }
+
+    @Override
+    public boolean isCancelled()
+    {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled)
+    {
+        this.cancelled = cancelled;
+    }
+}


### PR DESCRIPTION
Since GP is listening on the LOWEST event priority for claim inspections, this will add a way to cancel these inspection events.