### PR TITLE
Feature: Protect passive pillagers from being killed in claims

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -25,7 +25,6 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.Tag;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Block;


### PR DESCRIPTION
Pillagers are passive when they don't have a bow in their hand (see: https://minecraft.gamepedia.com/Pillager#Behavior), this PR aims to add protection for passive pillagers when protecting creatures is enabled in the config.