### PR TITLE
Fix listener registration on older servers

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -368,6 +368,12 @@ public class GriefPrevention extends JavaPlugin
         //player events
         playerEventHandler = new PlayerEventHandler(this.dataStore, this);
         pluginManager.registerEvents(playerEventHandler, this);
+        try {
+            Class.forName("org.bukkit.event.player.PlayerSignOpenEvent");
+            pluginManager.registerEvents(new PlayerSignOpenHandler(this), this);
+        } catch (ClassNotFoundException ignored) {
+            // Event is not present in this version, don't attempt to register events and cause a log warning.
+        }
 
         //block events
         BlockEventHandler blockEventHandler = new BlockEventHandler(this.dataStore);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -368,10 +368,13 @@ public class GriefPrevention extends JavaPlugin
         //player events
         playerEventHandler = new PlayerEventHandler(this.dataStore, this);
         pluginManager.registerEvents(playerEventHandler, this);
-        try {
+        try
+        {
             Class.forName("org.bukkit.event.player.PlayerSignOpenEvent");
             pluginManager.registerEvents(new PlayerSignOpenHandler(this), this);
-        } catch (ClassNotFoundException ignored) {
+        }
+        catch (ClassNotFoundException ignored)
+        {
             // Event is not present in this version, don't attempt to register events and cause a log warning.
         }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -80,7 +80,6 @@ import org.bukkit.event.player.PlayerLoginEvent.Result;
 import org.bukkit.event.player.PlayerPortalEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
-import org.bukkit.event.player.PlayerSignOpenEvent;
 import org.bukkit.event.player.PlayerTakeLecternBookEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -92,7 +91,6 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.BlockIterator;
-import org.jetbrains.annotations.NotNull;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -1598,28 +1596,6 @@ class PlayerEventHandler implements Listener
             bucketEvent.setCancelled(true);
             return;
         }
-    }
-
-    @EventHandler(priority = EventPriority.LOW)
-    void onPlayerSignOpen(@NotNull PlayerSignOpenEvent event)
-    {
-        if (event.getCause() != PlayerSignOpenEvent.Cause.INTERACT || event.getSign().getBlock().getType() != event.getSign().getType())
-        {
-            // If the sign is not opened by interaction or the corresponding block is no longer a sign,
-            // it is either the initial sign placement or another plugin is at work. Do not interfere.
-            return;
-        }
-
-        Player player = event.getPlayer();
-        String denial = instance.allowBuild(player, event.getSign().getLocation(), event.getSign().getType());
-
-        // If user is allowed to build, do nothing.
-        if (denial == null)
-            return;
-
-        // If user is not allowed to build, prevent sign UI opening and send message.
-        GriefPrevention.sendMessage(player, TextMode.Err, denial);
-        event.setCancelled(true);
     }
 
     //when a player interacts with the world

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerSignOpenHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerSignOpenHandler.java
@@ -1,0 +1,41 @@
+package me.ryanhamshire.GriefPrevention;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerSignOpenEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class PlayerSignOpenHandler implements Listener
+{
+
+    private final GriefPrevention instance;
+
+    PlayerSignOpenHandler(@NotNull GriefPrevention plugin) {
+        this.instance = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.LOW)
+    void onPlayerSignOpen(@NotNull PlayerSignOpenEvent event)
+    {
+        if (event.getCause() != PlayerSignOpenEvent.Cause.INTERACT || event.getSign().getBlock().getType() != event.getSign().getType())
+        {
+            // If the sign is not opened by interaction or the corresponding block is no longer a sign,
+            // it is either the initial sign placement or another plugin is at work. Do not interfere.
+            return;
+        }
+
+        Player player = event.getPlayer();
+        String denial = instance.allowBuild(player, event.getSign().getLocation(), event.getSign().getType());
+
+        // If user is allowed to build, do nothing.
+        if (denial == null)
+            return;
+
+        // If user is not allowed to build, prevent sign UI opening and send message.
+        GriefPrevention.sendMessage(player, TextMode.Err, denial);
+        event.setCancelled(true);
+    }
+
+}

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerSignOpenHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerSignOpenHandler.java
@@ -12,7 +12,8 @@ public class PlayerSignOpenHandler implements Listener
 
     private final GriefPrevention instance;
 
-    PlayerSignOpenHandler(@NotNull GriefPrevention plugin) {
+    PlayerSignOpenHandler(@NotNull GriefPrevention plugin)
+    {
         this.instance = plugin;
     }
 


### PR DESCRIPTION
Also should make the logs prettier by not attempting to register the listener if the event is not available.

Fixes #2190 