### PR TITLE
Fix ClaimResizeEvent generating deprecated event warning

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -21,6 +21,7 @@ package me.ryanhamshire.GriefPrevention;
 import com.google.common.io.Files;
 import com.griefprevention.visualization.BoundaryVisualization;
 import com.griefprevention.visualization.VisualizationType;
+import me.ryanhamshire.GriefPrevention.events.ClaimModifiedEvent;
 import me.ryanhamshire.GriefPrevention.events.ClaimResizeEvent;
 import me.ryanhamshire.GriefPrevention.events.ClaimCreatedEvent;
 import me.ryanhamshire.GriefPrevention.events.ClaimDeletedEvent;
@@ -1451,7 +1452,7 @@ public abstract class DataStore
         newClaim.greaterBoundaryCorner = new Location(world, newx2, newy2, newz2);
 
         //call event here to check if it has been cancelled
-        ClaimResizeEvent event = new ClaimResizeEvent(oldClaim, newClaim, player);
+        ClaimResizeEvent event = new ClaimModifiedEvent(oldClaim, newClaim, player); // Swap to ClaimResizeEvent when ClaimModifiedEvent is removed
         Bukkit.getPluginManager().callEvent(event);
 
         //return here if event is cancelled

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimExtendEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimExtendEvent.java
@@ -43,7 +43,7 @@ public class ClaimExtendEvent extends ClaimChangeEvent
      * @return the resulting {@code Claim}
      * @deprecated Use {@link #getTo() getTo} instead.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "16.18")
     public @NotNull Claim getClaim()
     {
         return getTo();

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimModifiedEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimModifiedEvent.java
@@ -2,6 +2,7 @@ package me.ryanhamshire.GriefPrevention.events;
 
 
 import me.ryanhamshire.GriefPrevention.Claim;
+import org.bukkit.Warning;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
@@ -16,7 +17,8 @@ import org.jetbrains.annotations.Nullable;
  *
  * @author Narimm on 5/08/2018.
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "16.18")
+@Warning(value = true, reason = "ClaimModifiedEvent will be removed in favor of ClaimResizeEvent")
 public class ClaimModifiedEvent extends ClaimChangeEvent
 {
 
@@ -43,7 +45,7 @@ public class ClaimModifiedEvent extends ClaimChangeEvent
      * @return the resulting {@code Claim}
      * @deprecated Use {@link #getTo()} instead.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "16.18")
     public @NotNull Claim getClaim()
     {
         return getTo();

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimModifiedEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimModifiedEvent.java
@@ -19,10 +19,8 @@ import org.jetbrains.annotations.Nullable;
  */
 @Deprecated(forRemoval = true, since = "16.18")
 @Warning(value = true, reason = "ClaimModifiedEvent will be removed in favor of ClaimResizeEvent")
-public class ClaimModifiedEvent extends ClaimChangeEvent
+public class ClaimModifiedEvent extends ClaimResizeEvent
 {
-
-    private final @Nullable CommandSender modifier;
 
     /**
      * Construct a new {@code ClaimModifiedEvent}.
@@ -35,29 +33,6 @@ public class ClaimModifiedEvent extends ClaimChangeEvent
      */
     public ClaimModifiedEvent(@NotNull Claim from, @NotNull Claim to, @Nullable CommandSender modifier)
     {
-        super(from, to);
-        this.modifier = modifier;
-    }
-
-    /**
-     * Get the resulting {@link Claim} after modification.
-     *
-     * @return the resulting {@code Claim}
-     * @deprecated Use {@link #getTo()} instead.
-     */
-    @Deprecated(forRemoval = true, since = "16.18")
-    public @NotNull Claim getClaim()
-    {
-        return getTo();
-    }
-
-    /**
-     * Get the {@link CommandSender} modifying the {@link Claim}. May be {@code null} if caused by a plugin.
-     *
-     * @return the actor causing creation
-     */
-    public @Nullable CommandSender getModifier()
-    {
-        return modifier;
+        super(from, to, modifier);
     }
 }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimResizeEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimResizeEvent.java
@@ -1,6 +1,7 @@
 package me.ryanhamshire.GriefPrevention.events;
 
 import me.ryanhamshire.GriefPrevention.Claim;
+import org.bukkit.Warning;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -8,8 +9,12 @@ import org.jetbrains.annotations.Nullable;
 /**
  * An {@link org.bukkit.event.Event Event} called when a {@link Claim} is resized.
  */
+@Deprecated // but not actually
+@Warning(reason = "Please ignore this line.")
 public class ClaimResizeEvent extends ClaimModifiedEvent
 {
+
+    private final @Nullable CommandSender modifier;
 
     /**
      * Construct a new {@code ClaimResizeEvent}.
@@ -23,6 +28,16 @@ public class ClaimResizeEvent extends ClaimModifiedEvent
     public ClaimResizeEvent(@NotNull Claim from, @NotNull Claim to, @Nullable CommandSender modifier)
     {
         super(from, to, modifier);
+        this.modifier = modifier;
     }
 
+    /**
+     * Get the {@link CommandSender} modifying the {@link Claim}. May be {@code null} if caused by a plugin.
+     *
+     * @return the actor causing creation
+     */
+    public @Nullable CommandSender getModifier()
+    {
+        return modifier;
+    }
 }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimResizeEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimResizeEvent.java
@@ -1,7 +1,6 @@
 package me.ryanhamshire.GriefPrevention.events;
 
 import me.ryanhamshire.GriefPrevention.Claim;
-import org.bukkit.Warning;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -9,9 +8,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * An {@link org.bukkit.event.Event Event} called when a {@link Claim} is resized.
  */
-@Deprecated // but not actually
-@Warning(reason = "Please ignore this line.")
-public class ClaimResizeEvent extends ClaimModifiedEvent
+public class ClaimResizeEvent extends ClaimChangeEvent
 {
 
     private final @Nullable CommandSender modifier;
@@ -27,7 +24,7 @@ public class ClaimResizeEvent extends ClaimModifiedEvent
      */
     public ClaimResizeEvent(@NotNull Claim from, @NotNull Claim to, @Nullable CommandSender modifier)
     {
-        super(from, to, modifier);
+        super(from, to);
         this.modifier = modifier;
     }
 
@@ -39,5 +36,17 @@ public class ClaimResizeEvent extends ClaimModifiedEvent
     public @Nullable CommandSender getModifier()
     {
         return modifier;
+    }
+
+    /**
+     * Get the resulting {@link Claim} after modification.
+     *
+     * @return the resulting {@code Claim}
+     * @deprecated Use {@link #getTo()} instead.
+     */
+    @Deprecated(forRemoval = true, since = "16.18")
+    public @NotNull Claim getClaim()
+    {
+        return getTo();
     }
 }


### PR DESCRIPTION
This is annoying for us in that we have to continue using the deprecated class to fire events for compatibility reasons, but the alternative is to make addon developers ignore a fake deprecation. Either way, someone's using deprecated stuff, and it's better that it be us so we're reminded to remove it.

Clarified warning printed to console in the event that someone is still actually using the ClaimModifiedEvent - the default warns about server performance.

Doesn't appear to break anything for normal usage, both events still worked identically in a quick test addon.

Closes #1791 