### PR TITLE
Fix rounding error on partial negative coordinates

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -730,8 +730,8 @@ public class Claim
         //not in the same world implies false
         if (!Objects.equals(location.getWorld(), this.lesserBoundaryCorner.getWorld())) return false;
 
-        int x = (int) location.getX();
-        int z = (int) location.getZ();
+        int x = location.getBlockX();
+        int z = location.getBlockZ();
         int y;
         if (ignoreHeight) {
             y = location.getBlockY();


### PR DESCRIPTION
Only affected player commands on negative edges, considered claim shifted by 1 block in those cases.