### PR TITLE
Fix visualization O(n2) performance

### DIFF
--- a/src/main/java/com/griefprevention/visualization/BlockBoundaryVisualization.java
+++ b/src/main/java/com/griefprevention/visualization/BlockBoundaryVisualization.java
@@ -1,6 +1,7 @@
 package com.griefprevention.visualization;
 
 import com.griefprevention.util.IntVector;
+import me.ryanhamshire.GriefPrevention.PlayerData;
 import me.ryanhamshire.GriefPrevention.util.BoundingBox;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -55,6 +56,12 @@ public abstract class BlockBoundaryVisualization extends BoundaryVisualization
     }
 
     @Override
+    protected void apply(@NotNull Player player, @NotNull PlayerData playerData) {
+        super.apply(player, playerData);
+        elements.forEach(element -> element.draw(player, world));
+    }
+
+    @Override
     protected void draw(@NotNull Player player, @NotNull Boundary boundary)
     {
         BoundingBox area = boundary.bounds();
@@ -102,8 +109,6 @@ public abstract class BlockBoundaryVisualization extends BoundaryVisualization
         addDisplayed(displayZone, new IntVector(area.getMaxX(), height, area.getMaxZ()), addCorner);
         addDisplayed(displayZone, new IntVector(area.getMinX(), height, area.getMinZ()), addCorner);
         addDisplayed(displayZone, new IntVector(area.getMaxX(), height, area.getMinZ()), addCorner);
-
-        elements.forEach(element -> element.draw(player, world));
     }
 
     /**

--- a/src/main/java/com/griefprevention/visualization/BoundaryVisualization.java
+++ b/src/main/java/com/griefprevention/visualization/BoundaryVisualization.java
@@ -67,7 +67,7 @@ public abstract class BoundaryVisualization
      * @param player the visualization target
      * @param playerData the {@link PlayerData} of the visualization target
      */
-    private void apply(@NotNull Player player, @NotNull PlayerData playerData)
+    protected void apply(@NotNull Player player, @NotNull PlayerData playerData)
     {
         // Remember the visualization so it can be reverted.
         playerData.setVisibleBoundaries(this);


### PR DESCRIPTION
This PR fixes a huge issue with visualization performance where for every boundary you draw, redraws all boundary BlockElements in the visualization. Giving you O(n2) performance.

This PR gives you O(n) performance.

Related to: #1986 #1987