### PR TITLE
Candles require full trust, remove duplicate candle cake handling

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1751,8 +1751,7 @@ class PlayerEventHandler implements Listener
                                 clickedBlockType == Material.RESPAWN_ANCHOR ||
                                 clickedBlockType == Material.ROOTED_DIRT ||
                                 clickedBlockType == Material.STONECUTTER ||
-                                clickedBlockType == Material.SWEET_BERRY_BUSH ||
-                                Tag.CANDLES.isTagged(clickedBlockType)
+                                clickedBlockType == Material.SWEET_BERRY_BUSH
                         )))
         {
             if (playerData == null) playerData = this.dataStore.getPlayerData(player.getUniqueId());
@@ -1864,7 +1863,7 @@ class PlayerEventHandler implements Listener
             }
         }
 
-        //apply rule for note blocks and repeaters and daylight sensors //RoboMWM: Include flower pots
+        //apply rule for redstone and various decor blocks that require full trust
         else if (clickedBlock != null &&
                 (
                         clickedBlockType == Material.NOTE_BLOCK ||
@@ -1873,7 +1872,8 @@ class PlayerEventHandler implements Listener
                                 clickedBlockType == Material.DAYLIGHT_DETECTOR ||
                                 clickedBlockType == Material.COMPARATOR ||
                                 clickedBlockType == Material.REDSTONE_WIRE ||
-                                Tag.FLOWER_POTS.isTagged(clickedBlockType)
+                                Tag.FLOWER_POTS.isTagged(clickedBlockType) ||
+                                Tag.CANDLES.isTagged(clickedBlockType)
                 ))
         {
             if (playerData == null) playerData = this.dataStore.getPlayerData(player.getUniqueId());

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1752,8 +1752,7 @@ class PlayerEventHandler implements Listener
                                 clickedBlockType == Material.ROOTED_DIRT ||
                                 clickedBlockType == Material.STONECUTTER ||
                                 clickedBlockType == Material.SWEET_BERRY_BUSH ||
-                                Tag.CANDLES.isTagged(clickedBlockType) ||
-                                Tag.CANDLE_CAKES.isTagged(clickedBlockType)
+                                Tag.CANDLES.isTagged(clickedBlockType)
                         )))
         {
             if (playerData == null) playerData = this.dataStore.getPlayerData(player.getUniqueId());


### PR DESCRIPTION
Candle cakes [were already handled](https://github.com/TechFortress/GriefPrevention/blob/9c196a3a5a676330b2ad9dc4f2d7bbc72a2c0f9a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java#L1850) and were erroneously added to containertrust. It made sense to match candles requiring container trust, but it's more accurate to match the underlying cake. Honestly, candles are used for decor, making them only require containertrust to modify makes them unusable in shop areas. Why did we make candles a container level thing at all? IMO they should be full trust just like armor stands.

Addresses https://github.com/TechFortress/GriefPrevention/issues/1560#issuecomment-912622769
