### PR TITLE
supports 1.20.4 GRASS -> SHORT_GRASS rename in enums

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <version>1.20.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- Vault dependency -->

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -410,7 +410,7 @@ public class BlockEventHandler implements Listener
         else if (Tag.SAPLINGS.isTagged(block.getType()) && GriefPrevention.instance.config_blockSkyTrees && GriefPrevention.instance.claimsEnabledForWorld(player.getWorld()))
         {
             Block earthBlock = placeEvent.getBlockAgainst();
-            if (earthBlock.getType() != Material.GRASS)
+            if (earthBlock.getType() != Material.SHORT_GRASS)
             {
                 if (earthBlock.getRelative(BlockFace.DOWN).getType() == Material.AIR ||
                         earthBlock.getRelative(BlockFace.DOWN).getRelative(BlockFace.DOWN).getType() == Material.AIR)

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -717,7 +717,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_siege_blocks = new HashSet<>();
         this.config_siege_blocks.add(Material.DIRT);
         this.config_siege_blocks.add(Material.GRASS_BLOCK);
-        this.config_siege_blocks.add(Material.GRASS);
+        this.config_siege_blocks.add(Material.SHORT_GRASS);
         this.config_siege_blocks.add(Material.FERN);
         this.config_siege_blocks.add(Material.DEAD_BUSH);
         this.config_siege_blocks.add(Material.COBBLESTONE);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -2174,7 +2174,7 @@ class PlayerEventHandler implements Listener
                 }
                 else
                 {
-                    allowedFillBlocks.add(Material.GRASS);
+                    allowedFillBlocks.add(Material.SHORT_GRASS);
                     allowedFillBlocks.add(Material.DIRT);
                     allowedFillBlocks.add(Material.STONE);
                     allowedFillBlocks.add(Material.SAND);
@@ -2238,7 +2238,7 @@ class PlayerEventHandler implements Listener
                             }
 
                             //only replace air, spilling water, snow, long grass
-                            if (block.getType() == Material.AIR || block.getType() == Material.SNOW || (block.getType() == Material.WATER && ((Levelled) block.getBlockData()).getLevel() != 0) || block.getType() == Material.GRASS)
+                            if (block.getType() == Material.AIR || block.getType() == Material.SNOW || (block.getType() == Material.WATER && ((Levelled) block.getBlockData()).getLevel() != 0) || block.getType() == Material.SHORT_GRASS)
                             {
                                 //if the top level, always use the default filler picked above
                                 if (y == maxHeight)
@@ -2650,7 +2650,7 @@ class PlayerEventHandler implements Listener
             Material type = result.getType();
             if (type != Material.AIR &&
                     (!passThroughWater || type != Material.WATER) &&
-                    type != Material.GRASS &&
+                    type != Material.SHORT_GRASS &&
                     type != Material.SNOW) return result;
         }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/RestoreNatureProcessingTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/RestoreNatureProcessingTask.java
@@ -95,7 +95,7 @@ class RestoreNatureProcessingTask implements Runnable
 
         this.notAllowedToHang = new HashSet<>();
         this.notAllowedToHang.add(Material.DIRT);
-        this.notAllowedToHang.add(Material.GRASS);
+        this.notAllowedToHang.add(Material.SHORT_GRASS);
         this.notAllowedToHang.add(Material.SNOW);
         this.notAllowedToHang.add(Material.OAK_LOG);
         this.notAllowedToHang.add(Material.SPRUCE_LOG);
@@ -106,7 +106,7 @@ class RestoreNatureProcessingTask implements Runnable
 
         if (this.aggressiveMode)
         {
-            this.notAllowedToHang.add(Material.GRASS);
+            this.notAllowedToHang.add(Material.SHORT_GRASS);
             this.notAllowedToHang.add(Material.STONE);
         }
 
@@ -395,7 +395,7 @@ class RestoreNatureProcessingTask implements Runnable
         Material[] excludedBlocksArray = new Material[]
                 {
                         Material.CACTUS,
-                        Material.GRASS,
+                        Material.SHORT_GRASS,
                         Material.RED_MUSHROOM,
                         Material.BROWN_MUSHROOM,
                         Material.DEAD_BUSH,
@@ -483,10 +483,10 @@ class RestoreNatureProcessingTask implements Runnable
         fillableBlocks.add(Material.AIR);
         fillableBlocks.add(Material.WATER);
         fillableBlocks.add(Material.LAVA);
-        fillableBlocks.add(Material.GRASS);
+        fillableBlocks.add(Material.SHORT_GRASS);
 
         ArrayList<Material> notSuitableForFillBlocks = new ArrayList<>();
-        notSuitableForFillBlocks.add(Material.GRASS);
+        notSuitableForFillBlocks.add(Material.SHORT_GRASS);
         notSuitableForFillBlocks.add(Material.CACTUS);
         notSuitableForFillBlocks.add(Material.WATER);
         notSuitableForFillBlocks.add(Material.LAVA);


### PR DESCRIPTION
In the recent mc update the id of GRASS was renamed to SHORT_GRASS. 
This change also requires to bump the minimum supported version to 1.20.4

This build will error since this doesn't fix the EntityDamageByEntityEvent from [#2214](https://github.com/GriefPrevention/GriefPrevention/issues/2214)