### PR TITLE
Update Java and fix AppVeyor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 16 ]
+        java: [ 16, 17 ]
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,25 +3,19 @@ skip_tags: true
 clone_depth: 10
 environment:
   matrix:
-    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+    - appveyor_build_worker_image: Visual Studio 2022
+      JAVA_HOME: C:\Program Files\Java\jdk17
 branches:
   only:
     - master
     - dev/v20
   except:
     - gh-pages
-os: Windows Server 2012
+init:
+  - cmd: SET PATH=%JAVA_HOME%\bin;%PATH%
 install:
-  - ps: |
-      Add-Type -AssemblyName System.IO.Compression.FileSystem
-      if (!(Test-Path -Path "C:\maven" )) {
-        (new-object System.Net.WebClient).DownloadFile('http://www.us.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip', 'C:\maven-bin.zip')
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
-      }
-  - cmd: SET PATH=C:\maven\apache-maven-3.2.5\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%
-  - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=2g -Xmx4g
-  - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
-  - cmd: SET M2_HOME=C:\maven\apache-maven-3.2.5
+  - cmd: SET MAVEN_OPTS=-Xmx4g
+  - cmd: SET JAVA_OPTS=-Xmx4g
   - cmd: mvn --version
   - cmd: java -version
 build_script:
@@ -29,7 +23,6 @@ build_script:
 test_script:
   - mvn clean install --batch-mode -Pqulice
 cache:
-  - C:\maven\
   - C:\Users\appveyor\.m2
 artifacts:
 - path: target/GriefPrevention.jar

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+  - sdk install java 17.0.1-open
+  - sdk use java 17.0.1-open

--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>16</source>
+                    <target>16</target>
                 </configuration>
             </plugin>
             <!-- Append git commit hash to version -->


### PR DESCRIPTION
* Target Java 16 for compilation
  * GP requires MC 1.17 to run and MC 1.17 requires Java 16, ergo GP requires Java 16.
  * This may be a bad change in that I'm not sure if the plugin.yml is read before or after the classloader checks class versions, this may make startup errors for GP on old servers with old Java less explicit.
* Run AppVeyor CI using Java 17
  * Requires new VS 2022 image: https://www.appveyor.com/updates/2021/11/09/
  * Certain dependencies cannot be upgraded to current versions (see #1630) because they are compiled with later Java versions. It's possible to target lower Java versions for compilation, but the Maven runner must be using a Java version equal to or greater than that of the dependency. Better to be ahead of the curve, particularly since 1.18 will require Java 17.
  * JDK 16 had several annotation-related compiler issues, preferable to just avoid
* Use provided AppVeyor Maven installation instead of manually installing
  * AppVeyor [bundles and sets up Maven](https://github.com/appveyor/build-images/blob/23e2721bc45845b24dd7724ec934aca0570dc670/scripts/Windows/install_maven.ps1).
  * The mirror link used in manual setup is no longer valid and the AppVeyor cache has been cleared. This causes all AppVeyor builds to fail.
* Remove Java 7-specific memory settings