### PR TITLE
Fix falling block and vehicle block change handling

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -36,10 +36,12 @@ import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Chest;
 import org.bukkit.block.data.type.Dispenser;
+import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Fireball;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
+import org.bukkit.entity.Trident;
 import org.bukkit.entity.minecart.HopperMinecart;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -737,34 +739,9 @@ public class BlockEventHandler implements Listener
             }
         }
 
-        // Handle arrows igniting TNT.
+        // Arrow ignition is handled by the EntityChangeBlockEvent.
         if (igniteEvent.getCause() == IgniteCause.ARROW)
         {
-            Claim claim = GriefPrevention.instance.dataStore.getClaimAt(igniteEvent.getBlock().getLocation(), false, null);
-
-            if (claim == null)
-            {
-                // Only TNT can be ignited by arrows, so the targeted block will be destroyed by completion.
-                if (!GriefPrevention.instance.config_fireDestroys || !GriefPrevention.instance.config_fireSpreads)
-                    igniteEvent.setCancelled(true);
-                return;
-            }
-
-            if (igniteEvent.getIgnitingEntity() instanceof Projectile)
-            {
-                ProjectileSource shooter = ((Projectile) igniteEvent.getIgnitingEntity()).getShooter();
-
-                // Allow ignition if arrow was shot by a player with build permission.
-                if (shooter instanceof Player && claim.allowBuild((Player) shooter, Material.TNT) == null) return;
-
-                // Allow ignition if arrow was shot by a dispenser in the same claim.
-                if (shooter instanceof BlockProjectileSource &&
-                        GriefPrevention.instance.dataStore.getClaimAt(((BlockProjectileSource) shooter).getBlock().getLocation(), false, claim) == claim)
-                    return;
-            }
-
-            // Block all other ignition by arrows in claims.
-            igniteEvent.setCancelled(true);
             return;
         }
 
@@ -923,10 +900,11 @@ public class BlockEventHandler implements Listener
         //don't track in worlds where claims are not enabled
         if (!GriefPrevention.instance.claimsEnabledForWorld(event.getEntity().getWorld())) return;
 
-        if (event.getHitBlock() == null || event.getHitBlock().getType() != Material.CHORUS_FLOWER)
-            return;
-
         Block block = event.getHitBlock();
+
+        // Ensure projectile affects block.
+        if (block == null || block.getType() != Material.CHORUS_FLOWER)
+            return;
 
         Claim claim = dataStore.getClaimAt(block.getLocation(), false, null);
         if (claim == null)
@@ -940,8 +918,7 @@ public class BlockEventHandler implements Listener
 
         if (shooter == null)
         {
-            event.getHitBlock().setType(Material.AIR);
-            Bukkit.getScheduler().runTask(GriefPrevention.instance, () -> event.getHitBlock().setBlockData(block.getBlockData()));
+            event.setCancelled(true);
             return;
         }
 
@@ -949,8 +926,7 @@ public class BlockEventHandler implements Listener
 
         if (allowContainer != null)
         {
-            event.getHitBlock().setType(Material.AIR);
-            Bukkit.getScheduler().runTask(GriefPrevention.instance, () -> event.getHitBlock().setBlockData(block.getBlockData()));
+            event.setCancelled(true);
             GriefPrevention.sendMessage(shooter, TextMode.Err, allowContainer);
             return;
         }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -19,7 +19,6 @@
 package me.ryanhamshire.GriefPrevention;
 
 import me.ryanhamshire.GriefPrevention.util.BoundingBox;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -36,12 +35,10 @@ import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Chest;
 import org.bukkit.block.data.type.Dispenser;
-import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Fireball;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
-import org.bukkit.entity.Trident;
 import org.bukkit.entity.minecart.HopperMinecart;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -92,6 +92,7 @@ import org.bukkit.metadata.MetadataValue;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.util.Vector;
 
@@ -147,6 +148,11 @@ public class EntityEventHandler implements Listener
         else if (!GriefPrevention.instance.config_rabbitsEatCrops && event.getEntityType() == EntityType.RABBIT)
         {
             event.setCancelled(true);
+        }
+        // Handle projectiles changing blocks: TNT ignition, tridents knocking down pointed dripstone, etc.
+        else if (event.getEntity() instanceof Projectile)
+        {
+            handleProjectileChangeBlock(event, (Projectile) event.getEntity());
         }
         else if (GriefPrevention.instance.config_claims_worldModes.get(event.getBlock().getWorld()) != ClaimsMode.Disabled)
         {
@@ -242,6 +248,60 @@ public class EntityEventHandler implements Listener
                 }
             }
         }
+    }
+
+    private void handleProjectileChangeBlock(EntityChangeBlockEvent event, Projectile projectile)
+    {
+        Block block = event.getBlock();
+        Claim claim = this.dataStore.getClaimAt(block.getLocation(), false, null);
+
+        // Wilderness rules
+        if (claim == null)
+        {
+            // TNT change means ignition. If no claim is present, use global fire rules.
+            if (block.getType() == Material.TNT)
+            {
+                if (!GriefPrevention.instance.config_fireDestroys || !GriefPrevention.instance.config_fireSpreads)
+                    event.setCancelled(true);
+                return;
+            }
+
+            // No modification in the wilderness in creative mode.
+            if (instance.creativeRulesApply(block.getLocation()) || instance.config_claims_worldModes.get(block.getWorld()) == ClaimsMode.SurvivalRequiringClaims)
+            {
+                event.setCancelled(true);
+                return;
+            }
+
+            // Unclaimed area is fair game.
+            return;
+        }
+
+        ProjectileSource shooter = projectile.getShooter();
+
+        if (shooter instanceof Player)
+        {
+            String denial = claim.allowBuild((Player) shooter, block.getType());
+
+            // If the player cannot place the material being broken, disallow.
+            if (denial != null)
+            {
+                // Unlike entities where arrows rebound and may cause multiple alerts,
+                // projectiles lodged in blocks do not continuously re-trigger events.
+                GriefPrevention.sendMessage((Player) shooter, TextMode.Err, denial);
+                event.setCancelled(true);
+            }
+
+            return;
+        }
+
+        // Allow change if projectile was shot by a dispenser in the same claim.
+        if (shooter instanceof BlockProjectileSource &&
+                GriefPrevention.instance.dataStore.getClaimAt(((BlockProjectileSource) shooter).getBlock().getLocation(), false, claim) == claim)
+            return;
+
+        // Prevent change in all other cases.
+        event.setCancelled(true);
     }
 
     //Used by "sand cannon" fix to ignore fallingblocks that fell through End Portals


### PR DESCRIPTION
Fixes handling being skipped because it requires claims. Fixes infinite dupe of items for falling blocks when handling actually runs.

Includes changes in #1423 because it'll have to be merged in later anyway, but this is a separate issue.

Closes #981