### PR TITLE
Improve claim creation over existing builds

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
@@ -38,13 +38,13 @@ class AutoExtendClaimTask implements Runnable
 
         int lowestLootableTile = lesserCorner.getBlockY();
         ArrayList<ChunkSnapshot> snapshots = new ArrayList<>();
-        for (int chunkx = lesserCorner.getBlockX() / 16; chunkx <= greaterCorner.getBlockX() / 16; chunkx++)
+        for (int chunkX = lesserCorner.getBlockX() / 16; chunkX <= greaterCorner.getBlockX() / 16; chunkX++)
         {
-            for (int chunkz = lesserCorner.getBlockZ() / 16; chunkz <= greaterCorner.getBlockZ() / 16; chunkz++)
+            for (int chunkZ = lesserCorner.getBlockZ() / 16; chunkZ <= greaterCorner.getBlockZ() / 16; chunkZ++)
             {
-                if (world.isChunkLoaded(chunkx, chunkz))
+                if (world.isChunkLoaded(chunkX, chunkZ))
                 {
-                    Chunk chunk = world.getChunkAt(chunkx, chunkz);
+                    Chunk chunk = world.getChunkAt(chunkX, chunkZ);
 
                     // If we're on the main thread, access to tile entities will speed up the process.
                     if (Bukkit.isPrimaryThread())

--- a/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
@@ -5,6 +5,7 @@ import org.bukkit.ChunkSnapshot;
 import org.bukkit.Material;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Biome;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -18,13 +19,23 @@ class AutoExtendClaimTask implements Runnable
     private final Claim claim;
     private final ArrayList<ChunkSnapshot> chunks;
     private final Environment worldType;
-    private final Map<Biome, Set<Material>> biomeMaterials = new HashMap<>();
+    private final Map<Biome, Set<Material>> biomePlayerMaterials = new HashMap<>();
+    private final int minY;
+    private final int lowestExistingY;
 
-    public AutoExtendClaimTask(Claim claim, ArrayList<ChunkSnapshot> chunks, Environment worldType)
+    public AutoExtendClaimTask(
+            @NotNull Claim claim,
+            @NotNull ArrayList<@NotNull ChunkSnapshot> chunks,
+            @NotNull Environment worldType,
+            int lowestExistingY)
     {
         this.claim = claim;
         this.chunks = chunks;
         this.worldType = worldType;
+        this.lowestExistingY = Math.min(lowestExistingY, claim.getLesserBoundaryCorner().getBlockY());
+        this.minY = Math.max(
+                Objects.requireNonNull(claim.getLesserBoundaryCorner().getWorld()).getMinHeight(),
+                GriefPrevention.instance.config_claims_maxDepth);
     }
 
     @Override
@@ -39,64 +50,80 @@ class AutoExtendClaimTask implements Runnable
 
     private int getLowestBuiltY()
     {
-        int y = this.claim.getLesserBoundaryCorner().getBlockY();
+        int y = this.lowestExistingY;
 
-        if (this.yTooSmall(y)) return y;
+        if (yTooSmall(y)) return this.minY;
 
         for (ChunkSnapshot chunk : this.chunks)
         {
-            boolean ychanged = true;
-            while (!this.yTooSmall(y) && ychanged)
-            {
-                ychanged = false;
-                for (int x = 0; x < 16; x++)
-                {
-                    for (int z = 0; z < 16; z++)
-                    {
-                        Material blockType = chunk.getBlockType(x, y, z);
-                        Biome biome = chunk.getBiome(x, y, z);
-                        while (!this.yTooSmall(y) && this.getBiomeBlocks(biome).contains(blockType))
-                        {
-                            ychanged = true;
-                            blockType = chunk.getBlockType(x, --y, z);
-                            biome = chunk.getBiome(x, y, z);
-                        }
+            y = findLowerBuiltY(chunk, y);
 
-                        if (this.yTooSmall(y)) return y;
-                    }
-                }
-            }
-
-            if (this.yTooSmall(y)) return y;
+            // If already at minimum Y, stop searching.
+            if (yTooSmall(y)) return this.minY;
         }
-
 
         return y;
     }
 
-    private Set<Material> getBiomeBlocks(Biome biome)
+    private int findLowerBuiltY(ChunkSnapshot chunkSnapshot, int y)
     {
-        return biomeMaterials.computeIfAbsent(biome, newBiome -> RestoreNatureProcessingTask.getPlayerBlocks(this.worldType, newBiome));
+        // Specifically not using yTooSmall here to allow protecting bottom layer.
+        nextY: for (int newY = y - 1; newY >= this.minY; newY--)
+        {
+            for (int x = 0; x < 16; x++)
+            {
+                for (int z = 0; z < 16; z++)
+                {
+                    // If the block is natural, ignore it and continue searching the same Y level.
+                    if (!isPlayerBlock(chunkSnapshot, x, newY, z)) continue;
+
+                    // If the block is player-placed and we're at the minimum Y allowed, we're done searching.
+                    if (yTooSmall(y)) return this.minY;
+
+                    // Because we found a player block, repeatedly check the next block in the column.
+                    while (isPlayerBlock(chunkSnapshot, x, newY--, z))
+                    {
+                        // If we've hit minimum Y we're done searching.
+                        if (yTooSmall(y)) return this.minY;
+                    }
+
+                    // Undo increment for unsuccessful player block check.
+                    newY++;
+
+                    // Move built level down to current level.
+                    y = newY;
+
+                    // Because the level is now protected, continue downwards.
+                    continue nextY;
+                }
+            }
+        }
+
+        // Return provided value or last located player block level.
+        return y;
     }
 
     private boolean yTooSmall(int y)
     {
-        return y <= Objects.requireNonNull(claim.getLesserBoundaryCorner().getWorld()).getMinHeight()
-                || y <= GriefPrevention.instance.config_claims_maxDepth;
+        return y <= this.minY;
+    }
+
+    private boolean isPlayerBlock(ChunkSnapshot chunkSnapshot, int x, int y, int z)
+    {
+        Material blockType = chunkSnapshot.getBlockType(x, y, z);
+        Biome biome = chunkSnapshot.getBiome(x, y, z);
+
+        return this.getBiomePlayerBlocks(biome).contains(blockType);
+    }
+
+    private Set<Material> getBiomePlayerBlocks(Biome biome)
+    {
+        return biomePlayerMaterials.computeIfAbsent(biome, newBiome -> RestoreNatureProcessingTask.getPlayerBlocks(this.worldType, newBiome));
     }
 
     //runs in the main execution thread, where it can safely change claims and save those changes
-    private class ExecuteExtendClaimTask implements Runnable
+    private record ExecuteExtendClaimTask(Claim claim, int newY) implements Runnable
     {
-        private final Claim claim;
-        private final int newY;
-
-        public ExecuteExtendClaimTask(Claim claim, int newY)
-        {
-            this.claim = claim;
-            this.newY = newY;
-        }
-
         @Override
         public void run()
         {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
@@ -51,14 +51,14 @@ class AutoExtendClaimTask implements Runnable
                     {
                         // Find the lowest non-natural storage block in the chunk.
                         // This way chests, barrels, etc. are always protected even if player block definitions are lacking.
-                        lowestLootableTile = Arrays.stream(chunk.getTileEntities())
+                        lowestLootableTile = Math.min(lowestLootableTile, Arrays.stream(chunk.getTileEntities())
                                 // Accept only Lootable tiles that do not have loot tables.
                                 // Naturally generated Lootables only have a loot table reference until the container is
                                 // accessed. On access the loot table is used to calculate the contents and removed.
                                 // This prevents claims from always extending over unexplored structures, spawners, etc.
                                 .filter(tile -> tile instanceof Lootable lootable && lootable.getLootTable() == null)
                                 // Return smallest value or default to existing min Y if no eligible tiles are present.
-                                .mapToInt(BlockState::getY).min().orElse(lowestLootableTile);
+                                .mapToInt(BlockState::getY).min().orElse(lowestLootableTile));
                     }
 
                     // Save a snapshot of the chunk for more detailed async block searching.

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -2599,7 +2599,7 @@ class PlayerEventHandler implements Listener
                         GriefPrevention.sendMessage(player, TextMode.Instr, Messages.SubdivisionVideo2, 201L, DataStore.SUBDIVISION_VIDEO_URL);
                     }
 
-                    instance.autoExtendClaim(result.claim);
+                    AutoExtendClaimTask.scheduleAsync(result.claim);
                 }
             }
         }


### PR DESCRIPTION
* Always include storage blocks in loaded chunks
  * This will ensure that chests etc. are always protected even if biome block definitions are problematic.
* Fix edge case where chunk is only partially searched
* Extract logic out of main class
  * Method was not public, this should not be breaking.

Closes #1832