### PR TITLE
Pass ignition by players to BlockBreakEvent handler

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -744,6 +744,17 @@ public class BlockEventHandler implements Listener
         // Arrow ignition.
         if (igniteEvent.getCause() == IgniteCause.ARROW && igniteEvent.getIgnitingEntity() != null)
         {
+            // Arrows shot by players may return the shooter, not the arrow.
+            if (igniteEvent.getIgnitingEntity() instanceof Player player)
+            {
+                BlockBreakEvent breakEvent = new BlockBreakEvent(igniteEvent.getBlock(), player);
+                onBlockBreak(breakEvent);
+                if (breakEvent.isCancelled())
+                {
+                    igniteEvent.setCancelled(true);
+                }
+                return;
+            }
             // Flammable lightable blocks do not fire EntityChangeBlockEvent when igniting.
             BlockData blockData = igniteEvent.getBlock().getBlockData();
             if (blockData instanceof Lightable lightable)


### PR DESCRIPTION
Technically a BlockPlaceEvent is more accurate to what's going on with a state change, but calling an accurate BlockPlaceEvent is a lot more annoying - we have to capture a state, make the change with no physics, and then undo the change again so that either the event is cancelled or MC can re-make the same change.
Really we more just want to not add a bunch of duplicate code here.

Closes #2048 