### PR TITLE
Remove `TheUnderground` from softdepend

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: GriefPrevention
 main: me.ryanhamshire.GriefPrevention.GriefPrevention
-softdepend: [Vault, Multiverse-Core, My_Worlds, MystCraft, Transporter, TheUnderground, WorldGuard, WorldEdit, RoyalCommands, MultiWorld, Denizen]
+softdepend: [Vault, Multiverse-Core, My_Worlds, MystCraft, Transporter, WorldGuard, WorldEdit, RoyalCommands, MultiWorld, Denizen]
 dev-url: https://dev.bukkit.org/projects/grief-prevention
 version: '${git.commit.id.describe}'
 api-version: '1.17'


### PR DESCRIPTION
See rationale on issue #2009, in particular https://github.com/TechFortress/GriefPrevention/issues/2009#issuecomment-1436095403

... but recent changes to Paper in https://github.com/PaperMC/Paper/pull/8108 have caused a circular dependency error to be triggered by this - we (soft-!)depend on `TheUnderground`, which depends on GriefPrevention, and boom.  I'd argue that a softdepend should not be considered a circular dependency really, but it is, currently, and results in an error like:

```
[11:26:57 ERROR]: [ConfiguredOrderedProviderStorage] Circular dependencies detected!
[11:26:57 ERROR]: [ConfiguredOrderedProviderStorage] You have a plugin that is depending on a plugin which refers back to that plugin. Your server will shut down until these are resolved, or the strategy is changed.
[11:26:57 ERROR]: [ConfiguredOrderedProviderStorage] Circular dependencies:
[11:26:57 ERROR]: [ConfiguredOrderedProviderStorage] GriefPrevention depends on TheUnderground depends on GriefPrevention...
```

`TheUnderground` appears to only work on 1.10, and current GriefPrevention builds don't support anything that ancient, so there doesn't seem to be much point in maintaining it in the softdepends list.  It also doesn't look widely used anyway.

Note that it was already removed from `loadbefore` in 6d0a1b9