### PR TITLE
Change method signature of allowBreak method in main class

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -3440,7 +3440,11 @@ public class GriefPrevention extends JavaPlugin
         return this.allowBreak(player, block, location, null);
     }
 
-    public String allowBreak(Player player, Block block, Location location, BlockBreakEvent breakEvent)
+    public String allowBreak(Player player, Block block, Location location, BlockBreakEvent breakEvent) {
+        return this.allowBreak(player, block.getType(), location, breakEvent);
+    }
+
+    public String allowBreak(Player player, Material material, Location location, BlockBreakEvent breakEvent)
     {
         if (!GriefPrevention.instance.claimsEnabledForWorld(location.getWorld())) return null;
 
@@ -3475,7 +3479,7 @@ public class GriefPrevention extends JavaPlugin
             playerData.lastClaim = claim;
 
             //if not in the wilderness, then apply claim rules (permissions, etc)
-            String cancel = claim.allowBreak(player, block.getType());
+            String cancel = claim.allowBreak(player, material);
             if (cancel != null && breakEvent != null)
             {
                 PreventBlockBreakEvent preventionEvent = new PreventBlockBreakEvent(breakEvent);


### PR DESCRIPTION
I'm working on a plugin, intending it to support GriefPrevention's land protection. There is this public method in the main class that caught my attention a`llowBreak(Player player, Block block, Location location, BlockBreakEvent breakEvent)`. This class takes in a Block type parameter but never utilises its properties - only calling `block.getType()` at some point to test if that block can be broken in a claimed area.

It is a suggestion to change the method signature to/add a method with signature `allowBreak(Player player, Material material, Location location, BlockBreakEvent breakEvent)` instead. This will allow plugin authors who want to know if a player can break STONE at a given location without having an actual stone there. Right now the best way to do this is to copy and paste the entire method down.