### PR TITLE
Add bar graph for claim modes

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/metrics/MetricsHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/metrics/MetricsHandler.java
@@ -5,8 +5,6 @@ import me.ryanhamshire.GriefPrevention.GriefPrevention;
 import org.bukkit.World;
 
 import java.util.concurrent.Callable;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Created on 9/22/2018.
@@ -110,13 +108,17 @@ public class MetricsHandler
         //siege
         addSimplePie("uses_siege", !plugin.config_siege_enabledWorlds.isEmpty());
 
-        metrics.addCustomChart(new Metrics.SimpleBarChart(
-                "claim_modes",
-                () -> plugin.config_claims_worldModes.values().stream()
-                        .filter(mode -> mode != null && mode != ClaimsMode.Disabled)
-                        .distinct()
-                        .map(Enum::name)
-                        .collect(Collectors.groupingBy(Function.identity(), Collectors.summingInt(v -> 1)))));
+        // Which claims modes are actually used?
+        addSimplePie(
+                "uses_claims_survival",
+                () -> String.valueOf(plugin.config_claims_worldModes.values().stream().anyMatch(mode -> mode == ClaimsMode.Survival)));
+        addSimplePie(
+                "uses_claims_survival_req_claim",
+                () -> String.valueOf(plugin.config_claims_worldModes.values().stream().anyMatch(mode -> mode == ClaimsMode.SurvivalRequiringClaims)));
+        addSimplePie(
+                "uses_claims_creative",
+                () -> String.valueOf(plugin.config_claims_worldModes.values().stream().anyMatch(mode -> mode == ClaimsMode.Creative)));
+
     }
 
     private void addSimplePie(String id, boolean value)
@@ -126,13 +128,18 @@ public class MetricsHandler
 
     private void addSimplePie(String id, String value)
     {
-        metrics.addCustomChart(new Metrics.SimplePie(id, new Callable<String>()
+        addSimplePie(id, new Callable<String>()
         {
             @Override
             public String call() throws Exception
             {
                 return value;
             }
-        }));
+        });
+    }
+
+    private void addSimplePie(String id, Callable<String> callable)
+    {
+        metrics.addCustomChart(new Metrics.SimplePie(id, callable));
     }
 }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/metrics/MetricsHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/metrics/MetricsHandler.java
@@ -5,6 +5,8 @@ import me.ryanhamshire.GriefPrevention.GriefPrevention;
 import org.bukkit.World;
 
 import java.util.concurrent.Callable;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Created on 9/22/2018.
@@ -107,6 +109,14 @@ public class MetricsHandler
 
         //siege
         addSimplePie("uses_siege", !plugin.config_siege_enabledWorlds.isEmpty());
+
+        metrics.addCustomChart(new Metrics.SimpleBarChart(
+                "claim_modes",
+                () -> plugin.config_claims_worldModes.values().stream()
+                        .filter(mode -> mode != null && mode != ClaimsMode.Disabled)
+                        .distinct()
+                        .map(Enum::name)
+                        .collect(Collectors.groupingBy(Function.identity(), Collectors.summingInt(v -> 1)))));
     }
 
     private void addSimplePie(String id, boolean value)


### PR DESCRIPTION
Per discussion in #2229. Pretty sure you have to do something on the bstats side to enable the graph? It's been a while since I've used it though.

I filtered out `Disabled` because I figure we will have toggles to prevent GP features per-world as necessary in future state. Claim making can just be permission-based or something.

I figure total server count using 1+ of the claim mode is more useful information than an aggregate of total worlds. Can just delete the `Stream#distinct` call to modify that.