### PR TITLE
Fix some more piston cases

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -532,6 +532,9 @@ public class BlockEventHandler implements Listener
         // If no blocks are moving, quickly check if another claim's boundaries are violated.
         if (blocks.isEmpty())
         {
+            // No block and retraction is always safe.
+            if (isRetract) return;
+
             Block invadedBlock = pistonBlock.getRelative(direction);
             Claim invadedClaim = this.dataStore.getClaimAt(invadedBlock.getLocation(), false, pistonClaim);
             if (invadedClaim != null && (pistonClaim == null || !Objects.equals(pistonClaim.getOwnerID(), invadedClaim.getOwnerID())))
@@ -586,6 +589,9 @@ public class BlockEventHandler implements Listener
 
             return;
         }
+
+        // Ensure we have top level claim - piston ownership is only checked based on claim owner in everywhere mode.
+        while (pistonClaim != null && pistonClaim.parent != null) pistonClaim = pistonClaim.parent;
 
         // Pushing down or pulling up is safe if all blocks are in line with the piston.
         if (minX == maxX && minZ == maxZ && direction == (isRetract ? BlockFace.UP : BlockFace.DOWN)) return;


### PR DESCRIPTION
* Fix retraction checking block behind piston when no blocks are moved
* Everywhere modes are supposed to ignore subclaims, so piston claim should not be a subclaim once we enter the everywhere checks. This will speed up comparison quite a bit for pistons in subclaims.

Relates to #1082 - subclaims are supposed to be ignored in both `EVERYWHERE` ([here](https://github.com/TechFortress/GriefPrevention/blob/746f10449d527410ae8af7815bdbd57671d449a4/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java#L643-L662)) and `EVERYWHERE_SIMPLE` ([here](https://github.com/TechFortress/GriefPrevention/blob/746f10449d527410ae8af7815bdbd57671d449a4/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java#L596-L608)). Unfortunately, subclaims that have been resized are added to the chunk map, so they are compared against. Technically after this PR the only required use of Claim#getOwnerID is now just the first quick check where claims may be subclaims.

I'm not sure if this is enough to fix the hard-to-reproduce ailments that have been hitting `EVERYWHERE_SIMPLE`, but I'm doing my best to spend a little time every so often rereading and testing.