### PR TITLE
Fix claims in other worlds preventing piston movement

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -606,8 +606,13 @@ public class BlockEventHandler implements Listener
                 for (int chunkZ = minZ >> 4; chunkZ <= chunkZMax; ++chunkZ)
                 {
                     ArrayList<Claim> chunkClaims = dataStore.chunksToClaimsMap.get(DataStore.getChunkHash(chunkX, chunkZ));
-                    if (chunkClaims != null)
-                        intersectable.addAll(chunkClaims);
+                    if (chunkClaims == null) continue;
+
+                    for (Claim claim : chunkClaims)
+                    {
+                        if (pistonBlock.getWorld().equals(claim.getLesserBoundaryCorner().getWorld()))
+                            intersectable.add(claim);
+                    }
                 }
             }
 


### PR DESCRIPTION
Affects only `EVERYWHERE_SIMPLE`.

Closes #1098 