### PR TITLE
Don't use global firespread rules for wilderness TNT ignition

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -245,14 +245,6 @@ public class EntityEventHandler implements Listener
         // Wilderness rules
         if (claim == null)
         {
-            // TNT change means ignition. If no claim is present, use global fire rules.
-            if (block.getType() == Material.TNT)
-            {
-                if (!GriefPrevention.instance.config_fireDestroys || !GriefPrevention.instance.config_fireSpreads)
-                    event.setCancelled(true);
-                return;
-            }
-
             // No modification in the wilderness in creative mode.
             if (instance.creativeRulesApply(block.getLocation()) || instance.config_claims_worldModes.get(block.getWorld()) == ClaimsMode.SurvivalRequiringClaims)
             {


### PR DESCRIPTION
#2042

Per our findings there, GP has never updated to account for Minecraft adding the ability to ignite TNT with flaming arrows in Minecraft 1.3.