### PR TITLE
Update to 1.17

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -105,6 +105,8 @@ public class BlockEventHandler implements Listener
         this.trashBlocks.add(Material.SAND);
         this.trashBlocks.add(Material.TNT);
         this.trashBlocks.add(Material.CRAFTING_TABLE);
+        this.trashBlocks.add(Material.TUFF);
+        this.trashBlocks.add(Material.COBBLED_DEEPSLATE);
     }
 
     //when a player breaks a block...

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -364,7 +364,10 @@ public class Claim
             Material.POTATOES,
             Material.NETHER_WART,
             Material.BEETROOTS,
-            Material.COCOA);
+            Material.COCOA,
+            Material.GLOW_BERRIES,
+            Material.CAVE_VINES,
+            Material.CAVE_VINES_PLANT);
 
     private static boolean placeableForFarming(Material material)
     {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -920,7 +920,7 @@ public abstract class DataStore
         //creative mode claims always go to bedrock
         if (GriefPrevention.instance.config_claims_worldModes.get(world) == ClaimsMode.Creative)
         {
-            smally = 0;
+            smally = world.getMinHeight();
         }
 
         //create a new claim instance (but don't save it, yet)

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -544,7 +544,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_claims_claimsExtendIntoGroundDistance = Math.abs(config.getInt("GriefPrevention.Claims.ExtendIntoGroundDistance", 5));
         this.config_claims_minWidth = config.getInt("GriefPrevention.Claims.MinimumWidth", 5);
         this.config_claims_minArea = config.getInt("GriefPrevention.Claims.MinimumArea", 100);
-        this.config_claims_maxDepth = config.getInt("GriefPrevention.Claims.MaximumDepth", 0);
+        this.config_claims_maxDepth = config.getInt("GriefPrevention.Claims.MaximumDepth", Integer.MIN_VALUE);
         this.config_claims_chestClaimExpirationDays = config.getInt("GriefPrevention.Claims.Expiration.ChestClaimDays", 7);
         this.config_claims_unusedClaimExpirationDays = config.getInt("GriefPrevention.Claims.Expiration.UnusedClaimDays", 14);
         this.config_claims_expirationDays = config.getInt("GriefPrevention.Claims.Expiration.AllClaims.DaysInactive", 60);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -2234,7 +2234,7 @@ class PlayerEventHandler implements Listener
                 int minz = centerBlock.getZ() - playerData.fillRadius;
                 int maxz = centerBlock.getZ() + playerData.fillRadius;
                 int minHeight = maxHeight - 10;
-                if (minHeight < 0) minHeight = 0;
+                minHeight = Math.max(minHeight, clickedBlock.getWorld().getMinHeight());
 
                 Claim cachedClaim = null;
                 for (int x = minx; x <= maxx; x++)

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1730,6 +1730,7 @@ class PlayerEventHandler implements Listener
                                 clickedBlockType == Material.CHIPPED_ANVIL ||
                                 clickedBlockType == Material.DAMAGED_ANVIL ||
                                 clickedBlockType == Material.CAKE ||
+                                Tag.CANDLE_CAKES.isTagged(clickedBlockType) ||
                                 clickedBlockType == Material.SWEET_BERRY_BUSH ||
                                 clickedBlockType == Material.BEE_NEST ||
                                 clickedBlockType == Material.BEEHIVE ||
@@ -1833,7 +1834,7 @@ class PlayerEventHandler implements Listener
         }
 
         //otherwise apply rule for cake
-        else if (clickedBlock != null && instance.config_claims_preventTheft && clickedBlockType == Material.CAKE)
+        else if (clickedBlock != null && instance.config_claims_preventTheft && (clickedBlockType == Material.CAKE || Tag.CANDLE_CAKES.isTagged(clickedBlockType)))
         {
             if (playerData == null) playerData = this.dataStore.getPlayerData(player.getUniqueId());
             Claim claim = this.dataStore.getClaimAt(clickedBlock.getLocation(), false, playerData.lastClaim);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/RestoreNatureProcessingTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/RestoreNatureProcessingTask.java
@@ -656,12 +656,16 @@ class RestoreNatureProcessingTask implements Runnable
         playerBlocks.addAll(Tag.BEDS.getValues());
         playerBlocks.addAll(Tag.BUTTONS.getValues());
         playerBlocks.addAll(Tag.CAMPFIRES.getValues());
+        playerBlocks.addAll(Tag.CANDLE_CAKES.getValues());
+        playerBlocks.addAll(Tag.CANDLES.getValues());
         playerBlocks.addAll(Tag.CARPETS.getValues());
+        playerBlocks.addAll(Tag.CAULDRONS.getValues());
         playerBlocks.addAll(Tag.DOORS.getValues());
-        playerBlocks.addAll(Tag.FENCES.getValues());
         playerBlocks.addAll(Tag.FENCE_GATES.getValues());
+        playerBlocks.addAll(Tag.FENCES.getValues());
         playerBlocks.addAll(Tag.FIRE.getValues());
         playerBlocks.addAll(Tag.FLOWER_POTS.getValues());
+        playerBlocks.addAll(Tag.IMPERMEABLE.getValues()); // Glass block variants
         playerBlocks.addAll(Tag.LOGS.getValues());
         playerBlocks.addAll(Tag.PLANKS.getValues());
         playerBlocks.addAll(Tag.PRESSURE_PLATES.getValues());
@@ -678,7 +682,6 @@ class RestoreNatureProcessingTask implements Runnable
         playerBlocks.add(Material.BREWING_STAND);
         playerBlocks.add(Material.BRICK);
         playerBlocks.add(Material.COBBLESTONE);
-        playerBlocks.add(Material.GLASS);
         playerBlocks.add(Material.LAPIS_BLOCK);
         playerBlocks.add(Material.DISPENSER);
         playerBlocks.add(Material.NOTE_BLOCK);
@@ -711,7 +714,6 @@ class RestoreNatureProcessingTask implements Runnable
         playerBlocks.add(Material.GLASS_PANE);
         playerBlocks.add(Material.MELON_STEM);
         playerBlocks.add(Material.ENCHANTING_TABLE);
-        playerBlocks.add(Material.CAULDRON);
         playerBlocks.add(Material.COBWEB);
         playerBlocks.add(Material.GRAVEL);
         playerBlocks.add(Material.SANDSTONE);
@@ -729,22 +731,6 @@ class RestoreNatureProcessingTask implements Runnable
         playerBlocks.add(Material.PLAYER_HEAD);
         playerBlocks.add(Material.DRAGON_HEAD);
         playerBlocks.add(Material.SPONGE);
-        playerBlocks.add(Material.WHITE_STAINED_GLASS);
-        playerBlocks.add(Material.ORANGE_STAINED_GLASS);
-        playerBlocks.add(Material.MAGENTA_STAINED_GLASS);
-        playerBlocks.add(Material.LIGHT_BLUE_STAINED_GLASS);
-        playerBlocks.add(Material.YELLOW_STAINED_GLASS);
-        playerBlocks.add(Material.LIME_STAINED_GLASS);
-        playerBlocks.add(Material.PINK_STAINED_GLASS);
-        playerBlocks.add(Material.GRAY_STAINED_GLASS);
-        playerBlocks.add(Material.LIGHT_GRAY_STAINED_GLASS);
-        playerBlocks.add(Material.CYAN_STAINED_GLASS);
-        playerBlocks.add(Material.PURPLE_STAINED_GLASS);
-        playerBlocks.add(Material.BLUE_STAINED_GLASS);
-        playerBlocks.add(Material.BROWN_STAINED_GLASS);
-        playerBlocks.add(Material.GREEN_STAINED_GLASS);
-        playerBlocks.add(Material.RED_STAINED_GLASS);
-        playerBlocks.add(Material.BLACK_STAINED_GLASS);
         playerBlocks.add(Material.WHITE_STAINED_GLASS_PANE);
         playerBlocks.add(Material.ORANGE_STAINED_GLASS_PANE);
         playerBlocks.add(Material.MAGENTA_STAINED_GLASS_PANE);
@@ -774,26 +760,47 @@ class RestoreNatureProcessingTask implements Runnable
         playerBlocks.add(Material.SEA_LANTERN);
         playerBlocks.add(Material.COAL_BLOCK);
         playerBlocks.add(Material.REDSTONE_LAMP);
-        playerBlocks.add(Material.PURPUR_BLOCK);
-        playerBlocks.add(Material.PURPUR_PILLAR);
         playerBlocks.add(Material.RED_NETHER_BRICKS);
+        playerBlocks.add(Material.POLISHED_ANDESITE);
+        playerBlocks.add(Material.POLISHED_DIORITE);
+        playerBlocks.add(Material.POLISHED_GRANITE);
+        playerBlocks.add(Material.POLISHED_BASALT);
+        playerBlocks.add(Material.POLISHED_DEEPSLATE);
+        playerBlocks.add(Material.DEEPSLATE_BRICKS);
+        playerBlocks.add(Material.CRACKED_DEEPSLATE_BRICKS);
+        playerBlocks.add(Material.DEEPSLATE_TILES);
+        playerBlocks.add(Material.CRACKED_DEEPSLATE_TILES);
+        playerBlocks.add(Material.CHISELED_DEEPSLATE);
+        playerBlocks.add(Material.RAW_COPPER_BLOCK);
+        playerBlocks.add(Material.RAW_IRON_BLOCK);
+        playerBlocks.add(Material.RAW_GOLD_BLOCK);
+        playerBlocks.add(Material.LIGHTNING_ROD);
+
+        //these are unnatural in the nether and end
+        if (environment != Environment.NORMAL && environment != Environment.CUSTOM)
+        {
+            playerBlocks.addAll(Tag.BASE_STONE_OVERWORLD.getValues());
+            playerBlocks.addAll(Tag.DIRT.getValues());
+            playerBlocks.addAll(Tag.SAND.getValues());
+        }
 
         //these are unnatural in the standard world, but not in the nether
         if (environment != Environment.NETHER)
         {
             playerBlocks.addAll(Tag.NYLIUM.getValues());
             playerBlocks.addAll(Tag.WART_BLOCKS.getValues());
+            playerBlocks.addAll(Tag.BASE_STONE_NETHER.getValues());
+            playerBlocks.add(Material.POLISHED_BLACKSTONE);
+            playerBlocks.add(Material.CHISELED_POLISHED_BLACKSTONE);
+            playerBlocks.add(Material.CRACKED_POLISHED_BLACKSTONE_BRICKS);
+            playerBlocks.add(Material.GILDED_BLACKSTONE);
             playerBlocks.add(Material.BONE_BLOCK);
-            playerBlocks.add(Material.NETHERRACK);
             playerBlocks.add(Material.SOUL_SAND);
             playerBlocks.add(Material.SOUL_SOIL);
             playerBlocks.add(Material.GLOWSTONE);
             playerBlocks.add(Material.NETHER_BRICK);
             playerBlocks.add(Material.MAGMA_BLOCK);
             playerBlocks.add(Material.ANCIENT_DEBRIS);
-            playerBlocks.add(Material.BASALT);
-            playerBlocks.add(Material.BLACKSTONE);
-            playerBlocks.add(Material.GILDED_BLACKSTONE);
             playerBlocks.add(Material.CHAIN);
             playerBlocks.add(Material.SHROOMLIGHT);
             playerBlocks.add(Material.NETHER_GOLD_ORE);
@@ -824,11 +831,20 @@ class RestoreNatureProcessingTask implements Runnable
         //these are unnatural in the standard and nether worlds, but not in the end
         if (environment != Environment.THE_END)
         {
-            playerBlocks.add(Material.OBSIDIAN);
-            playerBlocks.add(Material.END_STONE);
-            playerBlocks.add(Material.END_PORTAL_FRAME);
             playerBlocks.add(Material.CHORUS_PLANT);
             playerBlocks.add(Material.CHORUS_FLOWER);
+            playerBlocks.add(Material.END_ROD);
+            playerBlocks.add(Material.END_STONE);
+            playerBlocks.add(Material.END_STONE_BRICKS);
+            playerBlocks.add(Material.OBSIDIAN);
+            playerBlocks.add(Material.PURPUR_BLOCK);
+            playerBlocks.add(Material.PURPUR_PILLAR);
+        }
+        //blocks from tags that are natural in the end
+        else
+        {
+            playerBlocks.remove(Material.PURPUR_SLAB);
+            playerBlocks.remove(Material.PURPUR_STAIRS);
         }
 
         //these are unnatural in sandy biomes, but not elsewhere

--- a/src/main/java/me/ryanhamshire/GriefPrevention/util/BoundingBox.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/util/BoundingBox.java
@@ -20,8 +20,6 @@ import java.util.Objects;
  * <p>While similar to Bukkit's {@link org.bukkit.util.BoundingBox BoundingBox},
  * this implementation is much more focused on performance and does not use as
  * many input sanitization operations.
- *
- * @author Jikoo
  */
 public class BoundingBox implements Cloneable
 {
@@ -143,7 +141,8 @@ public class BoundingBox implements Cloneable
      */
     public BoundingBox(Claim claim)
     {
-        this(claim.getLesserBoundaryCorner(), claim.getGreaterBoundaryCorner().clone().add(0, 319, 0), false);
+        this(claim.getLesserBoundaryCorner(), claim.getGreaterBoundaryCorner(), false);
+        this.maxY = Objects.requireNonNull(claim.getLesserBoundaryCorner().getWorld()).getMaxHeight();
     }
 
     /**


### PR DESCRIPTION
* Update material listings to include new blocks
  * Fixes a few missed cases from previous versions
* Replaced claim to bounding box bandaid for world max height increase with actual world limit
* Account for worlds with min height less than zero
  * New default maximum depth is now integer min value (-2147483648) to not restrict users no matter how weirdly they set up worlds
  * Creative claims always extend to world min height, not 0
  * RestoreNature restores to a max depth of world min height instead of 0

Closes #1309 
Closes #1431 