### PR TITLE
Protect nametagged hostiles

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -721,8 +721,8 @@ public class EntityEventHandler implements Listener
 
     private void handleEntityDamageEvent(EntityDamageEvent event, boolean sendErrorMessagesToPlayers)
     {
-        //monsters are never protected
-        if (isMonster(event.getEntity())) return;
+        //unnamed monsters are never protected
+        if (isMonster(event.getEntity()) && event.getEntity().getCustomName() == null) return;
 
         //horse protections can be disabled
         if (event.getEntity() instanceof Horse && !GriefPrevention.instance.config_claims_protectHorses) return;


### PR DESCRIPTION
If a hostile mob is named, it's been named by a player, typically so that it doesn't respawn. If a player kills a mob that has been nametagged in this way, then it is grief.