### PR TITLE
Improve name lookups

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1703,6 +1703,7 @@ public abstract class DataStore
         this.addDefault(defaults, Messages.NoContainersSiege, "This claim is under siege by {0}.  No one can access containers here right now.", "0: attacker name");
         this.addDefault(defaults, Messages.NoContainersPermission, "You don't have {0}'s permission to use that.", "0: owner's name.  containers also include crafting blocks");
         this.addDefault(defaults, Messages.OwnerNameForAdminClaims, "an administrator", "as in 'You don't have an administrator's permission to build here.'");
+        this.addDefault(defaults, Messages.UnknownPlayerName, "someone", "Name used for unknown players. UUID will be appended if available: \"someone (01234567-0123-0123-0123-0123456789ab)\"");
         this.addDefault(defaults, Messages.ClaimTooSmallForEntities, "This claim isn't big enough for that.  Try enlarging it.", null);
         this.addDefault(defaults, Messages.TooManyEntitiesInClaim, "This claim has too many entities already.  Try enlarging the claim or removing some animals, monsters, paintings, or minecarts.", null);
         this.addDefault(defaults, Messages.YouHaveNoClaims, "You don't have any land claims.", null);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
@@ -159,6 +159,7 @@ public enum Messages
     NoContainersSiege,
     NoContainersPermission,
     OwnerNameForAdminClaims,
+    UnknownPlayerName,
     ClaimTooSmallForEntities,
     TooManyEntitiesInClaim,
     YouHaveNoClaims,


### PR DESCRIPTION
* Add uuid -> name cache
* Add translation key for "someone (UUID)"

I did also check that `CraftServer#getOfflinePlayer(UUID)` will prioritize returning a Player if available, so we don't need to add more logic to improve lookups in the event that users are online.

Closes #2212 

/e: Only thing I wasn't sure about was using a Guava cache. Figure that we want to keep the names in memory for a while in case of repeated access, and that seems like the easiest way to do it. CraftServer uses WeakReferences for loaded OfflinePlayers, but that clearly isn't enough to save us from ourselves. The old 30 day limit was used to keep GP from storing too much data when it maintained its own list and loaded that into memory, if I recall correctly. A 5 minute duration since last access seemed like a decent compromise.