### PR TITLE
Fix blocks not landing in subclaims from parent

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -180,26 +180,25 @@ public class EntityEventHandler implements Listener
         }
 
         //sand cannon fix - when the falling block doesn't fall straight down, take additional anti-grief steps
-        else if (event.getEntityType() == EntityType.FALLING_BLOCK)
+        else if (event.getEntity() instanceof FallingBlock fallingBlock)
         {
-            FallingBlock entity = (FallingBlock) event.getEntity();
-            handleFallingBlockChangeBlock(event, entity);
+            handleFallingBlockChangeBlock(event, fallingBlock);
         }
     }
 
-    private void handleFallingBlockChangeBlock(EntityChangeBlockEvent event, FallingBlock entity)
+    private void handleFallingBlockChangeBlock(EntityChangeBlockEvent event, FallingBlock fallingBlock)
     {
         Block block = event.getBlock();
 
         //if changing a block TO air, this is when the falling block formed.  note its original location
         if (event.getTo() == Material.AIR)
         {
-            entity.setMetadata("GP_FALLINGBLOCK", new FixedMetadataValue(GriefPrevention.instance, block.getLocation()));
+            fallingBlock.setMetadata("GP_FALLINGBLOCK", new FixedMetadataValue(GriefPrevention.instance, block.getLocation()));
         }
         //otherwise, the falling block is forming a block.  compare new location to original source
         else
         {
-            List<MetadataValue> values = entity.getMetadata("GP_FALLINGBLOCK");
+            List<MetadataValue> values = fallingBlock.getMetadata("GP_FALLINGBLOCK");
             //if we're not sure where this entity came from (maybe another plugin didn't follow the standard?), allow the block to form
             //Or if entity fell through an end portal, allow it to form, as the event is erroneously fired twice in this scenario.
             if (values.size() < 1) return;
@@ -214,7 +213,7 @@ public class EntityEventHandler implements Listener
                 if (GriefPrevention.instance.config_claims_worldModes.get(newLocation.getWorld()) == ClaimsMode.Creative)
                 {
                     event.setCancelled(true);
-                    entity.remove();
+                    fallingBlock.remove();
                     return;
                 }
 
@@ -226,16 +225,16 @@ public class EntityEventHandler implements Listener
                     event.setCancelled(true);
 
                     // Just in case, skip already dead entities.
-                    if (entity.isDead())
+                    if (fallingBlock.isDead())
                     {
                         return;
                     }
 
                     // Remove entity so it doesn't continuously spawn drops.
-                    entity.remove();
+                    fallingBlock.remove();
 
-                    ItemStack itemStack = new ItemStack(entity.getBlockData().getMaterial(), 1);
-                    block.getWorld().dropItemNaturally(entity.getLocation(), itemStack);
+                    ItemStack itemStack = new ItemStack(fallingBlock.getBlockData().getMaterial(), 1);
+                    block.getWorld().dropItemNaturally(fallingBlock.getLocation(), itemStack);
                 }
             }
         }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -239,7 +239,15 @@ public class EntityEventHandler implements Listener
             return;
         }
 
+        // If the claim contains the formation point, allow block to form.
         if (claim.contains(originalLocation, false, false)) return;
+
+        // If the claim is an unrestricted subclaim and the block is from
+        // within the parent (but not another subclaim!) block may form.
+        if (claim.parent != null && !claim.getSubclaimRestrictions() && claim.parent.contains(originalLocation, false, true))
+        {
+            return;
+        }
 
         //when not allowed, drop as item instead of forming a block
         event.setCancelled(true);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -183,54 +183,59 @@ public class EntityEventHandler implements Listener
         else if (event.getEntityType() == EntityType.FALLING_BLOCK)
         {
             FallingBlock entity = (FallingBlock) event.getEntity();
-            Block block = event.getBlock();
+            handleFallingBlockChangeBlock(event, entity);
+        }
+    }
 
-            //if changing a block TO air, this is when the falling block formed.  note its original location
-            if (event.getTo() == Material.AIR)
+    private void handleFallingBlockChangeBlock(EntityChangeBlockEvent event, FallingBlock entity)
+    {
+        Block block = event.getBlock();
+
+        //if changing a block TO air, this is when the falling block formed.  note its original location
+        if (event.getTo() == Material.AIR)
+        {
+            entity.setMetadata("GP_FALLINGBLOCK", new FixedMetadataValue(GriefPrevention.instance, block.getLocation()));
+        }
+        //otherwise, the falling block is forming a block.  compare new location to original source
+        else
+        {
+            List<MetadataValue> values = entity.getMetadata("GP_FALLINGBLOCK");
+            //if we're not sure where this entity came from (maybe another plugin didn't follow the standard?), allow the block to form
+            //Or if entity fell through an end portal, allow it to form, as the event is erroneously fired twice in this scenario.
+            if (values.size() < 1) return;
+
+            Location originalLocation = (Location) (values.get(0).value());
+            Location newLocation = block.getLocation();
+
+            //if did not fall straight down
+            if (originalLocation.getBlockX() != newLocation.getBlockX() || originalLocation.getBlockZ() != newLocation.getBlockZ())
             {
-                entity.setMetadata("GP_FALLINGBLOCK", new FixedMetadataValue(GriefPrevention.instance, block.getLocation()));
-            }
-            //otherwise, the falling block is forming a block.  compare new location to original source
-            else
-            {
-                List<MetadataValue> values = entity.getMetadata("GP_FALLINGBLOCK");
-                //if we're not sure where this entity came from (maybe another plugin didn't follow the standard?), allow the block to form
-                //Or if entity fell through an end portal, allow it to form, as the event is erroneously fired twice in this scenario.
-                if (values.size() < 1) return;
-
-                Location originalLocation = (Location) (values.get(0).value());
-                Location newLocation = block.getLocation();
-
-                //if did not fall straight down
-                if (originalLocation.getBlockX() != newLocation.getBlockX() || originalLocation.getBlockZ() != newLocation.getBlockZ())
+                //in creative mode worlds, never form the block
+                if (GriefPrevention.instance.config_claims_worldModes.get(newLocation.getWorld()) == ClaimsMode.Creative)
                 {
-                    //in creative mode worlds, never form the block
-                    if (GriefPrevention.instance.config_claims_worldModes.get(newLocation.getWorld()) == ClaimsMode.Creative)
+                    event.setCancelled(true);
+                    entity.remove();
+                    return;
+                }
+
+                //in other worlds, if landing in land claim, only allow if source was also in the land claim
+                Claim claim = this.dataStore.getClaimAt(newLocation, false, null);
+                if (claim != null && !claim.contains(originalLocation, false, false))
+                {
+                    //when not allowed, drop as item instead of forming a block
+                    event.setCancelled(true);
+
+                    // Just in case, skip already dead entities.
+                    if (entity.isDead())
                     {
-                        event.setCancelled(true);
-                        entity.remove();
                         return;
                     }
 
-                    //in other worlds, if landing in land claim, only allow if source was also in the land claim
-                    Claim claim = this.dataStore.getClaimAt(newLocation, false, null);
-                    if (claim != null && !claim.contains(originalLocation, false, false))
-                    {
-                        //when not allowed, drop as item instead of forming a block
-                        event.setCancelled(true);
+                    // Remove entity so it doesn't continuously spawn drops.
+                    entity.remove();
 
-                        // Just in case, skip already dead entities.
-                        if (entity.isDead())
-                        {
-                            return;
-                        }
-
-                        // Remove entity so it doesn't continuously spawn drops.
-                        entity.remove();
-
-                        ItemStack itemStack = new ItemStack(entity.getBlockData().getMaterial(), 1);
-                        block.getWorld().dropItemNaturally(entity.getLocation(), itemStack);
-                    }
+                    ItemStack itemStack = new ItemStack(entity.getBlockData().getMaterial(), 1);
+                    block.getWorld().dropItemNaturally(entity.getLocation(), itemStack);
                 }
             }
         }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -226,28 +226,21 @@ public class EntityEventHandler implements Listener
         //in other worlds, if landing in land claim, only allow if source was also in the land claim
         Claim claim = this.dataStore.getClaimAt(blockLocation, false, null);
 
-        // If not landing in a claim...
-        if (claim == null)
+        // If landing in a claim...
+        if (claim != null)
         {
-            // Remove if claims are required.
-            if (claimsMode == ClaimsMode.SurvivalRequiringClaims)
+            // If the claim contains the formation point, allow block to form.
+            if (claim.contains(originalLocation, false, false)) return;
+
+            // If the claim is an unrestricted subclaim and the block is from
+            // within the parent (but not another subclaim!) block may form.
+            if (claim.parent != null && !claim.getSubclaimRestrictions() && claim.parent.contains(originalLocation, false, true))
             {
-                event.setCancelled(true);
-                fallingBlock.remove();
+                return;
             }
-            // Otherwise allow block to form.
-            return;
         }
-
-        // If the claim contains the formation point, allow block to form.
-        if (claim.contains(originalLocation, false, false)) return;
-
-        // If the claim is an unrestricted subclaim and the block is from
-        // within the parent (but not another subclaim!) block may form.
-        if (claim.parent != null && !claim.getSubclaimRestrictions() && claim.parent.contains(originalLocation, false, true))
-        {
-            return;
-        }
+        // If not landing in a claim and claims are not required, allow block to form.
+        else if (claimsMode == ClaimsMode.Survival) return;
 
         //when not allowed, drop as item instead of forming a block
         event.setCancelled(true);


### PR DESCRIPTION
* Extract FallingBlock handling to a separate method
  * Great modulization candidate, pretty sure this is the entirety of the code barring the removal of the tag when it end portals (which may not be necessary since handling was updated to only do drops if not removed)
* Fix checking for claims in disabled worlds
* Add new behavior where falling blocks that have moved horizontally are removed when landing outside of a claim in SurvivalRequiringClaims mode
  * I know claim modes are slated for removal, but this feels like a good feature to have as an option when this becomes a module.
* Fix falling blocks not landing in unrestricted subclaims when created in parent claim

Diff looks awful, but that's why I made separate commits for everything.

Closes #1975 