### PR TITLE
Fix potion thrower potentially being spammed denial

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
@@ -981,7 +981,7 @@ public class EntityDamageHandler implements Listener
                     Consumer<Messages> cancelHandler = message ->
                     {
                         event.setIntensity(affected, 0);
-                        if (!messagedPlayer.compareAndSet(false, true))
+                        if (messagedPlayer.compareAndSet(false, true))
                             GriefPrevention.sendMessage(thrower, TextMode.Err, message);
                     };
                     if (handlePvpInClaim(thrower, affectedPlayer, thrower.getLocation(), playerData, () -> cancelHandler.accept(Messages.CantFightWhileImmune)))

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
@@ -947,10 +947,9 @@ public class EntityDamageHandler implements Listener
                                 if (noContainersReason != null)
                                 {
                                     event.setIntensity(affected, 0);
-                                    if (!messagedPlayer.get())
+                                    if (messagedPlayer.compareAndSet(false, true))
                                     {
                                         GriefPrevention.sendMessage(thrower, TextMode.Err, noContainersReason.get());
-                                        messagedPlayer.set(true);
                                     }
                                 }
                             }


### PR DESCRIPTION
Check was inverted (whoops) resulting in first hit not sending a message at all and subsequent hits causing spam.
<sub><sub>~~the spam was punishment for being rude and throwing harmful potions on other players~~</sub></sub>