### PR TITLE
Allow any type of Zombie to convert villagers.

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -990,7 +990,7 @@ public class EntityEventHandler implements Listener
                     if (attacker == null)
                     {
                         //exception case
-                        if (event.getEntityType() == EntityType.VILLAGER && damageSource != null && damageSource.getType() == EntityType.ZOMBIE)
+                        if (event.getEntityType() == EntityType.VILLAGER && damageSource != null && damageSource instanceof Zombie)
                         {
                             return;
                         }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -54,6 +54,7 @@ import org.bukkit.entity.ThrownPotion;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.entity.WaterMob;
 import org.bukkit.entity.Wolf;
+import org.bukkit.entity.Zombie;
 import org.bukkit.entity.minecart.ExplosiveMinecart;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -990,7 +991,7 @@ public class EntityEventHandler implements Listener
                     if (attacker == null)
                     {
                         //exception case
-                        if (event.getEntityType() == EntityType.VILLAGER && damageSource != null && damageSource.getType() == EntityType.ZOMBIE)
+                        if (event.getEntityType() == EntityType.VILLAGER && damageSource != null && damageSource instanceof Zombie)
                         {
                             return;
                         }


### PR DESCRIPTION
Any type of Zombie (ie. Husks and Drowned) should be able to convert villagers. `damageSource.getType() == EntityType.ZOMBIE` only covers the "normal" Zombie and no other variants.