### PR TITLE
Fix subclaims being added to chunk claims map when resized

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -473,6 +473,9 @@ public abstract class DataStore
 
     private void addToChunkClaimMap(Claim claim)
     {
+        // Subclaims should not be added to chunk claim map.
+        if (claim.parent != null) return;
+
         ArrayList<Long> chunkHashes = claim.getChunkHashes();
         for (Long chunkHash : chunkHashes)
         {


### PR DESCRIPTION
Claims are only supposed to be added to the chunk claim map when they are parent claims. Special handling for children is [here](https://github.com/TechFortress/GriefPrevention/blob/746f10449d527410ae8af7815bdbd57671d449a4/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java#L440-L452).
Subclaims are erroneously added to the chunk claim map when resized [here](https://github.com/TechFortress/GriefPrevention/blob/746f10449d527410ae8af7815bdbd57671d449a4/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java#L1313).

For the sake of preventing future issues (this was caused by a bugfix for an improvement) I opted to put the check directly in `DataStore#addToChunkClaimMap(Claim)` instead.