### PR TITLE
Avoid using Inventory.getHolder() in hopper check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -189,7 +189,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.7.0</version>
+            <version>5.9.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.4.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -21,28 +21,25 @@ package me.ryanhamshire.GriefPrevention;
 import com.griefprevention.visualization.BoundaryVisualization;
 import com.griefprevention.visualization.VisualizationType;
 import me.ryanhamshire.GriefPrevention.util.BoundingBox;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.Tag;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
-import org.bukkit.block.Hopper;
 import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Lightable;
 import org.bukkit.block.data.type.Chest;
 import org.bukkit.block.data.type.Dispenser;
 import org.bukkit.entity.Fireball;
-import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
-import org.bukkit.entity.minecart.HopperMinecart;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -64,9 +61,9 @@ import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.event.inventory.InventoryPickupItemEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.world.PortalCreateEvent;
 import org.bukkit.event.world.StructureGrowEvent;
-import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.projectiles.BlockProjectileSource;
@@ -1100,30 +1097,25 @@ public class BlockEventHandler implements Listener
     @EventHandler(ignoreCancelled = true)
     public void onInventoryPickupItem(InventoryPickupItemEvent event)
     {
-        //prevent hoppers from picking-up items dropped by players on death
-
-        InventoryHolder holder = event.getInventory().getHolder();
-        if (holder instanceof HopperMinecart || holder instanceof Hopper)
+        // Prevent hoppers from taking items dropped by players upon death.
+        if (event.getInventory().getType() != InventoryType.HOPPER)
         {
-            Item item = event.getItem();
-            List<MetadataValue> data = item.getMetadata("GP_ITEMOWNER");
-            //if this is marked as belonging to a player
-            if (data != null && data.size() > 0)
+            return;
+        }
+
+        List<MetadataValue> meta = event.getItem().getMetadata("GP_ITEMOWNER");
+        if (meta.isEmpty())
+        {
+            return;
+        }
+
+        UUID itemOwnerId = (UUID) meta.get(0).value();
+        if (Bukkit.getServer().getPlayer(itemOwnerId) != null)
+        {
+            PlayerData itemOwner = dataStore.getPlayerData(itemOwnerId);
+            if (!itemOwner.dropsAreUnlocked)
             {
-                UUID ownerID = (UUID) data.get(0).value();
-
-                //has that player unlocked his drops?
-                OfflinePlayer owner = GriefPrevention.instance.getServer().getOfflinePlayer(ownerID);
-                if (owner.isOnline())
-                {
-                    PlayerData playerData = this.dataStore.getPlayerData(ownerID);
-
-                    //if locked, don't allow pickup
-                    if (!playerData.dropsAreUnlocked)
-                    {
-                        event.setCancelled(true);
-                    }
-                }
+                event.setCancelled(true);
             }
         }
     }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -1104,15 +1104,19 @@ public class BlockEventHandler implements Listener
         }
 
         List<MetadataValue> meta = event.getItem().getMetadata("GP_ITEMOWNER");
+        // We only care about an item if it has been flagged as belonging to a player.
         if (meta.isEmpty())
         {
             return;
         }
 
         UUID itemOwnerId = (UUID) meta.get(0).value();
+        // Determine if the owner has unlocked their dropped items.
+        // This first requires that the player is logged in.
         if (Bukkit.getServer().getPlayer(itemOwnerId) != null)
         {
             PlayerData itemOwner = dataStore.getPlayerData(itemOwnerId);
+            // If locked, don't allow pickup
             if (!itemOwner.dropsAreUnlocked)
             {
                 event.setCancelled(true);

--- a/src/test/java/me/ryanhamshire/GriefPrevention/BlockEventHandlerTest.java
+++ b/src/test/java/me/ryanhamshire/GriefPrevention/BlockEventHandlerTest.java
@@ -1,0 +1,103 @@
+package me.ryanhamshire.GriefPrevention;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryPickupItemEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class BlockEventHandlerTest
+{
+    private static final UUID PLAYER_UUID = UUID.fromString("fa8d60a7-9645-4a9f-b74d-173966174739");
+
+    @Test
+    void verifyNormalHopperPassthrough()
+    {
+        // Verify that we don't cancel events for unprotected items.
+
+        Item item = mock(Item.class);
+        Inventory inventory = mock(Inventory.class);
+        InventoryPickupItemEvent event = mock(InventoryPickupItemEvent.class);
+        when(item.getMetadata("GP_ITEMOWNER")).thenReturn(List.of());
+        when(inventory.getType()).thenReturn(InventoryType.HOPPER);
+        when(event.getItem()).thenReturn(item);
+        when(event.getInventory()).thenReturn(inventory);
+        BlockEventHandler handler = new BlockEventHandler(null);
+
+        handler.onInventoryPickupItem(event);
+
+        verify(event, never()).setCancelled(true);
+    }
+
+    @Test
+    void verifyNoHopperPassthroughWhenItemIsProtected()
+    {
+        // Verify that we DO cancel events for items that are protected.
+
+        Item item = mock(Item.class);
+        when(item.getMetadata("GP_ITEMOWNER"))
+                .thenReturn(List.of(new FixedMetadataValue(mock(Plugin.class), PLAYER_UUID)));
+        Inventory inventory = mock(Inventory.class);
+        when(inventory.getType()).thenReturn(InventoryType.HOPPER);
+        DataStore dataStore = mock(DataStore.class);
+        when(dataStore.getPlayerData(PLAYER_UUID)).thenReturn(new PlayerData());
+        BlockEventHandler handler = new BlockEventHandler(dataStore);
+        InventoryPickupItemEvent event = mock(InventoryPickupItemEvent.class);
+        when(event.getInventory()).thenReturn(inventory);
+        when(event.getItem()).thenReturn(item);
+        Server server = mock(Server.class);
+        when(server.getPlayer(PLAYER_UUID)).thenReturn(mock(Player.class));
+
+        try (var bukkit = mockStatic(Bukkit.class))
+        {
+            bukkit.when(Bukkit::getServer).thenReturn(server);
+
+            handler.onInventoryPickupItem(event);
+        }
+
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    void verifyHopperPassthroughWhenItemIsProtectedButOwnerIsOffline()
+    {
+        // Verify that we don't cancel events for items that are protected, but where
+        // the owner of those items is not logged in.
+        // This behaviour matches older versions of GriefPrevention.
+
+        Item item = mock(Item.class);
+        when(item.getMetadata("GP_ITEMOWNER"))
+                .thenReturn(List.of(new FixedMetadataValue(mock(Plugin.class), PLAYER_UUID)));
+        Inventory inventory = mock(Inventory.class);
+        when(inventory.getType()).thenReturn(InventoryType.HOPPER);
+        BlockEventHandler handler = new BlockEventHandler(null);
+        InventoryPickupItemEvent event = mock(InventoryPickupItemEvent.class);
+        when(event.getInventory()).thenReturn(inventory);
+        when(event.getItem()).thenReturn(item);
+        Server server = mock(Server.class);
+        when(server.getPlayer(PLAYER_UUID)).thenReturn(null);
+
+        try (var bukkit = mockStatic(Bukkit.class))
+        {
+            bukkit.when(Bukkit::getServer).thenReturn(server);
+
+            handler.onInventoryPickupItem(event);
+        }
+
+        verify(event, never()).setCancelled(true);
+    }
+}


### PR DESCRIPTION
See [RazielMartelus96's thread on SpigotMC](https://www.spigotmc.org/threads/why-items-with-lots-of-metadata-actually-cause-lag-an-inventoryholder-psa.607711/) for discussion related to use of `Inventory.getHolder()`.

### TL;DR

`Inventory.getHolder()` return state snapshots, and this can be very slow for items that hold a lot of NBT data, like shulker boxes or custom items.

GriefPrevention has a single call to this method:
https://github.com/TechFortress/GriefPrevention/blob/a8d55dbdcef13acad59fa5d14c77cd291ebaf830/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java#L1105-L1106

... and it's not needed.


### Testing

Using the following code:
```java
GriefPrevention.instance.getLogger().info("-".repeat(25));
GriefPrevention.instance.getLogger().info("Item: " + event.getItem().getName());
GriefPrevention.instance.getLogger().info("hashCode: " + System.identityHashCode(event.getInventory().getHolder()));
GriefPrevention.instance.getLogger().info("hashCode: " + System.identityHashCode(event.getInventory().getHolder()));
```

Then dropping a protected item spawned with:
```java
@EventHandler
void onItemSpawn(ItemSpawnEvent event)
{
    event.getEntity().setMetadata("GP_ITEMOWNER", new FixedMetadataValue(GriefPrevention.instance,
        UUID.fromString("<UUID OF AN ONLINE PLAYER - YOU!?>")));
}
```

Will reveal that different instances are indeed given for subsequent calls:
```
[02:05:02 INFO]: [GriefPrevention] -------------------------
[02:05:02 INFO]: [GriefPrevention] Item: Iron Trapdoor
[02:05:02 INFO]: [GriefPrevention] hashCode: 1407605097
[02:05:02 INFO]: [GriefPrevention] hashCode: 522167492
[02:05:02 INFO]: [GriefPrevention] -------------------------
[02:05:02 INFO]: [GriefPrevention] Item: Cyan Shulker Box
[02:05:02 INFO]: [GriefPrevention] hashCode: 2098715974
[02:05:02 INFO]: [GriefPrevention] hashCode: 692044206
[02:05:02 INFO]: [GriefPrevention] -------------------------
[02:05:02 INFO]: [GriefPrevention] Item: Iron Trapdoor
[02:05:02 INFO]: [GriefPrevention] hashCode: 1223944433
[02:05:02 INFO]: [GriefPrevention] hashCode: 715676847
[02:05:02 INFO]: [GriefPrevention] -------------------------
[02:05:02 INFO]: [GriefPrevention] Item: Cyan Shulker Box
[02:05:02 INFO]: [GriefPrevention] hashCode: 1763068241
[02:05:02 INFO]: [GriefPrevention] hashCode: 1047775084
```

### Solution

Simply change the GriefPrevention code referenced above to this:
```java
if (event.getInventory().getType() == InventoryType.HOPPER)
```

This PR tidies up the related code, and as a result is not a one-line change.

In addition to the screenshot below proving behaviour is unchanged, there are also some tests included with the same intent. Feel free to omit those, if you don't want to add the approx. 2 second increase in build time Mockito adds.


![image](https://github.com/TechFortress/GriefPrevention/assets/1390631/41269c92-fb0f-48ba-a1f1-631b2a7a0895)
