### PR TITLE
Remove TheUnderground from loadbefore

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,6 @@ name: GriefPrevention
 main: me.ryanhamshire.GriefPrevention.GriefPrevention
 softdepend: [Vault, Multiverse-Core, My_Worlds, MystCraft, Transporter, TheUnderground, WorldGuard, WorldEdit, RoyalCommands, MultiWorld, Denizen]
 dev-url: https://dev.bukkit.org/projects/grief-prevention
-loadbefore: [TheUnderground]
 version: '${git.commit.id.describe}'
 api-version: '1.17'
 commands:


### PR DESCRIPTION
```yml
softdepend: [Vault, Multiverse-Core, My_Worlds, MystCraft, Transporter, TheUnderground, WorldGuard, WorldEdit, RoyalCommands, MultiWorld, Denizen]
dev-url: https://dev.bukkit.org/projects/grief-prevention
loadbefore: [TheUnderground]
```

The underground is both in softdepend/loadbefore, and this may cause unexpected behavior in plugin loading.
Soft Depends: Your plugin will load after any plugins listed here.
Load Before: Your plugin will load before any plugins listed here.

According to the commit that this was added, https://github.com/TechFortress/GriefPrevention/commit/935fc53bed1200c9b66c51d2f17719190cf18e21
" This mod adds a new world - need to load after this guy to detect the
world(s) it generates. "


This removes it from ``loadbefore``, as it doesn't make sense that the plugin should be loaded before AND after this dependency. And because the commit indicates that TheUnderground needs to be loaded before GriefPrevention is loaded, it should stay as a soft dependency.

(It doesn't look like the underground is public anymore btw, https://www.spigotmc.org/resources/the-underground-1-7-10-1-8-8.715/)

This behavior may not be supported in future versions of paper.