### PR TITLE
Don't re-render duplicate boundary visualizations

### DIFF
--- a/src/main/java/com/griefprevention/events/BoundaryVisualizationEvent.java
+++ b/src/main/java/com/griefprevention/events/BoundaryVisualizationEvent.java
@@ -12,8 +12,8 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.PlayerEvent;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 
 /**
  * An {@link org.bukkit.event.Event Event} called when a {@link Player} receives {@link Boundary} visuals.
@@ -66,7 +66,7 @@ public class BoundaryVisualizationEvent extends PlayerEvent
             @NotNull VisualizationProvider provider
     ) {
         super(player);
-        this.boundaries = new ArrayList<>(boundaries);
+        this.boundaries = new HashSet<>(boundaries);
         this.height = height;
         this.provider = provider;
     }

--- a/src/main/java/com/griefprevention/visualization/BoundaryVisualization.java
+++ b/src/main/java/com/griefprevention/visualization/BoundaryVisualization.java
@@ -25,7 +25,6 @@ import java.util.stream.Stream;
 
 /**
  * A representation of a system for displaying rectangular {@link Boundary Boundaries} to {@link Player Players}.
- *
  * This is used to display claim areas, visualize affected area during nature restoration, and more.
  */
 public abstract class BoundaryVisualization
@@ -257,15 +256,18 @@ public abstract class BoundaryVisualization
         Player player = event.getPlayer();
         PlayerData playerData = GriefPrevention.instance.dataStore.getPlayerData(player.getUniqueId());
         BoundaryVisualization currentVisualization = playerData.getVisibleBoundaries();
-        
-        if (currentVisualization != null && currentVisualization.elements.equals(event.getBoundaries()))
+
+        Collection<Boundary> boundaries = event.getBoundaries();
+        boundaries.removeIf(Objects::isNull);
+
+        if (currentVisualization != null && currentVisualization.elements.equals(boundaries))
         {
             // Ignore visualization with duplicate boundaries.
             return;
         }
-        
+
         BoundaryVisualization visualization = event.getProvider().create(player.getWorld(), event.getCenter(), event.getHeight());
-        event.getBoundaries().stream().filter(Objects::nonNull).forEach(visualization.elements::add);
+        visualization.elements.addAll(boundaries);
 
         // If they have a visualization active, clear it first.
         playerData.setVisibleBoundaries(null);

--- a/src/main/java/com/griefprevention/visualization/BoundaryVisualization.java
+++ b/src/main/java/com/griefprevention/visualization/BoundaryVisualization.java
@@ -255,10 +255,16 @@ public abstract class BoundaryVisualization
         Bukkit.getPluginManager().callEvent(event);
 
         Player player = event.getPlayer();
+        PlayerData playerData = GriefPrevention.instance.dataStore.getPlayerData(player.getUniqueId());
+        BoundaryVisualization currentVisualization = playerData.getVisibleBoundaries();
+        
+        if (currentVisualization != null && currentVisualization.elements.equals(event.getBoundaries())) {
+            // Ignore visualization with duplicate boundaries.
+            return;
+        }
+        
         BoundaryVisualization visualization = event.getProvider().create(player.getWorld(), event.getCenter(), event.getHeight());
         event.getBoundaries().stream().filter(Objects::nonNull).forEach(visualization.elements::add);
-
-        PlayerData playerData = GriefPrevention.instance.dataStore.getPlayerData(player.getUniqueId());
 
         // If they have a visualization active, clear it first.
         playerData.setVisibleBoundaries(null);

--- a/src/main/java/com/griefprevention/visualization/BoundaryVisualization.java
+++ b/src/main/java/com/griefprevention/visualization/BoundaryVisualization.java
@@ -258,7 +258,8 @@ public abstract class BoundaryVisualization
         PlayerData playerData = GriefPrevention.instance.dataStore.getPlayerData(player.getUniqueId());
         BoundaryVisualization currentVisualization = playerData.getVisibleBoundaries();
         
-        if (currentVisualization != null && currentVisualization.elements.equals(event.getBoundaries())) {
+        if (currentVisualization != null && currentVisualization.elements.equals(event.getBoundaries()))
+        {
             // Ignore visualization with duplicate boundaries.
             return;
         }


### PR DESCRIPTION
Partially addresses #1986. Doesn't solve players clicking in and out of claims quickly (which a client mod absolutely could do at a rate that would cause identical lag), does prevent holding down right click causing issues.

~~Note that I can't test this because my GPU is on the fritz and Intel's integrated graphics do not play well with OpenGL as far as I'm aware. Theoretically the .equals call should work because `AbstractCollection#equals` does not care about the collection implementation, only the contents.~~