### PR TITLE
Use a specific permission for /abandonallclaims

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -17,7 +17,7 @@ commands:
     abandonallclaims:
       description: Deletes ALL your claims.
       usage: /AbandonAllClaims
-      permission: griefprevention.claims
+      permission: griefprevention.abandonallclaims
     trust:
       description: Grants a player full access to your claim(s).
       usage: /Trust <player>  Grants a player permission to build.  See also /UnTrust, /ContainerTrust, /AccessTrust, and /PermissionTrust.
@@ -320,6 +320,9 @@ permissions:
         default: op
     griefprevention.claims:
         description: Grants access to claim-related slash commands.
+        default: true
+    griefprevention.abandonallclaims:
+        description: Grants access to /AbandonAllClaims.
         default: true
     griefprevention.buysellclaimblocks:
         description: Grants access to claim block buy/sell commands.


### PR DESCRIPTION
Proposed in #1915 

/abandonallclaims is a dangerous command, it doesn't make sense to use the common griefprevention.claims permission for it.