### PR TITLE
Fix erroneous inclusion of wooden buttons

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1754,7 +1754,8 @@ class PlayerEventHandler implements Listener
         }
 
         //otherwise apply rules for buttons and switches
-        else if (clickedBlock != null && instance.config_claims_preventButtonsSwitches && (Tag.BUTTONS.isTagged(clickedBlockType) || clickedBlockType == Material.LEVER))
+        else if (clickedBlock != null && instance.config_claims_preventButtonsSwitches
+                && (Tag.BUTTONS.isTagged(clickedBlockType) && !Tag.WOODEN_BUTTONS.isTagged(clickedBlockType) || clickedBlockType == Material.LEVER))
         {
             if (playerData == null) playerData = this.dataStore.getPlayerData(player.getUniqueId());
             Claim claim = this.dataStore.getClaimAt(clickedBlock.getLocation(), false, playerData.lastClaim);


### PR DESCRIPTION
Should probably update the wiki to include mention that the option only protects buttons that can't be depressed by arrows.

Apparently wooden buttons have been included since the update to 1.13, so it wasn't me for once.