### PR TITLE
Actions workflow: use the right default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Apologies, forgot GP uses master for default branch. Already gotten too used to the new default.

The reason I remove the `branches` entirely is because it doesn't really matter regardless in the context of this repository. If you created branches as the techfortress org, it would build those twice when PR'd without this, but from what I can see you don't, so it don't matter.

You will also have to actually enable Actions under `Settings` > `Actions` > `Allow all actions` (don't forget to save!)

By "allow all actions" it refers to actions like `actions/checkout`, not that others can change the workflow. Had me a bit confused at first. It will only run workflows in `.github/workflows` on the default branch.

Again, sorry about that!