### PR TITLE
Set up GitHub actions maven workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: "Test on JDK ${{ matrix.java }}"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 8, 11, 16 ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      - name: "Set up JDK ${{ matrix.java }}"
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: adopt
+      - name: "Cache local Maven repository"
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: "Test"
+        run: mvn --batch-mode verify


### PR DESCRIPTION
I am aware of AppVeyor.

It however, does not run on forks. Until a PR targeting this repository is created, anyway. GitHub actions allows testing on forks *BEFORE* a PR is made.

_For public GitHub repositories actions is free._ There are no downsides to this that I can think of, besides "more checks", but does that matter?

This configuration will build with Java 8, 11, and 16. I know GriefPrevention doesn't use reflection, but with Minecraft 1.17 forcing users to use more recent Java versions, it may help staying on top of things.