### PR TITLE
Restrict visualization of subdivisions

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -200,6 +200,7 @@ public class GriefPrevention extends JavaPlugin
     public ArrayList<String> config_eavesdrop_whisperCommands;        //list of whisper commands to eavesdrop on
 
     public boolean config_visualizationAntiCheatCompat;              // whether to engage compatibility mode for anti-cheat plugins
+    public boolean config_visualizeAllSubdivisions;                  // whether to always visualize all subdivisions
 
     public boolean config_smartBan;                                    //whether to ban accounts which very likely owned by a banned player
 
@@ -633,6 +634,7 @@ public class GriefPrevention extends JavaPlugin
         whisperCommandsToMonitor = config.getString("GriefPrevention.Spam.WhisperSlashCommands", whisperCommandsToMonitor);
 
         this.config_visualizationAntiCheatCompat = config.getBoolean("GriefPrevention.VisualizationAntiCheatCompatMode", false);
+        this.config_visualizeAllSubdivisions = config.getBoolean("GriefPrevention.VisualizeAllSubdivisions", true);
         this.config_smartBan = config.getBoolean("GriefPrevention.SmartBan", true);
         this.config_trollFilterEnabled = config.getBoolean("GriefPrevention.Mute New Players Using Banned Words", true);
         this.config_ipLimit = config.getInt("GriefPrevention.MaxPlayersPerIpAddress", 3);
@@ -887,6 +889,7 @@ public class GriefPrevention extends JavaPlugin
         outConfig.set("GriefPrevention.AdminsGetSignNotifications", this.config_signNotifications);
 
         outConfig.set("GriefPrevention.VisualizationAntiCheatCompatMode", this.config_visualizationAntiCheatCompat);
+        outConfig.set("GriefPrevention.VisualizeAllSubdivisions", this.config_visualizeAllSubdivisions);
         outConfig.set("GriefPrevention.SmartBan", this.config_smartBan);
         outConfig.set("GriefPrevention.Mute New Players Using Banned Words", this.config_trollFilterEnabled);
         outConfig.set("GriefPrevention.MaxPlayersPerIpAddress", this.config_ipLimit);


### PR DESCRIPTION
A large number of subdivisions can cause performance problems. Only allow owners, admins, etc, to see the parent claim and all subdivisions. Otherwise, only the single claim selected, be it a parent claim or subdivision, will be visualized. This is controlled by the new config item VisualizeAllSubdivisions

The following players can see all subdivisions:
- Claim owner
- Players with permission griefprevention.adminclaims if it's an admin claim
- Players with permission griefprevention.deleteclaims
- Players in ignoreclaims mode with permission griefprevention.ignoreclaims

Fixes #1986 