### PR TITLE
Makes onPlayerInteract ignore cancelled events

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1626,7 +1626,7 @@ class PlayerEventHandler implements Listener
     }
 
     //when a player interacts with the world
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     void onPlayerInteract(PlayerInteractEvent event)
     {
         //not interested in left-click-on-air actions


### PR DESCRIPTION
I'm currently working on a feature in my plugin to override some event handling in GP inside specific claims.
I would like to cancel it before GP, so it doesn't send the message `"You don't have <nick>'s permission to use that"`. ignoreCancelled should be true for that to work.
I think it shouldn't break any logic in GP, other events have that enabled...