### PR TITLE
Fix NPE when using `allowBuild` in a claim that the player has permission to build

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -354,7 +354,8 @@ public class Claim
     //build permission check
     public String allowBuild(Player player, Material material)
     {
-        return checkPermission(player, ClaimPermission.Build, new CompatBuildBreakEvent(material, false)).get();
+        Supplier<String> supplier = checkPermission(player, ClaimPermission.Build, new CompatBuildBreakEvent(material, false));
+        return supplier != null ? supplier.get() : null;
     }
 
     public static class CompatBuildBreakEvent extends Event


### PR DESCRIPTION
For some reason, while `allowBreak` has this check, `allowBuild` doesn't. So I copied the code from the `allowBreak` call to the `allowBuild` to fix the exception.