### PR TITLE
Remove magic number 7 from explosion handler

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -452,7 +452,7 @@ public class BlockEventHandler implements Listener
         //warn players when they place TNT above sea level, since it doesn't destroy blocks there
         if (GriefPrevention.instance.config_blockSurfaceOtherExplosions && block.getType() == Material.TNT &&
                 block.getWorld().getEnvironment() != Environment.NETHER &&
-                block.getY() >= GriefPrevention.instance.getSeaLevel(block.getWorld()) &&
+                block.getY() >= GriefPrevention.instance.getTNTSeaLevel(block.getWorld()) &&
                 claim == null &&
                 playerData.siegeData == null)
         {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -452,7 +452,7 @@ public class BlockEventHandler implements Listener
         //warn players when they place TNT above sea level, since it doesn't destroy blocks there
         if (GriefPrevention.instance.config_blockSurfaceOtherExplosions && block.getType() == Material.TNT &&
                 block.getWorld().getEnvironment() != Environment.NETHER &&
-                block.getY() > GriefPrevention.instance.getSeaLevel(block.getWorld()) - 5 &&
+                block.getY() >= GriefPrevention.instance.getSeaLevel(block.getWorld()) &&
                 claim == null &&
                 playerData.siegeData == null)
         {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -345,6 +345,9 @@ public class EntityEventHandler implements Listener
         //make a list of blocks which were allowed to explode
         List<Block> explodedBlocks = new ArrayList<>();
         Claim cachedClaim = null;
+
+        int seaLevel = GriefPrevention.instance.getSeaLevel(world);
+
         for (Block block : blocks)
         {
             //always ignore air blocks
@@ -376,7 +379,10 @@ public class EntityEventHandler implements Listener
             //if no, then also consider surface rules
             if (claim == null)
             {
-                if (!applySurfaceRules || block.getLocation().getBlockY() < GriefPrevention.instance.getSeaLevel(world) - 7)
+                //if the explosion happens above sea level, don't explode the block.
+                if (location.getBlockY() >= seaLevel) continue;
+
+                if (!applySurfaceRules || block.getLocation().getBlockY() < seaLevel)
                 {
                     explodedBlocks.add(block);
                 }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -346,7 +346,7 @@ public class EntityEventHandler implements Listener
         List<Block> explodedBlocks = new ArrayList<>();
         Claim cachedClaim = null;
 
-        int seaLevel = GriefPrevention.instance.getSeaLevel(world);
+        int seaLevel = GriefPrevention.instance.getTNTSeaLevel(world);
 
         for (Block block : blocks)
         {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -380,7 +380,7 @@ public class EntityEventHandler implements Listener
             if (claim == null)
             {
                 //if the explosion happens above sea level, don't explode the block.
-                if (location.getBlockY() >= seaLevel) continue;
+                if (applySurfaceRules && location.getBlockY() >= seaLevel) continue;
 
                 if (!applySurfaceRules || block.getLocation().getBlockY() < seaLevel)
                 {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -3590,6 +3590,19 @@ public class GriefPrevention extends JavaPlugin
         }
     }
 
+    public int getTNTSeaLevel(World world)
+    {
+        Integer overrideValue = this.config_seaLevelOverride.get(world.getName());
+        if (overrideValue == null || overrideValue == -1)
+        {
+            return this.getSeaLevel(world) - 7;
+        }
+        else
+        {
+            return overrideValue;
+        }
+    }
+
     public boolean containsBlockedIP(String message)
     {
         message = message.replace("\r\n", "");


### PR DESCRIPTION
Explosions above sea level are now disallowed altogether this to keep the feature of not having craters at the surface level, but keeping the feature consistent with allowing blocks to be exploded below sea level.

Discussion: https://github.com/TechFortress/GriefPrevention/discussions/1187