### PR TITLE
Feature: entity interactions require build trust

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -616,6 +616,15 @@ public class Claim
         return reason;
     }
 
+    public String allowEntityInteraction(Player player)
+    {
+        if (GriefPrevention.instance.config_claims_entityInteractionRequiresBuildTrust)
+        {
+            return allowBuild(player, null);
+        }
+        return allowContainers(player);
+    }
+
     public ClaimPermission getPermission(String playerID)
     {
         if (playerID == null || playerID.isEmpty())

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -1138,7 +1138,7 @@ public class EntityEventHandler implements Listener
                     //otherwise the player damaging the entity must have permission, unless it's a dog in a pvp world
                     else if (!(event.getEntity().getWorld().getPVP() && event.getEntity().getType() == EntityType.WOLF))
                     {
-                        String noContainersReason = claim.allowContainers(attacker);
+                        String noContainersReason = claim.allowEntityInteraction(attacker);
                         if (noContainersReason != null)
                         {
                             event.setCancelled(true);
@@ -1327,7 +1327,7 @@ public class EntityEventHandler implements Listener
             //otherwise the player damaging the entity must have permission
             else
             {
-                String noContainersReason = claim.allowContainers(attacker);
+                String noContainersReason = claim.allowEntityInteraction(attacker);
                 if (noContainersReason != null)
                 {
                     event.setCancelled(true);
@@ -1377,7 +1377,7 @@ public class EntityEventHandler implements Listener
                         if (claim != null)
                         {
                             cachedClaim = claim;
-                            if (thrower == null || claim.allowContainers(thrower) != null)
+                            if (thrower == null || claim.allowEntityInteraction(thrower) != null)
                             {
                                 event.setIntensity(effected, 0);
                                 instance.sendMessage(thrower, TextMode.Err, Messages.NoDamageClaimedEntity, claim.getOwnerName());

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -107,6 +107,7 @@ public class GriefPrevention extends JavaPlugin
     public int config_claims_maxClaimsPerPlayer;                    //maximum number of claims per player
     public boolean config_claims_respectWorldGuard;                 //whether claim creations requires WG build permission in creation area
     public boolean config_claims_villagerTradingRequiresTrust;      //whether trading with a claimed villager requires permission
+    public boolean config_claims_entityInteractionRequiresBuildTrust;  //whether entity interactions (spawning/killing) requires build permissions
 
     public int config_claims_initialBlocks;                            //the number of claim blocks a new player starts with
     public double config_claims_abandonReturnRatio;                 //the portion of claim blocks returned to a player when a claim is abandoned
@@ -528,6 +529,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_claims_lockFenceGates = config.getBoolean("GriefPrevention.Claims.LockFenceGates", true);
         this.config_claims_enderPearlsRequireAccessTrust = config.getBoolean("GriefPrevention.Claims.EnderPearlsRequireAccessTrust", true);
         this.config_claims_raidTriggersRequireBuildTrust = config.getBoolean("GriefPrevention.Claims.RaidTriggersRequireBuildTrust", true);
+        this.config_claims_entityInteractionRequiresBuildTrust = config.getBoolean("GriefPrevention.Claims.EntityInteractionRequiresBuildTrust", false);
         this.config_claims_initialBlocks = config.getInt("GriefPrevention.Claims.InitialBlocks", 100);
         this.config_claims_blocksAccruedPerHour_default = config.getInt("GriefPrevention.Claims.BlocksAccruedPerHour", 100);
         this.config_claims_blocksAccruedPerHour_default = config.getInt("GriefPrevention.Claims.Claim Blocks Accrued Per Hour.Default", config_claims_blocksAccruedPerHour_default);
@@ -771,6 +773,7 @@ public class GriefPrevention extends JavaPlugin
         outConfig.set("GriefPrevention.Claims.LockFenceGates", this.config_claims_lockFenceGates);
         outConfig.set("GriefPrevention.Claims.EnderPearlsRequireAccessTrust", this.config_claims_enderPearlsRequireAccessTrust);
         outConfig.set("GriefPrevention.Claims.RaidTriggersRequireBuildTrust", this.config_claims_raidTriggersRequireBuildTrust);
+        outConfig.set("GriefPrevention.Claims.EntityInteractionRequiresBuildTrust", this.config_claims_entityInteractionRequiresBuildTrust);
         outConfig.set("GriefPrevention.Claims.ProtectHorses", this.config_claims_protectHorses);
         outConfig.set("GriefPrevention.Claims.ProtectDonkeys", this.config_claims_protectDonkeys);
         outConfig.set("GriefPrevention.Claims.ProtectLlamas", this.config_claims_protectLlamas);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1306,7 +1306,7 @@ class PlayerEventHandler implements Listener
             Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, null);
             if (claim != null)
             {
-                if (claim.allowContainers(player) != null)
+                if (claim.allowEntityInteraction(player) != null)
                 {
                     String message = instance.dataStore.getMessage(Messages.NoDamageClaimedEntity, claim.getOwnerName());
                     if (player.hasPermission("griefprevention.ignoreclaims"))
@@ -1324,7 +1324,7 @@ class PlayerEventHandler implements Listener
             Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, playerData.lastClaim);
             if (claim != null)
             {
-                String failureReason = claim.allowContainers(player);
+                String failureReason = claim.allowEntityInteraction(player);
                 if (failureReason != null)
                 {
                     event.setCancelled(true);
@@ -1351,7 +1351,7 @@ class PlayerEventHandler implements Listener
             if (claim != null)
             {
                 //if no permission, cancel
-                String errorMessage = claim.allowContainers(player);
+                String errorMessage = claim.allowEntityInteraction(player);
                 if (errorMessage != null)
                 {
                     event.setCancelled(true);
@@ -1891,7 +1891,7 @@ class PlayerEventHandler implements Listener
                 Claim claim = this.dataStore.getClaimAt(clickedBlock.getLocation(), false, playerData.lastClaim);
                 if (claim != null)
                 {
-                    String reason = claim.allowContainers(player);
+                    String reason = claim.allowEntityInteraction(player);
                     if (reason != null)
                     {
                         instance.sendMessage(player, TextMode.Err, reason);


### PR DESCRIPTION
Added a config option which changes the behaviour for containertrust: players will now need build trust to interact (kill/spawn minecarts) with entities. Disabled by default. 