### PR TITLE
Resolve UUID strings when matching players

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -2338,17 +2338,7 @@ public class GriefPrevention extends JavaPlugin
             }
 
             //otherwise, find the specified player
-            OfflinePlayer targetPlayer;
-            try
-            {
-                UUID playerID = UUID.fromString(args[0]);
-                targetPlayer = this.getServer().getOfflinePlayer(playerID);
-
-            }
-            catch (IllegalArgumentException e)
-            {
-                targetPlayer = this.resolvePlayerByName(args[0]);
-            }
+            OfflinePlayer targetPlayer = this.resolvePlayerByName(args[0]);
 
             if (targetPlayer == null)
             {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -3189,7 +3189,16 @@ public class GriefPrevention extends JavaPlugin
         }
         if (bestMatchID == null)
         {
-            return null;
+            try
+            {
+                // Try to parse UUID from string.
+                bestMatchID = UUID.fromString(name);
+            }
+            catch (IllegalArgumentException ignored)
+            {
+                // Not a valid UUID string either.
+                return null;
+            }
         }
 
         return this.getServer().getOfflinePlayer(bestMatchID);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -2681,7 +2681,9 @@ public class GriefPrevention extends JavaPlugin
 
             //find the specified player
             OfflinePlayer targetPlayer = this.resolvePlayerByName(args[0]);
-            if (targetPlayer == null)
+            if (targetPlayer == null
+                    || !targetPlayer.isOnline() && !targetPlayer.hasPlayedBefore()
+                    || targetPlayer.getName() == null)
             {
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.PlayerNotFound2);
                 return true;


### PR DESCRIPTION
Allows commands such as /trust to target arbitrary UUIDs. Not a frequent thing, but improves mod support without requiring an addon. Addon would still be better UX, i.e. `/modtrust build create` or similar instead of `/trust <uuid of Create fake player>`, but it would at least allow GP to function to some degree for advanced users. Servers could also set up a `/trustmodname` in their commands.yml:
```yaml
aliases:
  trustmodname:
  - "trust <mod fake player UUID>"
```

Also allows targeting offline players via commands more reliably, i.e. a player data cleanup system might run commands from several plugins during an inactivity purge. `/deleteallclaims John_Minecraft` fails if John_Minecraft has not logged in since server restart, but `/deleteallclaims <John_Minecraft's uuid>` would succeed after this PR.
The only current case where UUID targeting is allowed is `/adjustbonusclaimblocks`

The only command blocked from arbitrary UUID execution is `/givepet` because it would allow users to give pets to nonexistent players, creating a mess that would require admin intervention.

Closes #1305 
Closes #1586 
/e: also #1970