### PR TITLE
Make POM more explicit about plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,23 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.griefprevention</groupId>
     <artifactId>GriefPrevention</artifactId>
     <version>16.17.1-SNAPSHOT</version>
+
+    <name>GriefPrevention</name>
+    <description>The official self-service anti-griefing Bukkit plugin for Minecraft servers since 2011.</description>
+    <inceptionYear>2011</inceptionYear>
+    <packaging>jar</packaging>
+
+    <licenses>
+        <license>
+            <name>GPL-3.0-or-later</name>
+            <url>https://choosealicense.com/licenses/gpl-3.0/</url>
+        </license>
+    </licenses>
+
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
+
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/TechFortress/GriefPrevention/issues</url>
+    </issueManagement>
+
+    <scm>
+        <developerConnection>scm:git:https://github.com/TechFortress/GriefPrevention.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
     <repositories>
         <repository>
             <id>paper-repo</id>
             <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
         <repository>
-            <id>spigot-repo</id> 
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url> 
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
             <id>worldedit-worldguard-repo</id>
@@ -27,33 +52,34 @@
             <id>essx-repo</id>
             <url>https://ci.ender.zone/plugin/repository/everything/</url>
         </repository>
-
     </repositories>
+
     <build>
-        <sourceDirectory>src/main/java</sourceDirectory>
-        <testSourceDirectory>src/test/java</testSourceDirectory>
-        <testResources>
-          <testResource>
-            <directory>src/test/resources</directory>
-          </testResource>
-        </testResources>
         <finalName>${project.name}</finalName>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
-                <targetPath>.</targetPath>
                 <includes>
                     <include>plugin.yml</include>
                 </includes>
             </resource>
         </resources>
         <plugins>
-            <!-- append git commit hash to version-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <!-- Append git commit hash to version -->
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>4.0.3</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>
@@ -74,73 +100,94 @@
                 </configuration>
             </plugin>
         </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
+
     <dependencies>
-        <!--Bukkit API. Bukkit has never ever deployed a release version.-->
+        <!-- Bukkit API. Bukkit has never ever deployed a release version -->
         <dependency>
-                <groupId>org.spigotmc</groupId>
-                <artifactId>spigot-api</artifactId>
-                <version>1.16.1-R0.1-SNAPSHOT</version>
-                <scope>provided</scope>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
-         <!--Worldguard dependency-->
+        <!-- Worldguard dependency -->
         <dependency>
-                <groupId>com.sk89q.worldguard</groupId>
-                <artifactId>worldguard-bukkit</artifactId>
-                <version>7.0.4-SNAPSHOT</version>
-                <scope>provided</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.bukkit</groupId>
-                        <artifactId>bukkit</artifactId>
-                    </exclusion>
-                    <!--<exclusion>-->
-                        <!--<groupId>com.sk89q.worldedit</groupId>-->
-                        <!--<artifactId>worldedit-bukkit</artifactId>-->
-                    <!--</exclusion>-->
-                    <exclusion>
-                        <groupId>com.sk89q</groupId>
-                        <artifactId>commandbook</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.bstats</groupId>
-                        <artifactId>bstats-bukkit</artifactId>
-                    </exclusion>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-bukkit</artifactId>
+            <version>7.0.4-SNAPSHOT</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>bukkit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sk89q</groupId>
+                    <artifactId>commandbook</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bstats</groupId>
+                    <artifactId>bstats-bukkit</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
-         <!--Vault dependency-->
+        <!-- Vault dependency -->
         <dependency>
-                <groupId>net.milkbowl.vault</groupId>
-                <artifactId>VaultAPI</artifactId>
-                <version>1.7</version>
-                <scope>provided</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.bukkit</groupId>
-                        <artifactId>bukkit</artifactId>
-                    </exclusion>
-                </exclusions>
+            <groupId>net.milkbowl.vault</groupId>
+            <artifactId>VaultAPI</artifactId>
+            <version>1.7</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>bukkit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-        <!--Tests-->
+        <!-- Tests -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.6.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.6.2</version>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
-    <scm>
-        <developerConnection>scm:git:https://github.com/TechFortress/GriefPrevention.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
-    
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>


### PR DESCRIPTION
Changes:
- Add missing POM sections: name, description, inceptionYear, packaging, licenses, and issueManagement
- For tests, use junit-jupiter instead of both junit-jupiter-api and junit-jupiter-engine
- Dependency versions:
    - junit-jupiter 5.6.2 -> 5.7.0
    - git-commit-id-plugin 3.0.0 -> 4.0.3
- Explicitly use the latest plugin versions, rather than the dated default versions from the Super POM
- Define Java language source- and target level directly in the maven-compiler-plugin configuration
- Use consistent identation