### PR TITLE
Confirm /abandonallclaims

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1550,6 +1550,7 @@ public abstract class DataStore
         this.addDefault(defaults, Messages.NotYourClaim, "This isn't your claim.", null);
         this.addDefault(defaults, Messages.DeleteTopLevelClaim, "To delete a subdivision, stand inside it.  Otherwise, use /AbandonTopLevelClaim to delete this claim and all subdivisions.", null);
         this.addDefault(defaults, Messages.AbandonSuccess, "Claim abandoned.  You now have {0} available claim blocks.", "0: remaining claim blocks");
+        this.addDefault(defaults, Messages.ConfirmAbandonAllClaims, "Are you sure you want to abandon ALL of your claims?  Please confirm with /AbandonAllClaims confirm", null);
         this.addDefault(defaults, Messages.CantGrantThatPermission, "You can't grant a permission you don't have yourself.", null);
         this.addDefault(defaults, Messages.GrantPermissionNoClaim, "Stand inside the claim where you want to grant permission.", null);
         this.addDefault(defaults, Messages.GrantPermissionConfirmation, "Granted {0} permission to {1} {2}.", "0: target player; 1: permission description; 2: scope (changed claims)");

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1318,7 +1318,13 @@ public class GriefPrevention extends JavaPlugin
         //abandonallclaims
         else if (cmd.getName().equalsIgnoreCase("abandonallclaims") && player != null)
         {
-            if (args.length != 0) return false;
+            if (args.length != 1) return false;
+
+            if (!"confirm".equalsIgnoreCase(args[0]))
+            {
+                GriefPrevention.sendMessage(player, TextMode.Err, Messages.ConfirmAbandonAllClaims);
+                return true;
+            }
 
             //count claims
             PlayerData playerData = this.dataStore.getPlayerData(player.getUniqueId());

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
@@ -79,6 +79,7 @@ public enum Messages
     NotYourClaim,
     DeleteTopLevelClaim,
     AbandonSuccess,
+    ConfirmAbandonAllClaims,
     CantGrantThatPermission,
     GrantPermissionNoClaim,
     GrantPermissionConfirmation,


### PR DESCRIPTION
Requires players to type `/abandonallclaims confirm` to actually abandon all claims. Closes #745.

I was going to try and make this consistent with other features, but it turns out anything requiring confirmation already has a specific command or no longer exists as a feature.