### PR TITLE
Stop boats from breaking item frames in claims

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -1020,8 +1020,8 @@ public class BlockEventHandler implements Listener
     @EventHandler(ignoreCancelled = true)
     public void onItemFrameBrokenByBoat(final HangingBreakEvent event)
     {
-        // Checks if the event is caused by Physic damage - 90% of cases caused by a boat (other 10% would be block,
-        // however since it's in a claim, unless you use a TNT block we can not worry about it).
+        // Checks if the event is caused by physics - 90% of cases caused by a boat (other 10% would be block,
+        // however since it's in a claim, unless you use a TNT block we don't need to worry about it).
         if (event.getCause() != HangingBreakEvent.RemoveCause.PHYSICS)
         {
             return;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -57,6 +57,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.BlockSpreadEvent;
 import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.event.inventory.InventoryPickupItemEvent;
 import org.bukkit.event.world.StructureGrowEvent;
 import org.bukkit.inventory.InventoryHolder;
@@ -1013,6 +1014,23 @@ public class BlockEventHandler implements Listener
                     }
                 }
             }
+        }
+    }
+    
+    @EventHandler(ignoreCancelled = true)
+    public void onItemFrameBrokenByBoat(final HangingBreakEvent event)
+    {
+        // Checks if the event is caused by Physic damage - 90% of cases caused by a boat (other 10% would be block,
+        // however since it's in a claim, unless you use a TNT block we can not worry about it).
+        if (event.getCause() != HangingBreakEvent.RemoveCause.PHYSICS)
+        {
+            return;
+        }
+
+        // Cancels the event if in a claim, as we can not efficiently retrieve the person/entity who broke the Item Frame/Hangable Item.
+        if (this.dataStore.getClaimAt(event.getEntity().getLocation(), false, null) != null)
+        {
+            event.setCancelled(true);
         }
     }
 }


### PR DESCRIPTION
This is a modified version of https://github.com/TechFortress/GriefPrevention/pull/962 with the requested changes made
Closes https://github.com/TechFortress/GriefPrevention/issues/771