### PR TITLE
Separate Permission Nodes for Eavesdrop

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -179,13 +179,13 @@ public class BlockEventHandler implements Listener
             PlayerEventHandler.makeSocialLogEntry(player.getName(), signMessage);
             //playerData.lastSignMessage = signMessage;
 
-            if (!player.hasPermission("griefprevention.eavesdropsigns"))
+            if (!player.hasPermission("griefprevention.eavesdrop.signs"))
             {
                 @SuppressWarnings("unchecked")
                 Collection<Player> players = (Collection<Player>) GriefPrevention.instance.getServer().getOnlinePlayers();
                 for (Player otherPlayer : players)
                 {
-                    if (otherPlayer.hasPermission("griefprevention.eavesdropsigns"))
+                    if (otherPlayer.hasPermission("griefprevention.eavesdrop.signs"))
                     {
                         otherPlayer.sendMessage(ChatColor.GRAY + player.getName() + signMessage);
                     }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -191,7 +191,7 @@ class PlayerEventHandler implements Listener
                 {
                     recipientsToKeep.add(recipient);
                 }
-                else if (recipient.hasPermission("griefprevention.eavesdrop"))
+                else if (recipient.hasPermission("griefprevention.eavesdrop.messages.public"))
                 {
                     recipient.sendMessage(ChatColor.GRAY + notificationMessage);
                 }
@@ -209,7 +209,7 @@ class PlayerEventHandler implements Listener
             String notificationMessage = "(Muted " + player.getName() + "): " + message;
             for (Player recipient : recipients)
             {
-                if (recipient.hasPermission("griefprevention.eavesdrop"))
+                if (recipient.hasPermission("griefprevention.eavesdrop.messages.public"))
                 {
                     recipient.sendMessage(ChatColor.GRAY + notificationMessage);
                 }
@@ -436,10 +436,10 @@ class PlayerEventHandler implements Listener
             }
 
             //if eavesdrop enabled and sender doesn't have the eavesdrop immunity permission, eavesdrop
-            if (instance.config_whisperNotifications && !player.hasPermission("griefprevention.eavesdropimmune"))
+            if (instance.config_whisperNotifications && !player.hasPermission("griefprevention.eavesdrop.immune"))
             {
                 //except for when the recipient has eavesdrop immunity
-                if (targetPlayer == null || !targetPlayer.hasPermission("griefprevention.eavesdropimmune"))
+                if (targetPlayer == null || !targetPlayer.hasPermission("griefprevention.eavesdrop.immune"))
                 {
                     StringBuilder logMessageBuilder = new StringBuilder();
                     logMessageBuilder.append("[[").append(event.getPlayer().getName()).append("]] ");
@@ -455,7 +455,7 @@ class PlayerEventHandler implements Listener
                     Collection<Player> players = (Collection<Player>) instance.getServer().getOnlinePlayers();
                     for (Player onlinePlayer : players)
                     {
-                        if (onlinePlayer.hasPermission("griefprevention.eavesdrop") && !onlinePlayer.equals(targetPlayer) && !onlinePlayer.equals(player))
+                        if (onlinePlayer.hasPermission("griefprevention.eavesdrop.messages.private") && !onlinePlayer.equals(targetPlayer) && !onlinePlayer.equals(player))
                         {
                             onlinePlayer.sendMessage(ChatColor.GRAY + logMessage);
                         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -297,14 +297,6 @@ permissions:
     griefprevention.lava:
         description: Grants permission to place lava near the surface and outside of claims.
         default: op
-    griefprevention.eavesdrop.*:
-        description: Allows a player to see signs, whispered chat messages (/tell) and softmuted messages.
-        default: op
-        children:
-            griefprevention.eavesdrop.messages.public: true
-            griefprevention.eavesdrop.messages.private: true
-            griefprevention.eavesdrop.signs: true
-            griefprevention.eavesdrop.immune: false
     griefprevention.eavesdrop.messages.*:
         description: Allows a player to see whispered chat messages (/tell) and softmuted messages.
         default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -297,10 +297,27 @@ permissions:
     griefprevention.lava:
         description: Grants permission to place lava near the surface and outside of claims.
         default: op
-    griefprevention.eavesdrop:
+    griefprevention.eavesdrop.*:
+        description: Allows a player to see signs, whispered chat messages (/tell) and softmuted messages.
+        default: op
+        children:
+            griefprevention.eavesdrop.messages.public: true
+            griefprevention.eavesdrop.messages.private: true
+            griefprevention.eavesdrop.signs: true
+            griefprevention.eavesdrop.immune: false
+    griefprevention.eavesdrop.messages.*:
         description: Allows a player to see whispered chat messages (/tell) and softmuted messages.
         default: op
-    griefprevention.eavesdropsigns:
+        children:
+            griefprevention.eavesdrop.messages.public: true
+            griefprevention.eavesdrop.messages.private: true
+    griefprevention.eavesdrop.messages.public:
+        description: Allows a player to see softmuted messages.
+        default: op
+    griefprevention.eavesdrop.messages.private:
+        description: Allows a player to see whispered chat messages (/tell)
+        default: op
+    griefprevention.eavesdrop.signs:
         description: Allows a player to see sign placements as chat messages.
         default: op
     griefprevention.restorenatureaggressive:
@@ -348,7 +365,7 @@ permissions:
     griefprevention.seeinactivity:
         description: Players with this permission can see how long a claim owner has been offline.
         default: op
-    griefprevention.eavesdropimmune:
+    griefprevention.eavesdrop.immune:
         description: Players with this permission can't have their private messages eavesdropped.
         default: op
     griefprevention.siegeteleport:


### PR DESCRIPTION
Separated Eavesdrop into a different categories

Signs
Messages (Private and Public)
Immune

Immune is set to false for eavesdrop.* by default incase if the server wants it to be an admin only feature.

Closes #38 
Closes #1644

Will keep it as a draft as I haven't been able to test it on a live server.