### PR TITLE
Prevent theft from water/lava cauldrons.

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1740,6 +1740,8 @@ class PlayerEventHandler implements Listener
                                 clickedBlockType == Material.CAKE ||
                                 clickedBlockType == Material.CARTOGRAPHY_TABLE ||
                                 clickedBlockType == Material.CAULDRON ||
+                                clickedBlockType == Material.WATER_CAULDRON ||
+                                clickedBlockType == Material.LAVA_CAULDRON ||
                                 clickedBlockType == Material.CAVE_VINES ||
                                 clickedBlockType == Material.CAVE_VINES_PLANT ||
                                 clickedBlockType == Material.CHIPPED_ANVIL ||


### PR DESCRIPTION
I noticed that players are able to take water & lava from claimed cauldrons, but they aren't able to fill them back up. This should prevent players from stealing from claimed cauldrons in the first place. It also prevents untrusted players from washing banners, armor, and shulker boxes (which all reduce water cauldrons 1 level until they're empty). 