### PR TITLE
Improve error handling when trying to assign a very large number of bonus claim blocks

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1820,6 +1820,7 @@ public abstract class DataStore
         this.addDefault(defaults, Messages.SubclaimUnrestricted, "This subclaim's permissions will now inherit from the parent claim", null);
 
         this.addDefault(defaults, Messages.NetherPortalTrapDetectionMessage, "It seems you might be stuck inside a nether portal. We will rescue you in a few seconds if that is the case!", "Sent to player on join, if they left while inside a nether portal.");
+        this.addDefault(defaults, Messages.InvalidNumber, "The provided number was invalid.");
 
         //load the config file
         FileConfiguration config = YamlConfiguration.loadConfiguration(new File(messagesFilePath));

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1820,7 +1820,7 @@ public abstract class DataStore
         this.addDefault(defaults, Messages.SubclaimUnrestricted, "This subclaim's permissions will now inherit from the parent claim", null);
 
         this.addDefault(defaults, Messages.NetherPortalTrapDetectionMessage, "It seems you might be stuck inside a nether portal. We will rescue you in a few seconds if that is the case!", "Sent to player on join, if they left while inside a nether portal.");
-        this.addDefault(defaults, Messages.InvalidNumber, "The provided number was invalid.");
+        this.addDefault(defaults, Messages.InvalidNumber, "The provided number was invalid.", null);
 
         //load the config file
         FileConfiguration config = YamlConfiguration.loadConfiguration(new File(messagesFilePath));

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -2321,7 +2321,8 @@ public class GriefPrevention extends JavaPlugin
             }
             catch (NumberFormatException numberFormatException)
             {
-                return false;  //causes usage to be displayed
+                GriefPrevention.sendMessage(player, TextMode.Err, Messages.InvalidNumber);
+                return true;
             }
 
             //if granting blocks to all players with a specific permission

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
@@ -254,5 +254,6 @@ public enum Messages
     StandInSubclaim,
     SubclaimRestricted,
     SubclaimUnrestricted,
-    NetherPortalTrapDetectionMessage
+    NetherPortalTrapDetectionMessage,
+    InvalidNumber
 }


### PR DESCRIPTION
When trying to grant someone more then 2,147,483,647 claim blocks, the plugin displays the usage implying the syntax was incorrect. Instead inform them the number was invalid