### PR TITLE
Add ClaimExtendEvent

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -21,6 +21,7 @@ package me.ryanhamshire.GriefPrevention;
 import com.google.common.io.Files;
 import me.ryanhamshire.GriefPrevention.events.ClaimCreatedEvent;
 import me.ryanhamshire.GriefPrevention.events.ClaimDeletedEvent;
+import me.ryanhamshire.GriefPrevention.events.ClaimExtendEvent;
 import me.ryanhamshire.GriefPrevention.events.ClaimModifiedEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -1038,6 +1039,11 @@ public abstract class DataStore
             newDepth = GriefPrevention.instance.config_claims_maxDepth;
 
         if (claim.parent != null) claim = claim.parent;
+
+        //call event and return if event got cancelled
+        ClaimExtendEvent event = new ClaimExtendEvent(claim, newDepth);
+        Bukkit.getPluginManager().callEvent(event);
+        if (event.isCancelled()) return;
 
         //adjust to new depth
         claim.lesserBoundaryCorner.setY(newDepth);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimExtendEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimExtendEvent.java
@@ -1,0 +1,58 @@
+package me.ryanhamshire.GriefPrevention.events;
+
+import me.ryanhamshire.GriefPrevention.Claim;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * A cancellable event which is called when a claim is extended in the Y direction.
+ * @author FrankHeijden
+ */
+public class ClaimExtendEvent extends Event implements Cancellable
+{
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlerList()
+    {
+        return handlers;
+    }
+
+    private final Claim claim;
+    private final int newDepth;
+    private boolean cancelled;
+
+    public ClaimExtendEvent(Claim claim, int newDepth)
+    {
+        this.claim = claim;
+        this.newDepth = newDepth;
+    }
+
+    @Override
+    public HandlerList getHandlers()
+    {
+        return handlers;
+    }
+
+    public Claim getClaim()
+    {
+        return claim;
+    }
+
+    public int getNewDepth()
+    {
+        return newDepth;
+    }
+
+    @Override
+    public boolean isCancelled()
+    {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled)
+    {
+        this.cancelled = cancelled;
+    }
+}

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimExtendEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimExtendEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 /**
- * A cancellable event which is called when a claim is extended in the Y direction.
+ * A cancellable event which is called when a claim's depth (lower y bound) is about to be extended.
  * @author FrankHeijden
  */
 public class ClaimExtendEvent extends Event implements Cancellable


### PR DESCRIPTION
Adds a ClaimExtendEvent as a replacement for ClaimModifiedEvent in `DataStore#extendClaim()`