### PR TITLE
Now pistons move in adjacent trusted regions. Configurable in config.yml

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -481,7 +481,7 @@ public class GriefPrevention extends JavaPlugin
                 this.config_claims_worldModes.put(world, ClaimsMode.Creative);
                 this.config_creativeWorldsExist = true;
             }
-            else if (world.getEnvironment() == Environment.NORMAL)
+            else if (world.getEnvironment() == World.Environment.NORMAL)
             {
                 this.config_claims_worldModes.put(world, ClaimsMode.Survival);
             }
@@ -2435,7 +2435,7 @@ public class GriefPrevention extends JavaPlugin
             Bukkit.getPluginManager().callEvent(event);
 
             //if the player is in the nether or end, he's screwed (there's no way to programmatically find a safe place for him)
-            if (player.getWorld().getEnvironment() != Environment.NORMAL && event.getDestination() == null)
+            if (player.getWorld().getEnvironment() != World.Environment.NORMAL && event.getDestination() == null)
             {
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.TrappedWontWorkHere);
                 return true;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -209,6 +209,7 @@ public class GriefPrevention extends JavaPlugin
 
     public boolean config_limitTreeGrowth;                          //whether trees should be prevented from growing into a claim from outside
     public PistonMode config_pistonMovement;                            //Setting for piston check options
+    public boolean config_pistonAllowIntersectionTrustedClaims; // allow to move pistons into trusted claims.
     public boolean config_pistonExplosionSound;                     //whether pistons make an explosion sound when they get removed
 
     public boolean config_advanced_fixNegativeClaimblockAmounts;    //whether to attempt to fix negative claim block amounts (some addons cause/assume players can go into negative amounts)
@@ -597,6 +598,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_limitTreeGrowth = config.getBoolean("GriefPrevention.LimitTreeGrowth", false);
         this.config_pistonExplosionSound = config.getBoolean("GriefPrevention.PistonExplosionSound", true);
         this.config_pistonMovement = PistonMode.of(config.getString("GriefPrevention.PistonMovement", "CLAIMS_ONLY"));
+        this.config_pistonAllowIntersectionTrustedClaims = config.getBoolean("GriefPrevention.Piston", true);
         if (config.isBoolean("GriefPrevention.LimitPistonsToLandClaims") && !config.getBoolean("GriefPrevention.LimitPistonsToLandClaims"))
             this.config_pistonMovement = PistonMode.EVERYWHERE_SIMPLE;
         if (config.isBoolean("GriefPrevention.CheckPistonMovement") && !config.getBoolean("GriefPrevention.CheckPistonMovement"))

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -37,7 +37,6 @@ import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Statistic;
 import org.bukkit.World;
-import org.bukkit.World.Environment;
 import org.bukkit.block.Block;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -598,7 +597,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_limitTreeGrowth = config.getBoolean("GriefPrevention.LimitTreeGrowth", false);
         this.config_pistonExplosionSound = config.getBoolean("GriefPrevention.PistonExplosionSound", true);
         this.config_pistonMovement = PistonMode.of(config.getString("GriefPrevention.PistonMovement", "CLAIMS_ONLY"));
-        this.config_pistonAllowIntersectionTrustedClaims = config.getBoolean("GriefPrevention.Piston", true);
+        this.config_pistonAllowIntersectionTrustedClaims = config.getBoolean("GriefPrevention.AllowPistonsIntersectionTrustedClaims", true);
         if (config.isBoolean("GriefPrevention.LimitPistonsToLandClaims") && !config.getBoolean("GriefPrevention.LimitPistonsToLandClaims"))
             this.config_pistonMovement = PistonMode.EVERYWHERE_SIMPLE;
         if (config.isBoolean("GriefPrevention.CheckPistonMovement") && !config.getBoolean("GriefPrevention.CheckPistonMovement"))


### PR DESCRIPTION
Basically what the titles say. 

I added this because some players wanted to coop but they weren't able to achieve this.
This can be modified (to the old behavior) in the configuration file. Default true. 