### PR TITLE
Fix max depth below world height

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
@@ -9,6 +9,7 @@ import org.bukkit.block.Biome;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 //automatically extends a claim downward based on block types detected
@@ -80,7 +81,8 @@ class AutoExtendClaimTask implements Runnable
 
     private boolean yTooSmall(int y)
     {
-        return y == 0 || y <= GriefPrevention.instance.config_claims_maxDepth;
+        return y <= Objects.requireNonNull(claim.getLesserBoundaryCorner().getWorld()).getMinHeight()
+                || y <= GriefPrevention.instance.config_claims_maxDepth;
     }
 
     //runs in the main execution thread, where it can safely change claims and save those changes

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -55,6 +55,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -868,8 +869,9 @@ public abstract class DataStore
 
         int smallx, bigx, smally, bigy, smallz, bigz;
 
-        if (y1 < GriefPrevention.instance.config_claims_maxDepth) y1 = GriefPrevention.instance.config_claims_maxDepth;
-        if (y2 < GriefPrevention.instance.config_claims_maxDepth) y2 = GriefPrevention.instance.config_claims_maxDepth;
+        int worldMinY = world.getMinHeight();
+        y1 = Math.max(worldMinY, Math.max(GriefPrevention.instance.config_claims_maxDepth, y1));
+        y2 = Math.max(worldMinY, Math.max(GriefPrevention.instance.config_claims_maxDepth, y2));
 
         //determine small versus big inputs
         if (x1 < x2)
@@ -1057,8 +1059,11 @@ public abstract class DataStore
     //respects the max depth config variable
     synchronized public void extendClaim(Claim claim, int newDepth)
     {
-        if (newDepth < GriefPrevention.instance.config_claims_maxDepth)
-            newDepth = GriefPrevention.instance.config_claims_maxDepth;
+        newDepth = Math.max(
+                Objects.requireNonNull(claim.getLesserBoundaryCorner().getWorld()).getMinHeight(),
+                Math.max(
+                        newDepth,
+                        GriefPrevention.instance.config_claims_maxDepth));
 
         if (claim.parent != null) claim = claim.parent;
 


### PR DESCRIPTION
Normalizes claim max depth to world min height. Theoretically the only thing that needed adjusting was `AutoExtendClaimTask#yTooSmall(int)`, but it's probably safer to also clamp all claims during creation/extension to make life easier for addons.

Closes #1501 