### PR TITLE
Add Claimbans

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/CheckClaimbannedTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/CheckClaimbannedTask.java
@@ -1,0 +1,22 @@
+package me.ryanhamshire.GriefPrevention;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+public class CheckClaimbannedTask implements Runnable {
+
+    @Override
+    public void run() {
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            Claim claim = GriefPrevention.instance.dataStore.getClaimAt(p.getLocation(), false, null);
+            if (claim != null) {
+                PlayerData whoData = GriefPrevention.instance.dataStore.getPlayerData(p.getUniqueId());
+                if (!whoData.ignoreClaims && claim.checkBanned(whoData.playerID)) {
+                    p.eject();
+                    GriefPrevention.instance.ejectPlayer(p);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/me/ryanhamshire/GriefPrevention/CheckClaimbannedTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/CheckClaimbannedTask.java
@@ -13,7 +13,7 @@ public class CheckClaimbannedTask implements Runnable {
                 PlayerData whoData = GriefPrevention.instance.dataStore.getPlayerData(p.getUniqueId());
                 if (!whoData.ignoreClaims && claim.checkBanned(whoData.playerID)) {
                     p.eject();
-                    GriefPrevention.instance.ejectPlayer(p);
+                    GriefPrevention.ejectPlayerFromBannedClaim(p);
                 }
             }
         }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -44,6 +44,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -97,7 +98,7 @@ public class Claim
     public ArrayList<Claim> children = new ArrayList<>();
 
     //playerIds who have been banned from this claim
-    public ArrayList<String> bannedPlayerIds = new ArrayList<>();
+    public HashSet<UUID> bannedPlayerIds = new HashSet<>();
 
     //information about a siege involving this claim.  null means no siege is impacting this claim
     public SiegeData siegeData = null;
@@ -469,7 +470,7 @@ public class Claim
      * @return true if banned, false otherwise
      */
     public boolean checkBanned(UUID uid) {
-        if (bannedPlayerIds.contains(uid.toString())) {
+        if (bannedPlayerIds.contains(uid)) {
             return true;
         } else if (!inheritNothing && parent != null) {
             return parent.checkBanned(uid);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -18,8 +18,8 @@
 
 package me.ryanhamshire.GriefPrevention;
 
-import me.ryanhamshire.GriefPrevention.util.BoundingBox;
 import me.ryanhamshire.GriefPrevention.events.ClaimPermissionCheckEvent;
+import me.ryanhamshire.GriefPrevention.util.BoundingBox;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -95,6 +95,9 @@ public class Claim
     //children (subdivisions)
     //note subdivisions themselves never have children
     public ArrayList<Claim> children = new ArrayList<>();
+
+    //playerIds who have been banned from this claim
+    public ArrayList<String> bannedPlayerIds = new ArrayList<>();
 
     //information about a siege involving this claim.  null means no siege is impacting this claim
     public SiegeData siegeData = null;
@@ -277,6 +280,7 @@ public class Claim
         this.children = new ArrayList<>(claim.children);
         this.siegeData = claim.siegeData;
         this.doorsOpen = claim.doorsOpen;
+        this.bannedPlayerIds = claim.bannedPlayerIds;
     }
 
     //measurements.  all measurements are in blocks
@@ -448,6 +452,29 @@ public class Claim
             @Nullable Event event)
     {
         return checkPermission(player, permission, event, null);
+    }
+
+    /**
+     * Checks if a player is banned from this claim
+     * @param who the player to check
+     * @return true if banned, false otherwise
+     */
+    public boolean checkBanned(Player who) {
+        return checkBanned(who.getUniqueId());
+    }
+
+    /**
+     * Checks if a player UUID is banned from this claim
+     * @param uid the player UUID to check
+     * @return true if banned, false otherwise
+     */
+    public boolean checkBanned(UUID uid) {
+        if (bannedPlayerIds.contains(uid.toString())) {
+            return true;
+        } else if (!inheritNothing && parent != null) {
+            return parent.checkBanned(uid);
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1811,6 +1811,15 @@ public abstract class DataStore
 
         this.addDefault(defaults, Messages.NetherPortalTrapDetectionMessage, "It seems you might be stuck inside a nether portal. We will rescue you in a few seconds if that is the case!", "Sent to player on join, if they left while inside a nether portal.");
 
+        this.addDefault(defaults, Messages.BannedFromClaim, "You are banned from this claim.", null);
+        this.addDefault(defaults, Messages.CannotBanManager, "Could not ban {0} from claim at {1} as they are a manager of it.", "{0} is the manager name {1} is the claim location");
+        this.addDefault(defaults, Messages.PlayerBannedFromClaim, "Player has been banned from this claim.", null);
+        this.addDefault(defaults, Messages.PlayerBannedFromClaims, "Player has been banned from all of your claims.", null);
+        this.addDefault(defaults, Messages.PlayerUnBannedFromClaim, "Player has been unbanned from your claim.", null);
+        this.addDefault(defaults, Messages.PlayerUnBannedFromClaims, "Player has been unbanned from all of your claims.", null);
+        this.addDefault(defaults, Messages.BanListNoClaim, "Stand inside the claim you're curious about.", null);
+        this.addDefault(defaults, Messages.BanListHeader, "Banned Players:", null);
+
         //load the config file
         FileConfiguration config = YamlConfiguration.loadConfiguration(new File(messagesFilePath));
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DatabaseDataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DatabaseDataStore.java
@@ -25,12 +25,7 @@ import org.bukkit.World;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -105,6 +100,9 @@ public class DatabaseDataStore extends DataStore
             statement.execute("CREATE TABLE IF NOT EXISTS griefprevention_claimdata (id INTEGER, owner VARCHAR(50), lessercorner VARCHAR(100), greatercorner VARCHAR(100), builders TEXT, containers TEXT, accessors TEXT, managers TEXT, inheritnothing BOOLEAN, parentid INTEGER, bannedplayerids TEXT)");
             statement.execute("CREATE TABLE IF NOT EXISTS griefprevention_playerdata (name VARCHAR(50), lastlogin DATETIME, accruedblocks INTEGER, bonusblocks INTEGER)");
             statement.execute("CREATE TABLE IF NOT EXISTS griefprevention_schemaversion (version INTEGER)");
+
+            //ensure old tables contain columns added in later versions
+            statement.execute("ALTER TABLE griefprevention_claimdata ADD IF NOT EXISTS bannedplayerids TEXT");
 
             // By making this run only for MySQL, we technically support SQLite too, as this is the only invalid
             // SQL we use that SQLite does not support. Seeing as its only use is to update VERY old, existing, MySQL

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DatabaseDataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DatabaseDataStore.java
@@ -48,7 +48,7 @@ public class DatabaseDataStore extends DataStore
     private static final String SQL_UPDATE_NAME =
             "UPDATE griefprevention_playerdata SET name = ? WHERE name = ?";
     private static final String SQL_INSERT_CLAIM =
-            "INSERT INTO griefprevention_claimdata (id, owner, lessercorner, greatercorner, builders, containers, accessors, managers, inheritnothing, parentid) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+            "INSERT INTO griefprevention_claimdata (id, owner, lessercorner, greatercorner, builders, containers, accessors, managers, inheritnothing, parentid, bannedplayerids) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
     private static final String SQL_DELETE_CLAIM =
             "DELETE FROM griefprevention_claimdata WHERE id = ?";
     private static final String SQL_SELECT_PLAYER_DATA =
@@ -351,11 +351,13 @@ public class DatabaseDataStore extends DataStore
                 Claim claim = new Claim(lesserBoundaryCorner, greaterBoundaryCorner, ownerID, builderNames, containerNames, accessorNames, managerNames, inheritNothing, claimID);
 
                 String bannedPlayerIDsString = results.getString("bannedplayerids");
-                for (String s : bannedPlayerIDsString.split(";")) {
-                    try {
-                        claim.bannedPlayerIds.add(UUID.fromString(s));
-                    } catch (IllegalArgumentException ex) {
-                        GriefPrevention.instance.getLogger().log(Level.WARNING, "Failed to deserialize banned player id \"" + s + "\" as it was not a valid UUID for claimID " + claimID, ex);
+                if (bannedPlayerIDsString != null && !bannedPlayerIDsString.isEmpty()) {
+                    for (String s : bannedPlayerIDsString.split(";")) {
+                        try {
+                            claim.bannedPlayerIds.add(UUID.fromString(s));
+                        } catch (IllegalArgumentException ex) {
+                            GriefPrevention.instance.getLogger().log(Level.WARNING, "Failed to deserialize banned player id \"" + s + "\" as it was not a valid UUID for claimID " + claimID, ex);
+                        }
                     }
                 }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/FlatFileDataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/FlatFileDataStore.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 import java.util.regex.Matcher;
 
 //manages data stored in the file system
@@ -526,7 +527,13 @@ public class FlatFileDataStore extends DataStore
         claim.modifiedDate = new Date(lastModifiedDate);
         claim.id = claimID;
 
-        claim.bannedPlayerIds.addAll(yaml.getStringList("bannedPlayerIDs"));
+        for (String s : yaml.getStringList("bannedPlayerIDs")) {
+            try {
+                claim.bannedPlayerIds.add(UUID.fromString(s));
+            } catch (IllegalArgumentException ex) {
+                GriefPrevention.instance.getLogger().log(Level.WARNING, "Failed to deserialize banned player id \"" + s + "\" as it was not a valid UUID for claimID " + claimID, ex);
+            }
+        }
 
         return claim;
     }
@@ -565,7 +572,7 @@ public class FlatFileDataStore extends DataStore
 
         yaml.set("inheritNothing", claim.getSubclaimRestrictions());
 
-        yaml.set("bannedPlayerIDs", claim.bannedPlayerIds);
+        yaml.set("bannedPlayerIDs", claim.bannedPlayerIds.stream().map(UUID::toString).toList());
 
         return yaml.saveToString();
     }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/FlatFileDataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/FlatFileDataStore.java
@@ -526,6 +526,8 @@ public class FlatFileDataStore extends DataStore
         claim.modifiedDate = new Date(lastModifiedDate);
         claim.id = claimID;
 
+        claim.bannedPlayerIds.addAll(yaml.getStringList("bannedPlayerIDs"));
+
         return claim;
     }
 
@@ -562,6 +564,8 @@ public class FlatFileDataStore extends DataStore
         yaml.set("Parent Claim ID", parentID);
 
         yaml.set("inheritNothing", claim.getSubclaimRestrictions());
+
+        yaml.set("bannedPlayerIDs", claim.bannedPlayerIds);
 
         return yaml.saveToString();
     }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -3490,6 +3490,29 @@ public class GriefPrevention extends JavaPlugin
         }
     }
 
+    // similar to ejectPlayer but will eject players into other claims if they are not banned from them
+    public static Location ejectPlayerFromBannedClaim(Player who) {
+        return ejectPlayerFromBannedClaim(who, who.getLocation());
+    }
+
+    // similar to ejectPlayer but will eject players into other claims if they are not banned from them
+    public static Location ejectPlayerFromBannedClaim(Player who, Location candidateLocation) {
+        candidateLocation = ejectionLocationForClaimban(who, candidateLocation);
+        GuaranteeChunkLoaded(candidateLocation);
+        who.teleport(candidateLocation);
+        return candidateLocation;
+    }
+
+    public static Location ejectionLocationForClaimban(Player who, Location candidateLocation) {
+        candidateLocation = candidateLocation.getWorld().getHighestBlockAt(candidateLocation.getBlock().getLocation()).getLocation().add(-1, 1, -1);
+        Claim claim = GriefPrevention.instance.dataStore.getClaimAt(candidateLocation, false, false, null);
+        while (claim != null && claim.checkBanned(who)) {
+            candidateLocation = candidateLocation.getWorld().getHighestBlockAt(claim.lesserBoundaryCorner).getLocation().add(-1, 1, -1);
+            claim = GriefPrevention.instance.dataStore.getClaimAt(candidateLocation, false, false, null);
+        }
+        return candidateLocation.clone().add(0.5, 0, 0.5);
+    }
+
     //ensures a piece of the managed world is loaded into server memory
     //(generates the chunk if necessary)
     private static void GuaranteeChunkLoaded(Location location)

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1801,10 +1801,10 @@ public class GriefPrevention extends JavaPlugin
                 for (Claim c : data.getClaims()) {
                     if (c != null) {
                         c.bannedPlayerIds.remove(targetIdString);
-                        dataStore.saveClaim(c);
                         for (Claim child : c.children) {
                             child.bannedPlayerIds.remove(targetIdString);
                         }
+                        dataStore.saveClaim(c);
                     }
                 }
                 GriefPrevention.sendMessage(player, TextMode.Success, Messages.PlayerUnBannedFromClaims, args[0]);
@@ -1814,10 +1814,10 @@ public class GriefPrevention extends JavaPlugin
                     return true;
                 } else {
                     claim.bannedPlayerIds.remove(targetIdString);
-                    dataStore.saveClaim(claim);
                     for (Claim child : claim.children) {
                         child.bannedPlayerIds.remove(targetIdString);
                     }
+                    dataStore.saveClaim(claim);
                 }
                 GriefPrevention.sendMessage(player, TextMode.Success, Messages.PlayerUnBannedFromClaim, args[0]);
             }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1749,12 +1749,12 @@ public class GriefPrevention extends JavaPlugin
                         return true;
                     } else if (!claim.bannedPlayerIds.contains(targetId)) {
                         if (claim.bannedPlayerIds.size() >= 512) {
-                            GriefPrevention.sendMessage(player, ChatColor.RED, "Too many players banned from claim");
+                            GriefPrevention.sendMessage(player, ChatColor.RED, "Too many players banned from this claim");
                         } else {
                             claim.bannedPlayerIds.add(targetId);
                             claim.dropPermission(targetId.toString());
                             dataStore.saveClaim(claim);
-                            if (targetPlayer != null && claim.contains(targetPlayer.getLocation(), false, false)) {
+                            if (targetPlayer != null && !dataStore.getPlayerData(targetId).ignoreClaims && claim.contains(targetPlayer.getLocation(), false, false)) {
                                 ejectPlayer(targetPlayer);
                                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.BannedFromClaim);
                             }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -354,6 +354,10 @@ public class GriefPrevention extends JavaPlugin
         FindUnusedClaimsTask task2 = new FindUnusedClaimsTask();
         this.getServer().getScheduler().scheduleSyncRepeatingTask(this, task2, 20L * 60, 20L * config_advanced_claim_expiration_check_rate);
 
+        //start recurring check for players in claims they are banned from
+        CheckClaimbannedTask task3 = new CheckClaimbannedTask();
+        this.getServer().getScheduler().scheduleSyncRepeatingTask(this, task3, 10, 10);
+
         //register for events
         PluginManager pluginManager = this.getServer().getPluginManager();
 
@@ -1734,7 +1738,7 @@ public class GriefPrevention extends JavaPlugin
             if (claim == null) {
                 for (Claim c : data.getClaims()) {
                     if (c != null && c.parent == null) {
-                        if (c.checkPermission(UUID.fromString(targetIdString), ClaimPermission.Manage, null) == null) {
+                        if (c.checkPermission(UUID.fromString(targetIdString), ClaimPermission.Manage, null) == null && !data.ignoreClaims) {
                             GriefPrevention.sendMessage(player, TextMode.Err, Messages.CannotBanManager, targetPlayer == null ? lookupPlayerName(targetIdString) : targetPlayer.getName(), getfriendlyLocationString(c.lesserBoundaryCorner));
                         } else if (!c.bannedPlayerIds.contains(targetIdString)) {
                             if (c.bannedPlayerIds.size() >= 128) {
@@ -1757,7 +1761,7 @@ public class GriefPrevention extends JavaPlugin
                     GriefPrevention.sendMessage(player, TextMode.Err, Messages.NoPermissionTrust, claim.getOwnerName());
                     return true;
                 } else {
-                    if (claim.checkPermission(UUID.fromString(targetIdString), ClaimPermission.Manage, null) == null) {
+                    if (claim.checkPermission(UUID.fromString(targetIdString), ClaimPermission.Manage, null) == null && !data.ignoreClaims) {
                         GriefPrevention.sendMessage(player, TextMode.Err, Messages.CannotBanManager, targetPlayer == null ? lookupPlayerName(targetIdString) : targetPlayer.getName(), getfriendlyLocationString(claim.lesserBoundaryCorner));
                         return true;
                     } else if (!claim.bannedPlayerIds.contains(targetIdString)) {
@@ -1848,7 +1852,7 @@ public class GriefPrevention extends JavaPlugin
                         i += 2;
                     }
                     i += name.length();
-                    if (i > 48) {
+                    if (i > 45) {
                         sb.append('\n').append(ChatColor.RED).append('>').append(' ');
                         i = 0;
                     }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -3468,7 +3468,10 @@ public class GriefPrevention extends JavaPlugin
                 candidateLocation = candidateLocation.getWorld().getHighestBlockAt(candidateLocation.getBlockX(), candidateLocation.getBlockZ()).getLocation();
                 if (!candidateLocation.getBlock().getType().isOccluding() || !candidateLocation.getWorld().getWorldBorder().isInside(candidateLocation)) {
                     candidateLocation = player.getBedSpawnLocation();
-                    if (candidateLocation == null) candidateLocation = Bukkit.getWorlds().get(0).getSpawnLocation();
+                    if (candidateLocation == null ||
+                            (claim = GriefPrevention.instance.dataStore.getClaimAt(candidateLocation, false, false, null)) != null && claim.checkBanned(player)) {
+                        candidateLocation = Bukkit.getWorlds().get(0).getSpawnLocation();
+                    }
                 } else {
                     candidateLocation.add(0, 2, 0);
                 }
@@ -3501,7 +3504,10 @@ public class GriefPrevention extends JavaPlugin
             while (!highest.getType().isOccluding()) {
                 if (attempts > 64) {
                     candidateLocation = who.getBedSpawnLocation();
-                    if (candidateLocation == null) candidateLocation = Bukkit.getWorlds().get(0).getSpawnLocation();
+                    if (candidateLocation == null ||
+                            (claim = GriefPrevention.instance.dataStore.getClaimAt(candidateLocation, false, false, null)) != null && claim.checkBanned(who)) {
+                        candidateLocation = Bukkit.getWorlds().get(0).getSpawnLocation();
+                    }
                     return candidateLocation.add(0.5, 0, 0.5);
                 }
                 highest = highest.getWorld().getHighestBlockAt(highest.getX() - 1, highest.getZ() - 1);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1732,20 +1732,20 @@ public class GriefPrevention extends JavaPlugin
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.PlayerNotFound2);
                 return true;
             }
-            String targetIdString = target.getUniqueId().toString();
+            UUID targetId = target.getUniqueId();
             Player targetPlayer = Bukkit.getPlayer(target.getUniqueId());
 
             if (claim == null) {
                 for (Claim c : data.getClaims()) {
                     if (c != null && c.parent == null) {
-                        if (c.checkPermission(UUID.fromString(targetIdString), ClaimPermission.Manage, null) == null && !data.ignoreClaims) {
-                            GriefPrevention.sendMessage(player, TextMode.Err, Messages.CannotBanManager, targetPlayer == null ? lookupPlayerName(targetIdString) : targetPlayer.getName(), getfriendlyLocationString(c.lesserBoundaryCorner));
-                        } else if (!c.bannedPlayerIds.contains(targetIdString)) {
-                            if (c.bannedPlayerIds.size() >= 128) {
+                        if (c.checkPermission(targetId, ClaimPermission.Manage, null) == null && !data.ignoreClaims) {
+                            GriefPrevention.sendMessage(player, TextMode.Err, Messages.CannotBanManager, targetPlayer == null ? lookupPlayerName(targetId) : targetPlayer.getName(), getfriendlyLocationString(c.lesserBoundaryCorner));
+                        } else if (!c.bannedPlayerIds.contains(targetId)) {
+                            if (c.bannedPlayerIds.size() >= 512) {
                                 GriefPrevention.sendMessage(player, ChatColor.RED, "Too many players banned from claim: " + getfriendlyLocationString(c.lesserBoundaryCorner));
                             } else {
-                                c.bannedPlayerIds.add(targetIdString);
-                                c.dropPermission(targetIdString);
+                                c.bannedPlayerIds.add(targetId);
+                                c.dropPermission(targetId.toString());
                                 dataStore.saveClaim(c);
                                 if (targetPlayer != null && c.contains(targetPlayer.getLocation(), false, false)) {
                                     ejectPlayer(targetPlayer);
@@ -1761,15 +1761,15 @@ public class GriefPrevention extends JavaPlugin
                     GriefPrevention.sendMessage(player, TextMode.Err, Messages.NoPermissionTrust, claim.getOwnerName());
                     return true;
                 } else {
-                    if (claim.checkPermission(UUID.fromString(targetIdString), ClaimPermission.Manage, null) == null && !data.ignoreClaims) {
-                        GriefPrevention.sendMessage(player, TextMode.Err, Messages.CannotBanManager, targetPlayer == null ? lookupPlayerName(targetIdString) : targetPlayer.getName(), getfriendlyLocationString(claim.lesserBoundaryCorner));
+                    if (claim.checkPermission(targetId, ClaimPermission.Manage, null) == null && !data.ignoreClaims) {
+                        GriefPrevention.sendMessage(player, TextMode.Err, Messages.CannotBanManager, targetPlayer == null ? lookupPlayerName(targetId) : targetPlayer.getName(), getfriendlyLocationString(claim.lesserBoundaryCorner));
                         return true;
-                    } else if (!claim.bannedPlayerIds.contains(targetIdString)) {
-                        if (claim.bannedPlayerIds.size() >= 128) {
+                    } else if (!claim.bannedPlayerIds.contains(targetId)) {
+                        if (claim.bannedPlayerIds.size() >= 512) {
                             GriefPrevention.sendMessage(player, ChatColor.RED, "Too many players banned from claim");
                         } else {
-                            claim.bannedPlayerIds.add(targetIdString);
-                            claim.dropPermission(targetIdString);
+                            claim.bannedPlayerIds.add(targetId);
+                            claim.dropPermission(targetId.toString());
                             dataStore.saveClaim(claim);
                             if (targetPlayer != null && claim.contains(targetPlayer.getLocation(), false, false)) {
                                 ejectPlayer(targetPlayer);
@@ -1795,14 +1795,14 @@ public class GriefPrevention extends JavaPlugin
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.PlayerNotFound2);
                 return true;
             }
-            String targetIdString = target.getUniqueId().toString();
+            UUID targetId = target.getUniqueId();
 
             if (claim == null) {
                 for (Claim c : data.getClaims()) {
                     if (c != null) {
-                        c.bannedPlayerIds.remove(targetIdString);
+                        c.bannedPlayerIds.remove(targetId);
                         for (Claim child : c.children) {
-                            child.bannedPlayerIds.remove(targetIdString);
+                            child.bannedPlayerIds.remove(targetId);
                         }
                         dataStore.saveClaim(c);
                     }
@@ -1813,9 +1813,9 @@ public class GriefPrevention extends JavaPlugin
                     GriefPrevention.sendMessage(player, TextMode.Err, Messages.NoPermissionTrust, claim.getOwnerName());
                     return true;
                 } else {
-                    claim.bannedPlayerIds.remove(targetIdString);
+                    claim.bannedPlayerIds.remove(targetId);
                     for (Claim child : claim.children) {
-                        child.bannedPlayerIds.remove(targetIdString);
+                        child.bannedPlayerIds.remove(targetId);
                     }
                     dataStore.saveClaim(claim);
                 }
@@ -1840,10 +1840,10 @@ public class GriefPrevention extends JavaPlugin
                 StringBuilder sb = new StringBuilder();
                 sb.append(ChatColor.RED).append('>').append(' ');
                 int i = -1;
-                for (String playerId : claim.bannedPlayerIds) {
+                for (UUID playerId : claim.bannedPlayerIds) {
                     String name = lookupPlayerName(playerId);
                     if (name == null) {
-                        name = playerId;
+                        name = playerId.toString();
                     }
                     if (i == -1) {
                         i = 0;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
@@ -254,5 +254,13 @@ public enum Messages
     StandInSubclaim,
     SubclaimRestricted,
     SubclaimUnrestricted,
-    NetherPortalTrapDetectionMessage
+    NetherPortalTrapDetectionMessage,
+    BannedFromClaim,
+    CannotBanManager,
+    PlayerBannedFromClaim,
+    PlayerBannedFromClaims,
+    PlayerUnBannedFromClaims,
+    PlayerUnBannedFromClaim,
+    BanListNoClaim,
+    BanListHeader;
 }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -862,7 +862,7 @@ class PlayerEventHandler implements Listener
 
         Claim atClaim = dataStore.getClaimAt(player.getLocation(), false, playerData.lastClaim);
         if (checkBannedFromClaim(atClaim, playerData)) {
-            instance.ejectPlayer(player);
+            GriefPrevention.ejectPlayerFromBannedClaim(event.getPlayer());
             GriefPrevention.sendMessage(player, TextMode.Err, Messages.BannedFromClaim);
         }
     }
@@ -887,7 +887,7 @@ class PlayerEventHandler implements Listener
 
         Claim toClaim = dataStore.getClaimAt(event.getRespawnLocation(), false, playerData.lastClaim);
         if (checkBannedFromClaim(toClaim, playerData)) {
-            instance.ejectPlayer(player, event.getRespawnLocation());
+            GriefPrevention.ejectPlayerFromBannedClaim(event.getPlayer(), event.getRespawnLocation());
             GriefPrevention.sendMessage(player, TextMode.Err, Messages.BannedFromClaim);
         }
     }
@@ -1085,7 +1085,7 @@ class PlayerEventHandler implements Listener
         Claim toClaim = dataStore.getClaimAt(event.getTo(), true, playerData.lastClaim);
 
         if (checkBannedFromClaim(toClaim, playerData)) {
-            instance.ejectPlayer(player, event.getTo());
+            GriefPrevention.ejectPlayerFromBannedClaim(event.getPlayer(), event.getTo());
             GriefPrevention.sendMessage(player, TextMode.Err, Messages.BannedFromClaim);
             return;
         }
@@ -1128,7 +1128,7 @@ class PlayerEventHandler implements Listener
         }
 
         if (checkBannedFromClaim(toClaim, playerData)) {
-            instance.ejectPlayer(player, event.getTo());
+            GriefPrevention.ejectPlayerFromBannedClaim(event.getPlayer(), event.getTo());
             GriefPrevention.sendMessage(player, TextMode.Err, Messages.BannedFromClaim);
             return;
         }
@@ -1172,8 +1172,8 @@ class PlayerEventHandler implements Listener
             PlayerData playerData = dataStore.getPlayerData(event.getPlayer().getUniqueId());
             Claim toClaim = dataStore.getClaimAt(event.getTo(), false, playerData.lastClaim);
             if (checkBannedFromClaim(toClaim, playerData)) {
-                if (claimContainsAABB(toClaim, event.getPlayer().getBoundingBox())) {
-                    instance.ejectPlayer(event.getPlayer());
+                if (toClaim.contains(event.getFrom(), false, false)) {
+                    GriefPrevention.ejectPlayerFromBannedClaim(event.getPlayer(), event.getFrom());
                 } else {
                     event.setCancelled(true);
                 }
@@ -1184,12 +1184,6 @@ class PlayerEventHandler implements Listener
 
     private boolean checkBannedFromClaim(Claim claim, PlayerData whoData) {
         return claim != null && !whoData.ignoreClaims && claim.checkBanned(whoData.playerID);
-    }
-
-    private boolean claimContainsAABB(Claim c, org.bukkit.util.BoundingBox bbox) {
-        Location loc = bbox.getMax().toLocation(c.getGreaterBoundaryCorner().getWorld());
-        return c.contains(loc, false, false) ||
-                c.contains(loc.zero().add(bbox.getMin()), false, false);
     }
 
     //when a player triggers a raid (in a claim)

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,21 @@ loadbefore: [TheUnderground]
 version: '${git.commit.id.describe}'
 api-version: '1.17'
 commands:
+    claimban:
+      description: Bans a player from a claim(s)
+      usage: /ClaimBan <player>
+      aliases: banish # Be gone!
+      permission: griefprevention.claims
+    claimunban:
+      description: Unbans a player from a claim(s)
+      usage: /ClaimUnBan <player>
+      aliases: [claimdeban, unbanish]
+      permission: griefprevention.claims
+    claimbanlist:
+      description: Lists claimbans for the claim your standing in
+      usage: /ClaimBanList
+      aliases: claimbans
+      permission: griefprevention.claims
     abandonclaim:
       description: Deletes a claim.
       usage: /AbandonClaim


### PR DESCRIPTION
This PR adds Claim Bans to GriefPrevention

I've added claimbans to GP to prevent players from annoying others inside claims (such as by inventory bombing, filling hopper systems, stealing loot from automatic farms etc)

Added commands:
- `claimban` aliases `banish`
- `claimunban` aliases `claimdeban, unbanish`
- `claimbanlist` aliases `claimbans`

Added Messages:
- `BannedFromClaim`
- `CannotBanManager`
- `PlayerBannedFromClaim`
- `PlayerBannedFromClaims`
- `PlayerUnBannedFromClaims`
- `PlayerUnBannedFromClaim`
- `BanListNoClaim`
- `BanListHeader`

Added Tasks:
- `CheckClaimbannedTask` interval `10` - Used to prevent mount plugins from bypassing claimbans

Added Data:
- List of claimbanned Player IDs mysql: `bannedplayerids TEXT` yaml: `bannedPlayerIDs`

