### PR TITLE
[Draft] Implement TabCompleter for GriefPrevention commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,25 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.7.0</version>
+            <version>5.7.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.11.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>3.11.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.20.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -18,6 +18,7 @@
 
 package me.ryanhamshire.GriefPrevention;
 
+import com.google.common.collect.ImmutableList;
 import me.ryanhamshire.GriefPrevention.util.BoundingBox;
 import me.ryanhamshire.GriefPrevention.events.ClaimPermissionCheckEvent;
 import org.bukkit.Bukkit;
@@ -677,32 +678,32 @@ public class Claim
         }
     }
 
-    public List<String> getBuildTrustList()
+    public ImmutableList<String> getBuildTrustList()
     {
-        return getPermissions(ClaimPermission.Build);
+        return getTrustList(ClaimPermission.Build);
     }
 
-    public List<String> getContainerTrustList()
+    public ImmutableList<String> getContainerTrustList()
     {
-        return getPermissions(ClaimPermission.Inventory);
+        return getTrustList(ClaimPermission.Inventory);
     }
 
-    public List<String> getAccessTrustList()
+    public ImmutableList<String> getAccessTrustList()
     {
-        return getPermissions(ClaimPermission.Access);
+        return getTrustList(ClaimPermission.Access);
     }
 
-    public List<String> getManagerTrustList()
+    public ImmutableList<String> getManagerTrustList()
     {
-        return new ArrayList<>(managers);
+        return ImmutableList.copyOf(managers);
     }
 
-    private List<String> getPermissions(ClaimPermission level)
+    private ImmutableList<String> getTrustList(ClaimPermission level)
     {
         return playerIDToClaimPermissionMap.entrySet().stream()
                 .filter(entry -> entry.getValue() == level)
                 .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
+                .collect(ImmutableList.toImmutableList());
     }
 
     //gets ALL permissions

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -47,6 +47,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 //represents a player claim
 //creating an instance doesn't make an effective claim
@@ -662,6 +663,34 @@ public class Claim
         {
             child.clearPermissions();
         }
+    }
+
+    public List<String> getBuildTrustList()
+    {
+        return getPermissions(ClaimPermission.Build);
+    }
+
+    public List<String> getContainerTrustList()
+    {
+        return getPermissions(ClaimPermission.Inventory);
+    }
+
+    public List<String> getAccessTrustList()
+    {
+        return getPermissions(ClaimPermission.Access);
+    }
+
+    public List<String> getManagerTrustList()
+    {
+        return new ArrayList<>(managers);
+    }
+
+    private List<String> getPermissions(ClaimPermission level)
+    {
+        return playerIDToClaimPermissionMap.entrySet().stream()
+                .filter(entry -> entry.getValue() == level)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
     }
 
     //gets ALL permissions

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -48,7 +48,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 //represents a player claim
 //creating an instance doesn't make an effective claim

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -435,6 +435,18 @@ public class Claim
      *
      * @param player the Player being checked for permissions
      * @param permission the ClaimPermission level required
+     * @return {@code true} if the player has the specified permission, {@code false} otherwise.
+     */
+    boolean hasPermission(Player player, ClaimPermission permission)
+    {
+        return checkPermission(player, permission, null, null) == null;
+    }
+
+    /**
+     * Check whether or not a Player has a certain level of trust.
+     *
+     * @param player the Player being checked for permissions
+     * @param permission the ClaimPermission level required
      * @param event the Event triggering the permission check
      * @return the denial message or null if permission is granted
      */

--- a/src/main/java/me/ryanhamshire/GriefPrevention/CommandTabCompleter.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/CommandTabCompleter.java
@@ -1,0 +1,135 @@
+package me.ryanhamshire.GriefPrevention;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+// See notes in GriefPrevention.onTabComplete() regarding why this is static, and not an actual implementation
+// of org.bukkit.command.TabCompleter.
+class CommandTabCompleter
+{
+    private static final String THE_PUBLIC = "public";
+
+    private CommandTabCompleter()
+    {
+        throw new AssertionError("CommandTabCompleter should not be instantiated");
+    }
+
+    static List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args)
+    {
+        // Assume all completions will be for players, and not console.
+        if (!delegate.isPlayer(sender))
+        {
+            return null;
+        }
+
+        final String label = alias.toLowerCase(Locale.ROOT);
+        List<String> options = new ArrayList<>();
+
+        if (args.length == 1 && label.equals("containertrust"))
+        {
+            Claim claim = delegate.getCurrentClaim(sender);
+            if (claim != null)
+            {
+                options.add(THE_PUBLIC);
+                options.addAll(delegate.listOnlineNames());
+                options.removeAll(delegate.trustListToNameList(claim.getContainerTrustList()));
+                removeIfNotNull(options, claim.getOwnerName());
+            }
+        }
+
+        if (args.length == 1 && label.equals("untrust")) {
+            Claim claim = delegate.getCurrentClaim(sender);
+            if (claim != null)
+            {
+                // One person may have multiple trust types, so this avoids duplicate options
+                Set<String> trustees = new HashSet<>();
+                trustees.addAll(claim.getAccessTrustList());
+                trustees.addAll(claim.getBuildTrustList());
+                trustees.addAll(claim.getContainerTrustList());
+                trustees.addAll(claim.getManagerTrustList());
+                options.addAll(delegate.trustListToNameList(trustees));
+            }
+        }
+
+        return options;
+    }
+
+    private static void removeIfNotNull(List<String> list, String str)
+    {
+        if (str != null)
+        {
+            list.remove(str);
+        }
+    }
+
+    // This exists purely to ease injecting mocks
+    interface Delegate
+    {
+        boolean isPlayer(CommandSender sender);
+        Claim getCurrentClaim(CommandSender sender);
+        Collection<String> trustListToNameList(Collection<String> trustList);
+        Collection<String> listOnlineNames();
+    }
+
+    private static final Delegate SYSTEM_DELEGATE =
+        new Delegate()
+        {
+            @Override
+            public boolean isPlayer(CommandSender sender)
+            {
+                return sender instanceof Player;
+            }
+
+            @Override
+            public Claim getCurrentClaim(CommandSender sender)
+            {
+                Player player = (Player) sender;
+                PlayerData playerData =  GriefPrevention.instance.dataStore.getPlayerData(player.getUniqueId());
+                return GriefPrevention.instance.dataStore.getClaimAt(player.getLocation(), false, playerData.lastClaim);
+            }
+
+            @Override
+            public Collection<String> trustListToNameList(Collection<String> trustList)
+            {
+                return trustList.stream()
+                        .map(entry -> GriefPrevention.instance.trustEntryToPlayerName(entry))
+                        .collect(Collectors.toList());
+            }
+
+            @Override
+            public Collection<String> listOnlineNames()
+            {
+                return Bukkit.getOnlinePlayers().stream()
+                        .map(HumanEntity::getName)
+                        .collect(Collectors.toList());
+            }
+        };
+
+    private static Delegate delegate = SYSTEM_DELEGATE;
+
+    @VisibleForTesting
+    static void setDelegate(Delegate delegate)
+    {
+        if (delegate != null)
+        {
+            CommandTabCompleter.delegate = delegate;
+        }
+        else
+        {
+            CommandTabCompleter.delegate = SYSTEM_DELEGATE;
+        }
+    }
+
+}

--- a/src/main/java/me/ryanhamshire/GriefPrevention/CommandTabCompleter.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/CommandTabCompleter.java
@@ -35,23 +35,25 @@ class CommandTabCompleter
         }
 
         final String label = alias.toLowerCase(Locale.ROOT);
+        final Player player = (Player) sender;
         List<String> options = new ArrayList<>();
 
         if (args.length == 1 && label.equals("containertrust"))
         {
-            Claim claim = delegate.getCurrentClaim(sender);
-            if (claim != null)
+            Claim claim = delegate.getCurrentClaim(player);
+            if (claim != null && claim.hasPermission(player, ClaimPermission.Manage))
             {
                 options.add(THE_PUBLIC);
                 options.addAll(delegate.listOnlineNames());
-                options.removeAll(delegate.trustListToNameList(claim.getContainerTrustList()));
                 removeIfNotNull(options, claim.getOwnerName());
+                options.removeAll(delegate.trustListToNameList(claim.getContainerTrustList()));
             }
         }
 
-        if (args.length == 1 && label.equals("untrust")) {
-            Claim claim = delegate.getCurrentClaim(sender);
-            if (claim != null)
+        if (args.length == 1 && label.equals("untrust"))
+        {
+            Claim claim = delegate.getCurrentClaim(player);
+            if (claim != null && claim.hasPermission(player, ClaimPermission.Manage))
             {
                 // One person may have multiple trust types, so this avoids duplicate options
                 Set<String> trustees = new HashSet<>();
@@ -78,7 +80,7 @@ class CommandTabCompleter
     interface Delegate
     {
         boolean isPlayer(CommandSender sender);
-        Claim getCurrentClaim(CommandSender sender);
+        Claim getCurrentClaim(Player player);
         Collection<String> trustListToNameList(Collection<String> trustList);
         Collection<String> listOnlineNames();
     }
@@ -93,9 +95,8 @@ class CommandTabCompleter
             }
 
             @Override
-            public Claim getCurrentClaim(CommandSender sender)
+            public Claim getCurrentClaim(Player player)
             {
-                Player player = (Player) sender;
                 PlayerData playerData =  GriefPrevention.instance.dataStore.getPlayerData(player.getUniqueId());
                 return GriefPrevention.instance.dataStore.getClaimAt(player.getLocation(), false, playerData.lastClaim);
             }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/CommandTabCompleter.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/CommandTabCompleter.java
@@ -65,6 +65,22 @@ class CommandTabCompleter
             }
         }
 
+        if (sender.hasPermission("griefprevention.adjustclaimblocks"))
+        {
+            if (args.length == 1 && label.equals("adjustbonusclaimblocks"))
+            {
+                options.addAll(delegate.listOnlineNames());
+            }
+            else if ((args.length == 1 && label.equals("adjustbonusclaimblocksall"))
+                    || (args.length == 2 && label.equals("adjustbonusclaimblocks")))
+            {
+                options.add("10");
+                options.add("100");
+                options.add("1000");
+                options.add("10000");
+            }
+        }
+
         return options;
     }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/CommandTabCompleter.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/CommandTabCompleter.java
@@ -34,7 +34,7 @@ class CommandTabCompleter
             return null;
         }
 
-        final String label = alias.toLowerCase(Locale.ROOT);
+        final String label = command.getName().toLowerCase(Locale.ROOT);
         final Player player = (Player) sender;
         List<String> options = new ArrayList<>();
 
@@ -45,8 +45,8 @@ class CommandTabCompleter
             {
                 options.add(THE_PUBLIC);
                 options.addAll(delegate.listOnlineNames());
-                removeIfNotNull(options, claim.getOwnerName());
                 options.removeAll(delegate.trustListToNameList(claim.getContainerTrustList()));
+                removeIfNotNull(options, claim.getOwnerName());
             }
         }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -970,7 +970,19 @@ public class GriefPrevention extends JavaPlugin
         }
     }
 
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args)
+    {
+        // Rather than make the already rather large GriefPrevention class larger,
+        // the actual implementation has been extracted out.
+        // Bukkit will automatically call the onTabComplete() on the CommandExecutor, if it happens to
+        // implement the TabCompleter interface. JavaPlugin, which is the superclass of this one,
+        // happens to implement both, which is why onCommand is in here from old times.
+        return CommandTabCompleter.onTabComplete(sender, command, alias, args);
+    }
+
     //handles slash commands
+    @Override
     public boolean onCommand(CommandSender sender, Command cmd, String commandLabel, String[] args)
     {
 
@@ -2853,7 +2865,7 @@ public class GriefPrevention extends JavaPlugin
     public enum IgnoreMode
     {None, StandardIgnore, AdminIgnore}
 
-    private String trustEntryToPlayerName(String entry)
+    public String trustEntryToPlayerName(String entry)
     {
         if (entry.startsWith("[") || entry.equals("public"))
         {

--- a/src/test/java/me/ryanhamshire/GriefPrevention/TabCompleterTest.java
+++ b/src/test/java/me/ryanhamshire/GriefPrevention/TabCompleterTest.java
@@ -1,0 +1,157 @@
+package me.ryanhamshire.GriefPrevention;
+
+import com.google.common.collect.ImmutableList;
+import org.bukkit.command.Command;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static me.ryanhamshire.GriefPrevention.CommandTabCompleter.onTabComplete;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TabCompleterTest
+{
+
+    private static CommandTabCompleter.Delegate delegate;
+
+    @Mock
+    private Player sender;
+
+    @Mock
+    private Claim claim;
+
+    @Mock
+    private Command command;
+
+    @BeforeAll
+    static void beforeAll()
+    {
+        delegate = mock(CommandTabCompleter.Delegate.class);
+        CommandTabCompleter.setDelegate(delegate);
+    }
+
+    @AfterAll
+    static void afterAll()
+    {
+        delegate = null;
+        CommandTabCompleter.setDelegate(null);
+    }
+
+    @BeforeEach
+    void beforeEach()
+    {
+        when(delegate.isPlayer(sender)).thenReturn(true);
+    }
+
+    @Test
+    void doNotTabCompleteForConsole()
+    {
+        when(delegate.isPlayer(sender)).thenReturn(false);
+
+        List<String> options = onTabComplete(sender, command, "anything", noArguments());
+
+        assertThat(options).isNull();
+    }
+
+    @Test
+    void noResultsForContainertrustInWilderness()
+    {
+        List<String> options = onTabComplete(sender, command, "containertrust", noArguments());
+        assertThat(options).isEmpty();
+    }
+
+    @Test
+    void verifyResultsForContainertrustInClaimWithEmptyTrustList()
+    {
+        when(delegate.getCurrentClaim(sender)).thenReturn(claim);
+        when(delegate.listOnlineNames()).thenReturn(ImmutableList.of("Nouish", "RoboMWM"));
+        when(claim.getOwnerName()).thenReturn("Nouish");
+        when(claim.getContainerTrustList()).thenReturn(ImmutableList.of());
+
+        List<String> options = onTabComplete(sender, command, "containertrust", noArguments());
+
+        assertThat(options).containsExactlyInAnyOrder("public", "RoboMWM");
+    }
+
+    @Test
+    void verifyResultsForContainertrustInClaimWithTrustList()
+    {
+        when(delegate.trustListToNameList(anyCollection())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(delegate.getCurrentClaim(sender)).thenReturn(claim);
+        when(delegate.listOnlineNames()).thenReturn(ImmutableList.of("Nouish", "RoboMWM", "Jikoo"));
+        when(claim.getOwnerName()).thenReturn("RoboMWM");
+        when(claim.getContainerTrustList()).thenReturn(ImmutableList.of("Nouish"));
+
+        List<String> options = onTabComplete(sender, command, "containertrust", noArguments());
+
+        assertThat(options).containsExactlyInAnyOrder("public", "Jikoo");
+    }
+
+    @Test
+    void noResultsForUntrustInWilderness()
+    {
+        List<String> options = onTabComplete(sender, command, "untrust", noArguments());
+        assertThat(options).isEmpty();
+    }
+
+    @Test
+    void verifyResultsForUntrustInClaimWithEmptyTrustList()
+    {
+        when(delegate.getCurrentClaim(sender)).thenReturn(claim);
+        when(claim.getAccessTrustList()).thenReturn(ImmutableList.of());
+        when(claim.getBuildTrustList()).thenReturn(ImmutableList.of());
+        when(claim.getContainerTrustList()).thenReturn(ImmutableList.of());
+        when(claim.getManagerTrustList()).thenReturn(ImmutableList.of());
+
+        List<String> options = onTabComplete(sender, command, "untrust", noArguments());
+
+        assertThat(options).isEmpty();
+    }
+
+    @Test
+    void verifyResultsForUntrustInClaimWithTrustList()
+    {
+        when(delegate.getCurrentClaim(sender)).thenReturn(claim);
+        when(claim.getAccessTrustList()).thenReturn(ImmutableList.of("Nouish"));
+        when(claim.getBuildTrustList()).thenReturn(ImmutableList.of("Jikoo"));
+        when(claim.getContainerTrustList()).thenReturn(ImmutableList.of("public"));
+        when(claim.getManagerTrustList()).thenReturn(ImmutableList.of("RoboMWM"));
+
+        List<String> options = onTabComplete(sender, command, "untrust", noArguments());
+
+        assertThat(options).containsExactlyInAnyOrder("public", "Nouish", "Jikoo", "RoboMWM");
+    }
+
+    @Test
+    void verifyNoDuplicateResultsForUntrustInClaimWithTrustListWhereUserHasDifferentPermissions()
+    {
+        when(delegate.trustListToNameList(anyCollection())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(delegate.getCurrentClaim(sender)).thenReturn(claim);
+        when(claim.getAccessTrustList()).thenReturn(ImmutableList.of("Nouish"));
+        when(claim.getBuildTrustList()).thenReturn(ImmutableList.of("Jikoo"));
+        when(claim.getContainerTrustList()).thenReturn(ImmutableList.of("Nouish"));
+        when(claim.getManagerTrustList()).thenReturn(ImmutableList.of("RoboMWM"));
+
+        List<String> options = onTabComplete(sender, command, "untrust", noArguments());
+
+        assertThat(options).containsExactlyInAnyOrder("Nouish", "Jikoo", "RoboMWM");
+    }
+
+    // Bukkit never returns a completely empty args-array.
+    private static String[] noArguments()
+    {
+        return new String[] { "" };
+    }
+
+}

--- a/src/test/java/me/ryanhamshire/GriefPrevention/TabCompleterTest.java
+++ b/src/test/java/me/ryanhamshire/GriefPrevention/TabCompleterTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import org.bukkit.command.Command;
 import org.bukkit.entity.Player;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ import static me.ryanhamshire.GriefPrevention.CommandTabCompleter.onTabComplete;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,6 +54,12 @@ class TabCompleterTest
     void beforeEach()
     {
         when(delegate.isPlayer(sender)).thenReturn(true);
+    }
+
+    @AfterEach
+    void afterEach()
+    {
+        reset(delegate);
     }
 
     @Test
@@ -122,6 +130,7 @@ class TabCompleterTest
     @Test
     void verifyResultsForUntrustInClaimWithTrustList()
     {
+        when(delegate.trustListToNameList(anyCollection())).thenAnswer(invocation -> invocation.getArgument(0));
         when(delegate.getCurrentClaim(sender)).thenReturn(claim);
         when(claim.getAccessTrustList()).thenReturn(ImmutableList.of("Nouish"));
         when(claim.getBuildTrustList()).thenReturn(ImmutableList.of("Jikoo"));

--- a/src/test/java/me/ryanhamshire/GriefPrevention/TabCompleterTest.java
+++ b/src/test/java/me/ryanhamshire/GriefPrevention/TabCompleterTest.java
@@ -18,7 +18,9 @@ import static me.ryanhamshire.GriefPrevention.CommandTabCompleter.onTabComplete;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -80,12 +82,25 @@ class TabCompleterTest
     }
 
     @Test
+    void noResultsForContainertrustInClaimWithoutManagePermission()
+    {
+        when(delegate.getCurrentClaim(sender)).thenReturn(claim);
+        when(claim.hasPermission(sender, ClaimPermission.Manage)).thenReturn(false);
+
+        List<String> options = onTabComplete(sender, command, "containertrust", noArguments());
+
+        assertThat(options).isEmpty();
+        verify(delegate, never()).listOnlineNames();
+    }
+
+    @Test
     void verifyResultsForContainertrustInClaimWithEmptyTrustList()
     {
         when(delegate.getCurrentClaim(sender)).thenReturn(claim);
         when(delegate.listOnlineNames()).thenReturn(ImmutableList.of("Nouish", "RoboMWM"));
         when(claim.getOwnerName()).thenReturn("Nouish");
         when(claim.getContainerTrustList()).thenReturn(ImmutableList.of());
+        when(claim.hasPermission(sender, ClaimPermission.Manage)).thenReturn(true);
 
         List<String> options = onTabComplete(sender, command, "containertrust", noArguments());
 
@@ -100,6 +115,7 @@ class TabCompleterTest
         when(delegate.listOnlineNames()).thenReturn(ImmutableList.of("Nouish", "RoboMWM", "Jikoo"));
         when(claim.getOwnerName()).thenReturn("RoboMWM");
         when(claim.getContainerTrustList()).thenReturn(ImmutableList.of("Nouish"));
+        when(claim.hasPermission(sender, ClaimPermission.Manage)).thenReturn(true);
 
         List<String> options = onTabComplete(sender, command, "containertrust", noArguments());
 
@@ -114,6 +130,21 @@ class TabCompleterTest
     }
 
     @Test
+    void noResultsForUntrustInClaimWithoutManagePermission()
+    {
+        when(delegate.getCurrentClaim(sender)).thenReturn(claim);
+        when(claim.hasPermission(sender, ClaimPermission.Manage)).thenReturn(false);
+
+        List<String> options = onTabComplete(sender, command, "untrust", noArguments());
+
+        assertThat(options).isEmpty();
+        verify(claim, never()).getAccessTrustList();
+        verify(claim, never()).getBuildTrustList();
+        verify(claim, never()).getContainerTrustList();
+        verify(claim, never()).getManagerTrustList();
+    }
+
+    @Test
     void verifyResultsForUntrustInClaimWithEmptyTrustList()
     {
         when(delegate.getCurrentClaim(sender)).thenReturn(claim);
@@ -121,6 +152,7 @@ class TabCompleterTest
         when(claim.getBuildTrustList()).thenReturn(ImmutableList.of());
         when(claim.getContainerTrustList()).thenReturn(ImmutableList.of());
         when(claim.getManagerTrustList()).thenReturn(ImmutableList.of());
+        when(claim.hasPermission(sender, ClaimPermission.Manage)).thenReturn(true);
 
         List<String> options = onTabComplete(sender, command, "untrust", noArguments());
 
@@ -136,6 +168,7 @@ class TabCompleterTest
         when(claim.getBuildTrustList()).thenReturn(ImmutableList.of("Jikoo"));
         when(claim.getContainerTrustList()).thenReturn(ImmutableList.of("public"));
         when(claim.getManagerTrustList()).thenReturn(ImmutableList.of("RoboMWM"));
+        when(claim.hasPermission(sender, ClaimPermission.Manage)).thenReturn(true);
 
         List<String> options = onTabComplete(sender, command, "untrust", noArguments());
 
@@ -151,6 +184,7 @@ class TabCompleterTest
         when(claim.getBuildTrustList()).thenReturn(ImmutableList.of("Jikoo"));
         when(claim.getContainerTrustList()).thenReturn(ImmutableList.of("Nouish"));
         when(claim.getManagerTrustList()).thenReturn(ImmutableList.of("RoboMWM"));
+        when(claim.hasPermission(sender, ClaimPermission.Manage)).thenReturn(true);
 
         List<String> options = onTabComplete(sender, command, "untrust", noArguments());
 

--- a/src/test/java/me/ryanhamshire/GriefPrevention/TabCompleterTest.java
+++ b/src/test/java/me/ryanhamshire/GriefPrevention/TabCompleterTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -173,6 +175,24 @@ class TabCompleterTest
 
         assertThat(options).containsExactlyInAnyOrder("Nouish", "Jikoo", "RoboMWM");
     }
+
+
+    // Verify that commands that don't take arguments don't suggest any options
+    @ParameterizedTest(name = "no options: {0}")
+    @ValueSource(strings = {
+        "abandonclaim", "abandontoplevelclaim", "abandonallclaims", "subdivideclaims", "restrictsubclaim",
+        "deleteclaim", "adminclaims", "restorenature", "restorenatureaggressive", "basicclaims", "trapped",
+        "trustlist", "ignoreclaims", "deletealladminclaims", "adminclaimslist", "unlockdrops", "claimexplosions",
+        "gpreload", "gpblockinfo", "ignoredplayerlist"
+    })
+    void verifyNoResultsForAbandonClaim(String name)
+    {
+        List<String> options = onTabComplete(name, noArguments());
+        assertThat(options).isEmpty();
+    }
+
+    // Following are helper functions for the tests
+
 
     private List<String> onTabComplete(String name, String[] args)
     {

--- a/src/test/java/me/ryanhamshire/GriefPrevention/TabCompleterTest.java
+++ b/src/test/java/me/ryanhamshire/GriefPrevention/TabCompleterTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -176,6 +177,37 @@ class TabCompleterTest
         assertThat(options).containsExactlyInAnyOrder("Nouish", "Jikoo", "RoboMWM");
     }
 
+    @Test
+    void verifyResultsForAdjustBonusClaimBlocksAll()
+    {
+        when(sender.hasPermission("griefprevention.adjustclaimblocks")).thenReturn(true);
+
+        List<String> options = onTabComplete("adjustbonusclaimblocksall", noArguments());
+
+        assertThat(options).containsExactlyInAnyOrder("10", "100", "1000", "10000");
+    }
+
+    @Test
+    void verifyResultsForAdjustBonusClaimBlocksWithNoArgs()
+    {
+        when(sender.hasPermission("griefprevention.adjustclaimblocks")).thenReturn(true);
+        when(delegate.listOnlineNames()).thenReturn(listOf("Jikoo", "BigScary"));
+
+        List<String> options = onTabComplete("adjustbonusclaimblocks", noArguments());
+
+        assertThat(options).containsExactlyInAnyOrder("Jikoo", "BigScary");
+    }
+
+    @Test
+    void verifyResultsForAdjustBonusClaimBlocksWithTarget()
+    {
+        when(sender.hasPermission("griefprevention.adjustclaimblocks")).thenReturn(true);
+
+        List<String> options = onTabComplete("adjustbonusclaimblocks", withArguments("Notch"));
+
+        assertThat(options).containsExactlyInAnyOrder("10", "100", "1000", "10000");
+    }
+
 
     // Verify that commands that don't take arguments don't suggest any options
     @ParameterizedTest(name = "no options: {0}")
@@ -205,6 +237,13 @@ class TabCompleterTest
     private static String[] noArguments()
     {
         return new String[] { "" };
+    }
+
+    private static String[] withArguments(String... args)
+    {
+        String[] arguments = Arrays.copyOf(args, args.length + 1);
+        arguments[args.length] = "";
+        return arguments;
     }
 
     private static <E> ImmutableList<E> emptyList()


### PR DESCRIPTION
Nowhere near complete.

Just want to welcome ideas and suggestions right away, and perhaps discuss this topic.

## Summary

### List of implemented commands

- [x] `/abandonclaim`
- [x] `/abandontoplevelclaim`
- [x] `/abandonallclaims`
- [ ] `/trust <player>`
- [x] `/untrust <player>`
- [x] `/containertrust <player>`
- [ ] `/accesstrust <player>`
- [ ] `/permissiontrust <player>`
- [x] `/subdivideclaims`
- [x] `/restrictsubclaim`
- [ ] `/adjustbonusclaimblocks <player> <amount>`
- [ ] `/adjustbonusclaimblocksall <amount>`
- [ ] `/setaccruedclaimblocks <player> <amount>`
- [x] `/deleteclaim`
- [ ] `/deleteallclaims <player>`
- [ ] `/deleteclaimsinworld <world>`
- [ ] `/deleteuserclaimsinworld <world>`
- [x] `/adminclaims`
- [x] `/restorenature`
- [x] `/restorenatureaggressive`
- [ ] `/restorenaturefill <radius>`
- [x] `/basicclaims`
- [ ] `/extendclaim <numberOfBlocks>`
- [ ] `/claim [<radius>]`
- [ ] `/buyclaimblocks <numberOfBlocks>`
- [ ] `/sellclaimblocks <numberOfBlocks>`
- [x] `/trapped`
- [x] `/trustlist`
- [ ] `/siege <player>`
- [x] `/ignoreclaims`
- [x] `/deletealladminclaims`
- [x] `/adminclaimslist`
- [ ] `/transferclaim <player>`
- [x] `/unlockdrops`
- [ ] `/claimslist [<player>]`
- [x] `/claimexplosions`
- [ ] `/softmute <player>`
- [ ] `/givepet <player>`
- [ ] `/ignoreplayer <player>`
- [ ] `/unignoreplayer <player>`
- [ ] `/separate <player1> <player2>`
- [ ] `/unseparate <player1> <player2>`
- [ ] `/claimbook <player>`
- [x] `/gpreload`
- [x] `/gpblockinfo`
- [x] `/ignoredplayerlist`
<sub>* not all commands take input, but I will write tests to ensure nothing is suggested for those</sub>

### Implementation features:

- [x] Don't forget about aliases
- [ ] Don't forget about groups

### API Changes

Added the following public methods to `Claim`:
```java
ImmutableList<String> getBuildTrustList()
ImmutableList<String> getContainerTrustList()
ImmutableList<String> getAccessTrustList()
ImmutableList<String> getManagerTrustList()
```

Added package-private method, that perhaps should be public, to `Claim`:
```java
boolean hasPermission(Player, ClaimPermission)
```

Made `GriefPrevention#trustEntryToPlayerName` public

### Dependencies

- Bumped version of `org.junit.jupiter:junit-jupiter` from `5.7.0` -> `5.7.2`
- Added test dependencies:
  1) `org.mockito:mockito-inline:3.11.2`
  2) `org.mockito:mockito-junit-jupiter:3.11.2`
  3) `org.assertj:assertj-core:3.20.2`