### PR TITLE
Improve overlap check

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -779,48 +779,15 @@ public class Claim
     //used internally to prevent overlaps when creating claims
     boolean overlaps(Claim otherClaim)
     {
-        //NOTE:  if trying to understand this makes your head hurt, don't feel bad - it hurts mine too.
-        //try drawing pictures to visualize test cases.
+        // For help visualizing test cases, try https://silentmatt.com/rectangle-intersection/
 
         if (!this.lesserBoundaryCorner.getWorld().equals(otherClaim.getLesserBoundaryCorner().getWorld())) return false;
 
-        //first, check the corners of this claim aren't inside any existing claims
-        if (otherClaim.contains(this.lesserBoundaryCorner, true, false)) return true;
-        if (otherClaim.contains(this.greaterBoundaryCorner, true, false)) return true;
-        if (otherClaim.contains(new Location(this.lesserBoundaryCorner.getWorld(), this.lesserBoundaryCorner.getBlockX(), 0, this.greaterBoundaryCorner.getBlockZ()), true, false))
-            return true;
-        if (otherClaim.contains(new Location(this.lesserBoundaryCorner.getWorld(), this.greaterBoundaryCorner.getBlockX(), 0, this.lesserBoundaryCorner.getBlockZ()), true, false))
-            return true;
+        return !(this.getGreaterBoundaryCorner().getX() < otherClaim.getLesserBoundaryCorner().getX() ||
+                this.getLesserBoundaryCorner().getX() > otherClaim.getGreaterBoundaryCorner().getX() ||
+                this.getGreaterBoundaryCorner().getZ() < otherClaim.getLesserBoundaryCorner().getZ() ||
+                this.getLesserBoundaryCorner().getZ() > otherClaim.getGreaterBoundaryCorner().getZ());
 
-        //verify that no claim's lesser boundary point is inside this new claim, to cover the "existing claim is entirely inside new claim" case
-        if (this.contains(otherClaim.getLesserBoundaryCorner(), true, false)) return true;
-
-        //verify this claim doesn't band across an existing claim, either horizontally or vertically
-        if (this.getLesserBoundaryCorner().getBlockZ() <= otherClaim.getGreaterBoundaryCorner().getBlockZ() &&
-                this.getLesserBoundaryCorner().getBlockZ() >= otherClaim.getLesserBoundaryCorner().getBlockZ() &&
-                this.getLesserBoundaryCorner().getBlockX() < otherClaim.getLesserBoundaryCorner().getBlockX() &&
-                this.getGreaterBoundaryCorner().getBlockX() > otherClaim.getGreaterBoundaryCorner().getBlockX())
-            return true;
-
-        if (this.getGreaterBoundaryCorner().getBlockZ() <= otherClaim.getGreaterBoundaryCorner().getBlockZ() &&
-                this.getGreaterBoundaryCorner().getBlockZ() >= otherClaim.getLesserBoundaryCorner().getBlockZ() &&
-                this.getLesserBoundaryCorner().getBlockX() < otherClaim.getLesserBoundaryCorner().getBlockX() &&
-                this.getGreaterBoundaryCorner().getBlockX() > otherClaim.getGreaterBoundaryCorner().getBlockX())
-            return true;
-
-        if (this.getLesserBoundaryCorner().getBlockX() <= otherClaim.getGreaterBoundaryCorner().getBlockX() &&
-                this.getLesserBoundaryCorner().getBlockX() >= otherClaim.getLesserBoundaryCorner().getBlockX() &&
-                this.getLesserBoundaryCorner().getBlockZ() < otherClaim.getLesserBoundaryCorner().getBlockZ() &&
-                this.getGreaterBoundaryCorner().getBlockZ() > otherClaim.getGreaterBoundaryCorner().getBlockZ())
-            return true;
-
-        if (this.getGreaterBoundaryCorner().getBlockX() <= otherClaim.getGreaterBoundaryCorner().getBlockX() &&
-                this.getGreaterBoundaryCorner().getBlockX() >= otherClaim.getLesserBoundaryCorner().getBlockX() &&
-                this.getLesserBoundaryCorner().getBlockZ() < otherClaim.getLesserBoundaryCorner().getBlockZ() &&
-                this.getGreaterBoundaryCorner().getBlockZ() > otherClaim.getGreaterBoundaryCorner().getBlockZ())
-            return true;
-
-        return false;
     }
 
     //whether more entities may be added to a claim

--- a/src/test/java/me/ryanhamshire/GriefPrevention/ClaimTest.java
+++ b/src/test/java/me/ryanhamshire/GriefPrevention/ClaimTest.java
@@ -49,5 +49,24 @@ public class ClaimTest {
 
         assertTrue(claimA.overlaps(claimB));
         assertTrue(claimB.overlaps(claimA));
+
+        // Linear North-South
+        claimA = new Claim(new Location(world, 0, 0, 0), new Location(world, 10, 0, 10), null,
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false, 0L);
+        claimB = new Claim(new Location(world, 0, 0, 15), new Location(world, 15, 0, 25), null,
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false, 0L);
+
+        assertFalse(claimA.overlaps(claimB));
+        assertFalse(claimB.overlaps(claimA));
+
+        // Linear East-West
+        claimA = new Claim(new Location(world, 0, 0, 0), new Location(world, 10, 0, 10), null,
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false, 0L);
+        claimB = new Claim(new Location(world, 15, 0, 0), new Location(world, 25, 0, 15), null,
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false, 0L);
+
+        assertFalse(claimA.overlaps(claimB));
+        assertFalse(claimB.overlaps(claimA));
     }
+
 }


### PR DESCRIPTION
Due to a mistake in the previous check (self instead of other used for comparison) claims could not be created north of existing claims.

The unit test changes included now properly catch this, failing when run on 70b6574fe1e3bad11dede434871e642642a0b65d