### PR TITLE
Add permission allowing pre-movement chat

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -688,7 +688,7 @@ class PlayerEventHandler implements Listener
         this.lastLoginThisServerSessionMap.put(playerID, nowDate);
 
         //if newish, prevent chat until he's moved a bit to prove he's not a bot
-        if (GriefPrevention.isNewToServer(player))
+        if (GriefPrevention.isNewToServer(player) && !player.hasPermission("griefprevention.premovementchat"))
         {
             playerData.noChatLocation = player.getLocation();
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -369,3 +369,6 @@ permissions:
     griefprevention.siegeteleport:
         description: Players with this permission can teleport into and out of besieged areas.
         default: op
+    griefprevention.premovementchat:
+        description: Players with this permission can chat before moving.
+        default: false


### PR DESCRIPTION
There is currently no way for a player to bypass the pre-movement chat restriction until they've picked up a log or created a claim. In the case of a server with multiple worlds, players in a Creative world with GriefPrevention disabled may never pick up a log and certainly will never create a claim. This results in longtime players being subject to the pre-movement chat restriction, unless all spam checks are disabled via the config file (which is undesirable).

This pull request adds a new permission, `griefprevention.premovementchat`, which if true will allow a player to chat without having to move first.

I considered adding this as a config file option, but using a new permission provides server owners with greater flexability. For example, in the case of a Creative world as described above, the permission can be given only to players in the Creative world. When brand new players join in the main Survival world, they will be subject to the pre-movement chat rules, and this will remain the case as long as they play Survival. Once they find their way to the Creative world, the restriction will no longer apply. Another advantage of using a permission is that it can be selectively applied to players.
