### PR TITLE
Fix potential NPE visualizing conflict zones

### DIFF
--- a/src/main/java/com/griefprevention/events/BoundaryVisualizationEvent.java
+++ b/src/main/java/com/griefprevention/events/BoundaryVisualizationEvent.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 public class BoundaryVisualizationEvent extends PlayerEvent
 {
 
-    private static final VisualizationProvider DEFAULT_PROVIDER = (world, visualizeFrom, height) ->
+    public static final VisualizationProvider DEFAULT_PROVIDER = (world, visualizeFrom, height) ->
     {
         if (GriefPrevention.instance.config_visualizationAntiCheatCompat)
         {

--- a/src/main/java/com/griefprevention/util/IntVector.java
+++ b/src/main/java/com/griefprevention/util/IntVector.java
@@ -46,7 +46,7 @@ public record IntVector(int x, int y, int z)
     }
 
     /**
-     * Get ae {@link Block} representing the {@code IntVector} in the specified {@link World}.
+     * Get a {@link Block} representing the {@code IntVector} in the specified {@link World}.
      *
      * @param world the {@code World}
      * @return the corresponding {@code Block}

--- a/src/main/java/com/griefprevention/visualization/BoundaryVisualization.java
+++ b/src/main/java/com/griefprevention/visualization/BoundaryVisualization.java
@@ -1,6 +1,7 @@
 package com.griefprevention.visualization;
 
 import me.ryanhamshire.GriefPrevention.Claim;
+import me.ryanhamshire.GriefPrevention.CustomLogEntryTypes;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
 import me.ryanhamshire.GriefPrevention.PlayerData;
 import com.griefprevention.events.BoundaryVisualizationEvent;
@@ -18,6 +19,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -266,9 +268,55 @@ public abstract class BoundaryVisualization
         {
             GriefPrevention.instance.getServer().getScheduler().scheduleSyncDelayedTask(
                     GriefPrevention.instance,
-                    () -> visualization.apply(player, playerData),
+                    new DelayedVisualizationTask(visualization, playerData, event),
                     1L);
         }
+    }
+
+    private record DelayedVisualizationTask(
+            @NotNull BoundaryVisualization visualization,
+            @NotNull PlayerData playerData,
+            @NotNull BoundaryVisualizationEvent event)
+            implements Runnable
+    {
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                visualization.apply(event.getPlayer(), playerData);
+            }
+            catch (Exception exception)
+            {
+                if (event.getProvider() == BoundaryVisualizationEvent.DEFAULT_PROVIDER)
+                {
+                    // If the provider is our own, log normally.
+                    GriefPrevention.instance.getLogger().log(Level.WARNING, "Exception visualizing claim", exception);
+                    return;
+                }
+
+                // Otherwise, add an extra hint that the problem is not with GP.
+                GriefPrevention.AddLogEntry(
+                        String.format(
+                                "External visualization provider %s caused %s: %s",
+                                event.getProvider().getClass().getName(),
+                                exception.getClass().getName(),
+                                exception.getCause()),
+                        CustomLogEntryTypes.Exception);
+                GriefPrevention.instance.getLogger().log(
+                        Level.WARNING,
+                        "Exception visualizing claim using external provider",
+                        exception);
+
+                // Fall through to default provider.
+                BoundaryVisualization fallback = BoundaryVisualizationEvent.DEFAULT_PROVIDER
+                        .create(event.getPlayer().getWorld(), event.getCenter(), event.getHeight());
+                event.getBoundaries().stream().filter(Objects::nonNull).forEach(fallback.elements::add);
+                fallback.apply(event.getPlayer(), playerData);
+            }
+        }
+
     }
 
 }

--- a/src/main/java/com/griefprevention/visualization/BoundaryVisualization.java
+++ b/src/main/java/com/griefprevention/visualization/BoundaryVisualization.java
@@ -206,6 +206,8 @@ public abstract class BoundaryVisualization
      */
     private static Collection<Boundary> defineBoundaries(Claim claim, VisualizationType type)
     {
+        if (claim == null) return Set.of();
+
         // For single claims, always visualize parent and children.
         if (claim.parent != null) claim = claim.parent;
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/CreateClaimResult.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/CreateClaimResult.java
@@ -18,6 +18,8 @@
 
 package me.ryanhamshire.GriefPrevention;
 
+import org.jetbrains.annotations.Nullable;
+
 public class CreateClaimResult
 {
     //whether or not the creation succeeded (it would fail if the new claim overlapped another existing claim)
@@ -25,5 +27,5 @@ public class CreateClaimResult
 
     //when succeeded, this is a reference to the new claim
     //when failed, this is a reference to the pre-existing, conflicting claim
-    public Claim claim;
+    public @Nullable Claim claim;
 }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1474,7 +1474,7 @@ public abstract class DataStore
                 newClaim.getGreaterBoundaryCorner().getBlockZ(),
                 player);
 
-        if (result.succeeded)
+        if (result.succeeded && result.claim != null)
         {
             //decide how many claim blocks are available for more resizing
             int claimBlocksRemaining = 0;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1079,7 +1079,7 @@ public class GriefPrevention extends JavaPlugin
                     gc.getWorld().getHighestBlockYAt(gc) - GriefPrevention.instance.config_claims_claimsExtendIntoGroundDistance - 1,
                     lc.getBlockZ(), gc.getBlockZ(),
                     player.getUniqueId(), null, null, player);
-            if (!result.succeeded)
+            if (!result.succeeded || result.claim == null)
             {
                 if (result.claim != null)
                 {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -2428,10 +2428,17 @@ class PlayerEventHandler implements Listener
                                     null, player);
 
                             //if it didn't succeed, tell the player why
-                            if (!result.succeeded)
+                            if (!result.succeeded || result.claim == null)
                             {
-                                GriefPrevention.sendMessage(player, TextMode.Err, Messages.CreateSubdivisionOverlap);
-                                BoundaryVisualization.visualizeClaim(player, result.claim, VisualizationType.CONFLICT_ZONE, clickedBlock);
+                                if (result.claim != null)
+                                {
+                                    GriefPrevention.sendMessage(player, TextMode.Err, Messages.CreateSubdivisionOverlap);
+                                    BoundaryVisualization.visualizeClaim(player, result.claim, VisualizationType.CONFLICT_ZONE, clickedBlock);
+                                }
+                                else
+                                {
+                                    GriefPrevention.sendMessage(player, TextMode.Err, Messages.CreateClaimFailOverlapRegion);
+                                }
 
                                 return;
                             }
@@ -2570,7 +2577,7 @@ class PlayerEventHandler implements Listener
                         player);
 
                 //if it didn't succeed, tell the player why
-                if (!result.succeeded)
+                if (!result.succeeded || result.claim == null)
                 {
                     if (result.claim != null)
                     {


### PR DESCRIPTION
* Fix potential NPE visualizing conflict zones
  * Handle edge cases more gracefully, no result is always a failure.
* Add error handling for external visualization providers
  * Falls through to GP's default provider so visualization is still done even if external provider is broken

Closes #1853 