### PR TITLE
protect iron doors and trapdoors, too (for purpur servers)

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1806,11 +1806,11 @@ class PlayerEventHandler implements Listener
         //otherwise apply rules for doors and beds, if configured that way
         else if (clickedBlock != null &&
 
-                (instance.config_claims_lockWoodenDoors && Tag.WOODEN_DOORS.isTagged(clickedBlockType) ||
+                (instance.config_claims_lockWoodenDoors && Tag.DOORS.isTagged(clickedBlockType) ||
 
                 instance.config_claims_preventButtonsSwitches && Tag.BEDS.isTagged(clickedBlockType) ||
 
-                instance.config_claims_lockTrapDoors && Tag.WOODEN_TRAPDOORS.isTagged(clickedBlockType) ||
+                instance.config_claims_lockTrapDoors && Tag.TRAPDOORS.isTagged(clickedBlockType) ||
 
                 instance.config_claims_lecternReadingRequiresAccessTrust && clickedBlockType == Material.LECTERN ||
 


### PR DESCRIPTION
Purpur servers (and some plugins) have the option to open iron doors and trapdoors by right clicking them. When this is enabled, GriefPrevention does not protect them. This PR alleviates that by simply using the DOORS and TRAPDOORS block tags to ensure they are included in the interact check.

Servers without this right click opening iron doors feature will not notice a difference, since there is no right click feature/ability on these doors in vanilla.