### PR TITLE
Add an optional cancellation message to the Claim event

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/CreateClaimResult.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/CreateClaimResult.java
@@ -23,6 +23,9 @@ public class CreateClaimResult
     //whether or not the creation succeeded (it would fail if the new claim overlapped another existing claim)
     public boolean succeeded;
 
+    //an optional message specifying why (and if) the claim was cancelled
+    public String cancelMessage;
+
     //when succeeded, this is a reference to the new claim
     //when failed, this is a reference to the pre-existing, conflicting claim
     public Claim claim;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -982,6 +982,7 @@ public abstract class DataStore
         if (event.isCancelled())
         {
             result.succeeded = false;
+            result.cancelMessage = event.getCancelMessage();
             result.claim = null;
             return result;
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -2447,15 +2447,24 @@ class PlayerEventHandler implements Listener
                             //if it didn't succeed, tell the player why
                             if (!result.succeeded)
                             {
-                                GriefPrevention.sendMessage(player, TextMode.Err, Messages.CreateSubdivisionOverlap);
+                                if (result.cancelMessage != null)
+                                {
+                                    GriefPrevention.sendMessage(player, TextMode.Err, result.cancelMessage);
+                                }
+                                else
+                                {
+                                    GriefPrevention.sendMessage(player, TextMode.Err, Messages.CreateSubdivisionOverlap);
 
-                                Visualization visualization = Visualization.FromClaim(result.claim, clickedBlock.getY(), VisualizationType.ErrorClaim, player.getLocation());
+                                    if (result.claim != null)
+                                    {
+                                        Visualization visualization = Visualization.FromClaim(result.claim, clickedBlock.getY(), VisualizationType.ErrorClaim, player.getLocation());
 
-                                // alert plugins of a visualization
-                                Bukkit.getPluginManager().callEvent(new VisualizationEvent(player, visualization, result.claim));
+                                        // alert plugins of a visualization
+                                        Bukkit.getPluginManager().callEvent(new VisualizationEvent(player, visualization, result.claim));
 
-                                Visualization.Apply(player, visualization);
-
+                                        Visualization.Apply(player, visualization);
+                                    }
+                                }
                                 return;
                             }
 
@@ -2616,7 +2625,13 @@ class PlayerEventHandler implements Listener
                 //if it didn't succeed, tell the player why
                 if (!result.succeeded)
                 {
-                    if (result.claim != null)
+                    // If we have a cancel message, we should use that
+                    if(result.cancelMessage != null)
+                    {
+                        GriefPrevention.sendMessage(player, TextMode.Err, result.cancelMessage);
+                    }
+                    // Otherwise if a claim is provided, we can notify the player of an overlap
+                    else if (result.claim != null)
                     {
                         GriefPrevention.sendMessage(player, TextMode.Err, Messages.CreateClaimFailOverlapShort);
 
@@ -2627,6 +2642,7 @@ class PlayerEventHandler implements Listener
 
                         Visualization.Apply(player, visualization);
                     }
+                    // Else send the generic message
                     else
                     {
                         GriefPrevention.sendMessage(player, TextMode.Err, Messages.CreateClaimFailOverlapRegion);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -2447,14 +2447,17 @@ class PlayerEventHandler implements Listener
                             //if it didn't succeed, tell the player why
                             if (!result.succeeded)
                             {
+                                // If we have a cancel message, we should use that
                                 if (result.cancelMessage != null)
                                 {
                                     GriefPrevention.sendMessage(player, TextMode.Err, result.cancelMessage);
                                 }
                                 else
                                 {
+                                    // Assume there is a subdivision overlap
                                     GriefPrevention.sendMessage(player, TextMode.Err, Messages.CreateSubdivisionOverlap);
 
+                                    // If a claim is provided, we can visualize it
                                     if (result.claim != null)
                                     {
                                         Visualization visualization = Visualization.FromClaim(result.claim, clickedBlock.getY(), VisualizationType.ErrorClaim, player.getLocation());

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimCreatedEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimCreatedEvent.java
@@ -1,6 +1,7 @@
 package me.ryanhamshire.GriefPrevention.events;
 
 import me.ryanhamshire.GriefPrevention.Claim;
+import me.ryanhamshire.GriefPrevention.Messages;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -29,6 +30,8 @@ public class ClaimCreatedEvent extends Event implements Cancellable
 
     private boolean cancelled = false;
 
+    private String cancelMessage = null;
+
     public ClaimCreatedEvent(Claim claim, CommandSender creator)
     {
         this.claim = claim;
@@ -51,6 +54,24 @@ public class ClaimCreatedEvent extends Event implements Cancellable
     public void setCancelled(boolean b)
     {
         this.cancelled = b;
+    }
+
+    /**
+     * Get a message for cancellation optionally provided by an event handler
+     *
+     * @return String
+     */
+    public String getCancelMessage()
+    {
+        return cancelMessage;
+    }
+
+    /**
+     * @param cancelMessage A message optionally specified when cancelling this event
+     */
+    public void setCancelMessage(String cancelMessage)
+    {
+        this.cancelMessage = cancelMessage;
     }
 
     /**

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimCreatedEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimCreatedEvent.java
@@ -1,7 +1,6 @@
 package me.ryanhamshire.GriefPrevention.events;
 
 import me.ryanhamshire.GriefPrevention.Claim;
-import me.ryanhamshire.GriefPrevention.Messages;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;


### PR DESCRIPTION
When other plugins cancel the claim event, the message handling logic falls apart. This PR allows them to optionally specify their own message to replace the built-in logic. It also fixes a NullPointerException when a subdivision is cancelled externally.