### PR TITLE
Fix WordFinder matching anything with empty BannedWords.txt

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/WordFinder.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/WordFinder.java
@@ -27,6 +27,8 @@ class WordFinder
             //trim extraneous leading pipe (|)
             patternString = patternString.substring(1);
         }
+        // No words are defined, match nothing.
+        else return;
 
         this.pattern = Pattern.compile(patternString, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
     }

--- a/src/test/java/me/ryanhamshire/GriefPrevention/Tests.java
+++ b/src/test/java/me/ryanhamshire/GriefPrevention/Tests.java
@@ -2,7 +2,6 @@ package me.ryanhamshire.GriefPrevention;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
@@ -68,8 +67,10 @@ public class Tests
     @Test
     public void testWordFinderEmptyList()
     {
-        WordFinder finder = new WordFinder(new ArrayList<>());
+        WordFinder finder = new WordFinder(Collections.emptyList());
         assertFalse(finder.hasMatch("alpha"));
+        finder = new WordFinder(Collections.singletonList(""));
+        assertFalse(finder.hasMatch("beta"));
     }
 
     @Test


### PR DESCRIPTION
Empty/empty-appearing lines are skipped, but GP does not check if the file contains only empty lines. No content = 1 empty line.
Fixed unit test to properly catch failures of existing system.

Closes #982 