### PR TITLE
Update and improve economy handling

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/EconomyHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EconomyHandler.java
@@ -30,7 +30,7 @@ public class EconomyHandler implements Listener
     EconomyWrapper getWrapper()
     {
         // Attempt to load the Economy if it is not already set up.
-        loadEconomy(true);
+        loadEconomy(false);
 
         return economy;
     }
@@ -43,7 +43,7 @@ public class EconomyHandler implements Listener
     @EventHandler
     private void onPluginEnable(PluginEnableEvent event)
     {
-        loadEconomy(false);
+        loadEconomy(true);
     }
 
     /**
@@ -54,18 +54,19 @@ public class EconomyHandler implements Listener
     @EventHandler
     private void onPluginDisable(PluginDisableEvent event)
     {
-        loadEconomy(false);
+        loadEconomy(true);
     }
 
     /**
-     * Attempt to change economy.
+     * Attempt to change economy. If the setup state does not match the
+     * provided value this does nothing to prevent unnecessary loads.
      *
-     * @param skipIfSetUp whether or not to refresh Economy even if it is already set
+     * @param setupState the expected setup state
      */
-    private void loadEconomy(boolean skipIfSetUp)
+    private void loadEconomy(boolean setupState)
     {
         // If no change is likely, have we already obtained the Economy?
-        if (skipIfSetUp && setupDone) return;
+        if (setupState != setupDone) return;
 
         // Are we configured to allow transactions?
         if (!(instance.config_economy_claimBlocksPurchaseCost > 0 || instance.config_economy_claimBlocksSellValue > 0))

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EconomyHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EconomyHandler.java
@@ -1,0 +1,138 @@
+package me.ryanhamshire.GriefPrevention;
+
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.server.PluginDisableEvent;
+import org.bukkit.event.server.PluginEnableEvent;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+/**
+ * Listener for events which may result in a change in the active Economy.
+ */
+public class EconomyHandler implements Listener
+{
+
+    private final GriefPrevention instance;
+    private boolean setupDone = false;
+    private EconomyWrapper economy = null;
+
+    public EconomyHandler(GriefPrevention instance)
+    {
+        this.instance = instance;
+    }
+
+    /**
+     * Gets the current Economy inside of a wrapper class.
+     *
+     * @return the current wrapped Economy or null if no Economy is active
+     */
+    EconomyWrapper getWrapper()
+    {
+        // Attempt to load the Economy if it is not already set up.
+        loadEconomy(true);
+
+        return economy;
+    }
+
+    /**
+     * EventHandler for PluginEnableEvents in case of an Economy being enabled.
+     *
+     * @param event the PluginEnableEvent
+     */
+    @EventHandler
+    private void onPluginEnable(PluginEnableEvent event)
+    {
+        loadEconomy(false);
+    }
+
+    /**
+     * EventHandler for PluginDisableEvents in case of an Economy being disabled.
+     *
+     * @param event the PluginDisableEvent
+     */
+    @EventHandler
+    private void onPluginDisable(PluginDisableEvent event)
+    {
+        loadEconomy(false);
+    }
+
+    /**
+     * Attempt to change economy.
+     *
+     * @param skipIfSetUp whether or not to refresh Economy even if it is already set
+     */
+    private void loadEconomy(boolean skipIfSetUp)
+    {
+        // If no change is likely, have we already obtained the Economy?
+        if (skipIfSetUp && setupDone) return;
+
+        // Are we configured to allow transactions?
+        if (!(instance.config_economy_claimBlocksPurchaseCost > 0 || instance.config_economy_claimBlocksSellValue > 0))
+        {
+            finishSetup(false, null);
+            return;
+        }
+
+        // Ensure Vault present.
+        try
+        {
+            Class.forName("net.milkbowl.vault.economy.Economy");
+        }
+        catch (ClassNotFoundException e)
+        {
+            finishSetup(false, "ERROR: GriefPrevention requires Vault for economy integration.");
+            return;
+        }
+
+        RegisteredServiceProvider<Economy> registration = instance.getServer().getServicesManager().getRegistration(Economy.class);
+
+        // Ensure an Economy is available.
+        if (registration == null)
+        {
+            finishSetup(false, "ERROR: Vault was unable to find a supported economy plugin.  Either install a Vault-compatible economy plugin, or set both of the economy config variables to zero.");
+            return;
+        }
+
+        Economy newEconomy = registration.getProvider();
+
+        // If Economy hasn't changed, do nothing.
+        if (economy != null && economy.getEconomy().equals(newEconomy)) return;
+
+        // Set setupDone false to force log line for changing Economy.
+        setupDone = false;
+        economy = new EconomyWrapper(newEconomy);
+
+        finishSetup(true, "Hooked into economy: " + economy.economy.getName() + ". Ready to buy/sell claim blocks!");
+    }
+
+    private void finishSetup(boolean ready, String log) {
+        if (!ready) this.economy = null;
+
+        if (log != null && !setupDone) GriefPrevention.AddLogEntry(log);
+
+        this.setupDone = true;
+    }
+
+    /**
+     * Wrapper class used to prevent Bukkit from logging an error and
+     * preventing registering events for the listener when Vault is not loaded.
+     */
+    static class EconomyWrapper
+    {
+
+        private final Economy economy;
+
+        private EconomyWrapper(Economy economy)
+        {
+            this.economy = economy;
+        }
+
+        Economy getEconomy()
+        {
+            return this.economy;
+        }
+
+    }
+
+}

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -49,7 +49,6 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.plugin.PluginManager;
-import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.BlockIterator;
@@ -177,6 +176,7 @@ public class GriefPrevention extends JavaPlugin
     public boolean config_lockDeathDropsInPvpWorlds;                //whether players' dropped on death items are protected in pvp worlds
     public boolean config_lockDeathDropsInNonPvpWorlds;             //whether players' dropped on death items are protected in non-pvp worlds
 
+    private EconomyHandler economyHandler;
     public int config_economy_claimBlocksMaxBonus;                  //max "bonus" blocks a player can buy.  set to zero for no limit.
     public double config_economy_claimBlocksPurchaseCost;            //cost to purchase a claim block.  set to zero to disable purchase.
     public double config_economy_claimBlocksSellValue;                //return on a sold claim block.  set to zero to disable sale.
@@ -231,9 +231,6 @@ public class GriefPrevention extends JavaPlugin
     private String databaseUserName;
     private String databasePassword;
 
-
-    //reference to the economy plugin, if economy integration is enabled
-    public static Economy economy = null;
 
     //how far away to search from a tree trunk for its branch blocks
     public static final int TREE_RADIUS = 5;
@@ -362,41 +359,9 @@ public class GriefPrevention extends JavaPlugin
         EntityEventHandler entityEventHandler = new EntityEventHandler(this.dataStore, this);
         pluginManager.registerEvents(entityEventHandler, this);
 
-        //if economy is enabled
-        if (this.config_economy_claimBlocksPurchaseCost > 0 || this.config_economy_claimBlocksSellValue > 0)
-        {
-            //try to load Vault
-            GriefPrevention.AddLogEntry("GriefPrevention requires Vault for economy integration.");
-            GriefPrevention.AddLogEntry("Attempting to load Vault...");
-            RegisteredServiceProvider<Economy> economyProvider = getServer().getServicesManager().getRegistration(net.milkbowl.vault.economy.Economy.class);
-            GriefPrevention.AddLogEntry("Vault loaded successfully!");
-
-            //ask Vault to hook into an economy plugin
-            GriefPrevention.AddLogEntry("Looking for a Vault-compatible economy plugin...");
-            if (economyProvider != null)
-            {
-                GriefPrevention.economy = economyProvider.getProvider();
-
-                //on success, display success message
-                if (GriefPrevention.economy != null)
-                {
-                    GriefPrevention.AddLogEntry("Hooked into economy: " + GriefPrevention.economy.getName() + ".");
-                    GriefPrevention.AddLogEntry("Ready to buy/sell claim blocks!");
-                }
-
-                //otherwise error message
-                else
-                {
-                    GriefPrevention.AddLogEntry("ERROR: Vault was unable to find a supported economy plugin.  Either install a Vault-compatible economy plugin, or set both of the economy config variables to zero.");
-                }
-            }
-
-            //another error case
-            else
-            {
-                GriefPrevention.AddLogEntry("ERROR: Vault was unable to find a supported economy plugin.  Either install a Vault-compatible economy plugin, or set both of the economy config variables to zero.");
-            }
-        }
+        //vault-based economy integration
+        economyHandler = new EconomyHandler(this);
+        pluginManager.registerEvents(economyHandler, this);
 
         //cache offline players
         OfflinePlayer[] offlinePlayers = this.getServer().getOfflinePlayers();
@@ -1795,7 +1760,8 @@ public class GriefPrevention extends JavaPlugin
         else if (cmd.getName().equalsIgnoreCase("buyclaimblocks") && player != null)
         {
             //if economy is disabled, don't do anything
-            if (GriefPrevention.economy == null)
+            EconomyHandler.EconomyWrapper economyWrapper = economyHandler.getWrapper();
+            if (economyWrapper == null)
             {
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.BuySellNotConfigured);
                 return true;
@@ -1814,10 +1780,12 @@ public class GriefPrevention extends JavaPlugin
                 return true;
             }
 
+            Economy economy = economyWrapper.getEconomy();
+
             //if no parameter, just tell player cost per block and balance
             if (args.length != 1)
             {
-                GriefPrevention.sendMessage(player, TextMode.Info, Messages.BlockPurchaseCost, String.valueOf(GriefPrevention.instance.config_economy_claimBlocksPurchaseCost), String.valueOf(GriefPrevention.economy.getBalance(player.getName())));
+                GriefPrevention.sendMessage(player, TextMode.Info, Messages.BlockPurchaseCost, String.valueOf(GriefPrevention.instance.config_economy_claimBlocksPurchaseCost), String.valueOf(economy.getBalance(player)));
                 return false;
             }
             else
@@ -1841,7 +1809,7 @@ public class GriefPrevention extends JavaPlugin
                 }
 
                 //if the player can't afford his purchase, send error message
-                double balance = economy.getBalance(player.getName());
+                double balance = economy.getBalance(player);
                 double totalCost = blockCount * GriefPrevention.instance.config_economy_claimBlocksPurchaseCost;
                 if (totalCost > balance)
                 {
@@ -1862,7 +1830,7 @@ public class GriefPrevention extends JavaPlugin
                     }
 
                     //withdraw cost
-                    economy.withdrawPlayer(player.getName(), totalCost);
+                    economy.withdrawPlayer(player, totalCost);
 
                     //add blocks
                     playerData.setBonusClaimBlocks(playerData.getBonusClaimBlocks() + blockCount);
@@ -1880,7 +1848,8 @@ public class GriefPrevention extends JavaPlugin
         else if (cmd.getName().equalsIgnoreCase("sellclaimblocks") && player != null)
         {
             //if economy is disabled, don't do anything
-            if (GriefPrevention.economy == null)
+            EconomyHandler.EconomyWrapper economyWrapper = economyHandler.getWrapper();
+            if (economyWrapper == null)
             {
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.BuySellNotConfigured);
                 return true;
@@ -1937,7 +1906,7 @@ public class GriefPrevention extends JavaPlugin
             {
                 //compute value and deposit it
                 double totalValue = blockCount * GriefPrevention.instance.config_economy_claimBlocksSellValue;
-                economy.depositPlayer(player.getName(), totalValue);
+                economyWrapper.getEconomy().depositPlayer(player, totalValue);
 
                 //subtract blocks
                 playerData.setBonusClaimBlocks(playerData.getBonusClaimBlocks() - blockCount);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: GriefPrevention
 main: me.ryanhamshire.GriefPrevention.GriefPrevention
-softdepend: [Vault, Multiverse-Core, My_Worlds, MystCraft, Transporter, TheUnderground, WorldGuard, WorldEdit, RoyalCommands, MultiWorld, Denizen, Hyperconomy]
+softdepend: [Vault, Multiverse-Core, My_Worlds, MystCraft, Transporter, TheUnderground, WorldGuard, WorldEdit, RoyalCommands, MultiWorld, Denizen]
 dev-url: https://dev.bukkit.org/projects/grief-prevention
 loadbefore: [TheUnderground]
 version: '${project.version}-${git.commit.id.abbrev}'


### PR DESCRIPTION
* Usernames have not been used to identify accounts since Vault 1.4 in 2014
* Prevent enable error if economy configured but Vault not present
* Prevent command error in same state if enable actually succeeded
* Adds support for hotswapping of economy (and theoretically Vault itself, but I'm not sure how Bukkit/hotswap plugins handle class loading. Loading Vault later is fine, hotswapping in a new Vault instance with a different Economy class may not be fine.)
* Removes potential need to softdepend on every economy plugin for compatibility

I ended up using a little wrapper class for the Economy instance because otherwise Bukkit complained about the listener having a field of type Economy and wouldn't register events with Vault not present. I suppose another take would be to use a separate inner class for the listener instead, but this seemed cleaner.