### PR TITLE
Added option to toggle IgnoreClaims on join

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -195,6 +195,7 @@ public class GriefPrevention extends JavaPlugin
     public ArrayList<String> config_eavesdrop_whisperCommands;        //list of whisper commands to eavesdrop on
 
     public boolean config_smartBan;                                    //whether to ban accounts which very likely owned by a banned player
+    public boolean config_toggleIgnoreClaimsOnJoin;                    //whether to toggle IgnoreClaims by default when permission is satisfied.
 
     public boolean config_endermenMoveBlocks;                        //whether or not endermen may move blocks around
     public boolean config_claims_ravagersBreakBlocks;                //whether or not ravagers may break blocks in claims
@@ -618,6 +619,7 @@ public class GriefPrevention extends JavaPlugin
         whisperCommandsToMonitor = config.getString("GriefPrevention.Spam.WhisperSlashCommands", whisperCommandsToMonitor);
 
         this.config_smartBan = config.getBoolean("GriefPrevention.SmartBan", true);
+        this.config_toggleIgnoreClaimsOnJoin = config.getBoolean("GriefPrevention.ToggleIgnoreClaimsOnJoin", false);
         this.config_trollFilterEnabled = config.getBoolean("GriefPrevention.Mute New Players Using Banned Words", true);
         this.config_ipLimit = config.getInt("GriefPrevention.MaxPlayersPerIpAddress", 3);
         this.config_silenceBans = config.getBoolean("GriefPrevention.SilenceBans", true);
@@ -871,6 +873,8 @@ public class GriefPrevention extends JavaPlugin
         outConfig.set("GriefPrevention.AdminsGetSignNotifications", this.config_signNotifications);
 
         outConfig.set("GriefPrevention.SmartBan", this.config_smartBan);
+        outConfig.set("GriefPrevention.ToggleIgnoreClaimsOnJoin", this.config_toggleIgnoreClaimsOnJoin);
+
         outConfig.set("GriefPrevention.Mute New Players Using Banned Words", this.config_trollFilterEnabled);
         outConfig.set("GriefPrevention.MaxPlayersPerIpAddress", this.config_ipLimit);
         outConfig.set("GriefPrevention.SilenceBans", this.config_silenceBans);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -706,6 +706,11 @@ class PlayerEventHandler implements Listener
             }
         }
 
+        if (player.hasPermission("griefprevention.ignoreclaims"))
+        {
+            playerData.ignoreClaims = instance.config_toggleIgnoreClaimsOnJoin;
+        }
+
         //silence notifications when they're coming too fast
         if (event.getJoinMessage() != null && this.shouldSilenceNotification())
         {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -706,9 +706,9 @@ class PlayerEventHandler implements Listener
             }
         }
 
-        if (player.hasPermission("griefprevention.ignoreclaims"))
+        if (instance.config_toggleIgnoreClaimsOnJoin && player.hasPermission("griefprevention.ignoreclaims"))
         {
-            playerData.ignoreClaims = instance.config_toggleIgnoreClaimsOnJoin;
+            playerData.ignoreClaims = true;
         }
 
         //silence notifications when they're coming too fast

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -705,7 +705,8 @@ class PlayerEventHandler implements Listener
                 Bukkit.getScheduler().scheduleSyncDelayedTask(instance, task, instance.config_claims_manualDeliveryDelaySeconds * 20L);
             }
         }
-
+        
+        //FEATURE: option to enable ignoreclaims by default when the player has permission.
         if (instance.config_toggleIgnoreClaimsOnJoin && player.hasPermission("griefprevention.ignoreclaims"))
         {
             playerData.ignoreClaims = true;


### PR DESCRIPTION
**NOTE: For this to work the player must also have the permission to toggle ignoreclaims**
**Disabled by default to maintain existing functionality.**
I added this because Typing /ignoreclaims is starting to get annoying for staff.