### PR TITLE
Update api-version to required minimum

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: me.ryanhamshire.GriefPrevention.GriefPrevention
 softdepend: [Vault, Multiverse-Core, My_Worlds, MystCraft, Transporter, WorldGuard, WorldEdit, RoyalCommands, MultiWorld, Denizen, CommandHelper]
 dev-url: https://dev.bukkit.org/projects/grief-prevention
 version: '${git.commit.id.describe}'
-api-version: '1.17'
+api-version: '1.19'
 commands:
     abandonclaim:
       description: Deletes a claim.


### PR DESCRIPTION
Recent commit uses decorated pots, which were added as a 1.20 preview feature in 1.19.4.