### PR TITLE
Fix claim bounding boxes not covering whole claim

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/util/BoundingBox.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/util/BoundingBox.java
@@ -143,7 +143,7 @@ public class BoundingBox implements Cloneable
      */
     public BoundingBox(Claim claim)
     {
-        this(claim.getLesserBoundaryCorner(), claim.getGreaterBoundaryCorner(), false);
+        this(claim.getLesserBoundaryCorner(), claim.getGreaterBoundaryCorner().clone().add(0, 255, 0), false);
     }
 
     /**


### PR DESCRIPTION
This is a temporary bandaid for a larger issue that will prevent addons implementing 3D (sub)claims. GP does not have a concept of max Y, so while in some cases it is set to build height, in others max y is exactly the same as min y.

This un-breaks resizing claims. MY BAD.