### PR TITLE
Improve sign interaction handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.17-R0.1-SNAPSHOT</version>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- Worldguard dependency -->

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -61,6 +61,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -3697,7 +3698,7 @@ public class GriefPrevention extends JavaPlugin
         else
         {
             BanList bans = Bukkit.getServer().getBanList(Type.NAME);
-            bans.addBan(player.getName(), reason, null, source);
+            bans.addBan(player.getName(), reason, (Date) null, source);
 
             //kick
             if (player.isOnline())

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1159,7 +1159,7 @@ class PlayerEventHandler implements Listener
     }
 
     //when a player interacts with a specific part of entity...
-    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
     public void onPlayerInteractAtEntity(PlayerInteractAtEntityEvent event)
     {
         //treat it the same as interacting with an entity in general
@@ -1170,7 +1170,7 @@ class PlayerEventHandler implements Listener
     }
 
     //when a player interacts with an entity...
-    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
     public void onPlayerInteractEntity(PlayerInteractEntityEvent event)
     {
         Player player = event.getPlayer();
@@ -1610,7 +1610,7 @@ class PlayerEventHandler implements Listener
     }
 
     //when a player interacts with the world
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.LOW)
     void onPlayerInteract(PlayerInteractEvent event)
     {
         //not interested in left-click-on-air actions


### PR DESCRIPTION
* Preserves improved UX for 1.20 vanilla behavior where sign is opened on right click
  * Denial is done immediately and UI is not opened rather than deny post-edit
* Improves compatibility with other plugins
  * No longer blanket cancelling interaction should make it easier for sign-based shops etc. to operate
    * Does not address GP messages with items that have vanilla behaviors GP needs to block. These plugins should look to update their handling to make it clearer that the vanilla interaction will not occur.
  * Increasing listener priority gives other plugins a chance to register their listeners before GP's

While this does require us to compile against 1.20.1, it should still be compatible with 1.17 because Bukkit handles non-existent events by logging the attempt at registration and moving on. This will result in a harmless warning on startup for older versions.

Closes #2134 
Closes #2085 