### PR TITLE
Fix inconsistencies with damage handling

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
@@ -4,10 +4,9 @@ import me.ryanhamshire.GriefPrevention.events.PreventPvPEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
-import org.bukkit.damage.DamageSource;
-import org.bukkit.damage.DamageType;
 import org.bukkit.entity.AnimalTamer;
 import org.bukkit.entity.Animals;
+import org.bukkit.entity.AreaEffectCloud;
 import org.bukkit.entity.Creature;
 import org.bukkit.entity.Donkey;
 import org.bukkit.entity.Entity;
@@ -31,10 +30,13 @@ import org.bukkit.entity.ThrownPotion;
 import org.bukkit.entity.Vex;
 import org.bukkit.entity.Zombie;
 import org.bukkit.entity.minecart.ExplosiveMinecart;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityCombustByEntityEvent;
+import org.bukkit.event.entity.EntityCombustEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
@@ -127,98 +129,30 @@ public class EntityDamageHandler implements Listener
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
     public void onEntityDamage(@NotNull EntityDamageEvent event)
     {
-        this.handleEntityDamageEvent(event, true);
+        this.handleEntityDamageEvent(new EntityDamageInstance(event), true);
     }
 
     //when an entity is set on fire
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
     public void onEntityCombustByEntity(@NotNull EntityCombustByEntityEvent event)
     {
-        this.handleEntityDamageEvent(event, false);
+        this.handleEntityDamageEvent(new EntityDamageInstance(event), false);
     }
 
-    private void handleEntityDamageEvent(@NotNull EntityCombustByEntityEvent event, boolean sendMessages)
+    private void handleEntityDamageEvent(@NotNull EntityDamageInstance event, boolean sendMessages)
     {
         //monsters are never protected
-        if (isHostile(event.getEntity())) return;
+        if (isHostile(event.damaged())) return;
 
         //horse protections can be disabled
-        if (event.getEntity() instanceof Horse && !instance.config_claims_protectHorses) return;
-        if (event.getEntity() instanceof Donkey && !instance.config_claims_protectDonkeys) return;
-        if (event.getEntity() instanceof Mule && !instance.config_claims_protectDonkeys) return;
-        if (event.getEntity() instanceof Llama && !instance.config_claims_protectLlamas) return;
+        if (event.damaged() instanceof Horse && !instance.config_claims_protectHorses) return;
+        if (event.damaged() instanceof Donkey && !instance.config_claims_protectDonkeys) return;
+        if (event.damaged() instanceof Mule && !instance.config_claims_protectDonkeys) return;
+        if (event.damaged() instanceof Llama && !instance.config_claims_protectLlamas) return;
         //protected death loot can't be destroyed, only picked up or despawned due to expiration
-        if (event.getEntityType() == EntityType.DROPPED_ITEM)
+        if (event.damaged().getType() == EntityType.DROPPED_ITEM)
         {
-            if (event.getEntity().hasMetadata("GP_ITEMOWNER"))
-            {
-                event.setCancelled(true);
-            }
-        }
-
-        // Handle environmental damage to tamed animals that could easily be caused maliciously.
-        if (handlePetDamageByEnvironment(event)) return;
-
-        if (event.getCombuster() instanceof LightningStrike && event.getCombuster().hasMetadata("GP_TRIDENT"))
-        {
-            event.setCancelled(true);
-            return;
-        }
-
-        //determine which player is attacking, if any
-        Player attacker = null;
-        Projectile arrow = null;
-        Entity damageSource = event.getCombuster();
-        if (damageSource instanceof Player damager)
-        {
-            attacker = damager;
-        }
-        else if (damageSource instanceof Projectile projectile)
-        {
-            arrow = projectile;
-            if (arrow.getShooter() instanceof Player shooter)
-            {
-                attacker = shooter;
-            }
-        }
-
-        // Specific handling for PVP-enabled situations.
-        if (instance.pvpRulesApply(event.getEntity().getWorld()))
-        {
-            if (event.getEntity() instanceof Player defender)
-            {
-                // Handle regular PVP with an attacker and defender.
-                if (attacker != null && handlePvpDamageByPlayer(event, attacker, defender, sendMessages))
-                {
-                    return;
-                }
-            }
-        }
-
-        //don't track in worlds where claims are not enabled
-        if (!instance.claimsEnabledForWorld(event.getEntity().getWorld())) return;
-
-        //if the damaged entity is a claimed item frame or armor stand, the damager needs to be a player with build trust in the claim
-        if (handleClaimedBuildTrustDamageByEntity(event, attacker, sendMessages)) return;
-
-        //if the entity is a non-monster creature (remember monsters disqualified above), or a vehicle
-        if (handleCreatureDamageByEntity(event, attacker, arrow, sendMessages)) return;
-    }
-
-    private void handleEntityDamageEvent(@NotNull EntityDamageEvent event, boolean sendMessages)
-    {
-        //monsters are never protected
-        if (isHostile(event.getEntity())) return;
-
-        //horse protections can be disabled
-        if (event.getEntity() instanceof Horse && !instance.config_claims_protectHorses) return;
-        if (event.getEntity() instanceof Donkey && !instance.config_claims_protectDonkeys) return;
-        if (event.getEntity() instanceof Mule && !instance.config_claims_protectDonkeys) return;
-        if (event.getEntity() instanceof Llama && !instance.config_claims_protectLlamas) return;
-        //protected death loot can't be destroyed, only picked up or despawned due to expiration
-        if (event.getEntityType() == EntityType.DROPPED_ITEM)
-        {
-            if (event.getEntity().hasMetadata("GP_ITEMOWNER"))
+            if (event.damaged().hasMetadata("GP_ITEMOWNER"))
             {
                 event.setCancelled(true);
             }
@@ -231,9 +165,9 @@ public class EntityDamageHandler implements Listener
         if (handleEntityDamageByBlockExplosion(event)) return;
 
         //the rest is only interested in entities damaging entities (ignoring environmental damage)
-        if (!(event instanceof EntityDamageByEntityEvent subEvent)) return;
+        if (event.damager() == null) return;
 
-        if (subEvent.getDamager() instanceof LightningStrike && subEvent.getDamager().hasMetadata("GP_TRIDENT"))
+        if (event.damager() instanceof LightningStrike && event.damager().hasMetadata("GP_TRIDENT"))
         {
             event.setCancelled(true);
             return;
@@ -242,7 +176,7 @@ public class EntityDamageHandler implements Listener
         //determine which player is attacking, if any
         Player attacker = null;
         Projectile arrow = null;
-        Entity damageSource = subEvent.getDamager();
+        Entity damageSource = event.damager();
         if (damageSource instanceof Player damager)
         {
             attacker = damager;
@@ -257,25 +191,25 @@ public class EntityDamageHandler implements Listener
         }
 
         // Specific handling for PVP-enabled situations.
-        if (instance.pvpRulesApply(event.getEntity().getWorld()))
+        if (instance.pvpRulesApply(event.damaged().getWorld()))
         {
-            if (event.getEntity() instanceof Player defender)
+            if (event.damaged() instanceof Player defender)
             {
                 // Protect players from other players' pets when protected from PVP.
-                if (handlePvpDamageByPet(subEvent, attacker, defender)) return;
+                if (handlePvpDamageByPet(event, attacker, defender)) return;
 
                 // Protect players from lingering splash potions when protected from PVP.
-                if (handlePvpDamageByLingeringPotion(subEvent, attacker, defender)) return;
+                if (handlePvpDamageByLingeringPotion(event, attacker, defender)) return;
 
                 // Handle regular PVP with an attacker and defender.
-                if (attacker != null && handlePvpDamageByPlayer(subEvent, attacker, defender, sendMessages))
+                if (attacker != null && handlePvpDamageByPlayer(event, attacker, defender, sendMessages))
                 {
                     return;
                 }
             }
-            else if (event.getEntity() instanceof Tameable tameable)
+            else if (event.damaged() instanceof Tameable tameable)
             {
-                if (attacker != null && handlePvpPetDamageByPlayer(subEvent, tameable, attacker, sendMessages))
+                if (attacker != null && handlePvpPetDamageByPlayer(event, tameable, attacker, sendMessages))
                 {
                     return;
                 }
@@ -283,13 +217,13 @@ public class EntityDamageHandler implements Listener
         }
 
         //don't track in worlds where claims are not enabled
-        if (!instance.claimsEnabledForWorld(event.getEntity().getWorld())) return;
+        if (!instance.claimsEnabledForWorld(event.damaged().getWorld())) return;
 
         //if the damaged entity is a claimed item frame or armor stand, the damager needs to be a player with build trust in the claim
-        if (handleClaimedBuildTrustDamageByEntity(subEvent, attacker, sendMessages)) return;
+        if (handleClaimedBuildTrustDamageByEntity(event, attacker, sendMessages)) return;
 
         //if the entity is a non-monster creature (remember monsters disqualified above), or a vehicle
-        if (handleCreatureDamageByEntity(subEvent, attacker, arrow, sendMessages)) return;
+        if (handleCreatureDamageByEntity(event, attacker, arrow, sendMessages)) return;
     }
 
     /**
@@ -327,19 +261,19 @@ public class EntityDamageHandler implements Listener
     /**
      * Handle damage to {@link Tameable} entities by environmental sources.
      *
-     * @param event the {@link EntityDamageEvent}
+     * @param event the {@link EntityDamageInstance}
      * @return true if the damage is handled
      */
-    private boolean handlePetDamageByEnvironment(@NotNull EntityDamageEvent event)
+    private boolean handlePetDamageByEnvironment(@NotNull EntityDamageInstance event)
     {
         // If PVP is enabled, the damaged entity is not a pet, or the pet has no owner, allow.
-        if (instance.pvpRulesApply(event.getEntity().getWorld())
-                || !(event.getEntity() instanceof Tameable tameable)
+        if (instance.pvpRulesApply(event.damaged().getWorld())
+                || !(event.damaged() instanceof Tameable tameable)
                 || !tameable.isTamed())
         {
             return false;
         }
-        switch (event.getCause())
+        switch (event.cause())
         {
             // Block environmental and easy-to-cause damage sources.
             case BLOCK_EXPLOSION,
@@ -361,29 +295,18 @@ public class EntityDamageHandler implements Listener
             }
         }
     }
-    private boolean handlePetDamageByEnvironment(@NotNull EntityCombustByEntityEvent event)
-    {
-        // If PVP is enabled, the damaged entity is not a pet, or the pet has no owner, allow.
-        if (instance.pvpRulesApply(event.getEntity().getWorld())
-                || !(event.getEntity() instanceof Tameable tameable)
-                || !tameable.isTamed())
-        {
-            return false;
-        }
-        return true;
-    }
 
     /**
      * Handle entity damage caused by block explosions.
      *
-     * @param event the {@link EntityDamageEvent}
+     * @param event the {@link EntityDamageInstance}
      * @return true if the damage is handled
      */
-    private boolean handleEntityDamageByBlockExplosion(@NotNull EntityDamageEvent event)
+    private boolean handleEntityDamageByBlockExplosion(@NotNull EntityDamageInstance event)
     {
-        if (event.getCause() != EntityDamageEvent.DamageCause.BLOCK_EXPLOSION) return false;
+        if (event.cause() != EntityDamageEvent.DamageCause.BLOCK_EXPLOSION) return false;
 
-        Entity entity = event.getEntity();
+        Entity entity = event.damaged();
 
         // Skip players - does allow players to use block explosions to bypass PVP protections,
         // but also doesn't disable self-damage.
@@ -404,17 +327,17 @@ public class EntityDamageHandler implements Listener
      * <p>For logical simplicity, this method does not check the state of the PVP rules. PVP rules should be confirmed
      * to be enabled before calling this method.
      *
-     * @param event the {@link EntityDamageByEntityEvent}
+     * @param event the {@link EntityDamageInstance}
      * @param attacker the attacking {@link Player}, if any
      * @param damaged the defending {@link Player}
      * @return true if the damage is handled
      */
     private boolean handlePvpDamageByLingeringPotion(
-            @NotNull EntityDamageByEntityEvent event,
+            @NotNull EntityDamageInstance event,
             @Nullable Player attacker,
             @NotNull Player damaged)
     {
-        if (event.getDamager().getType() != EntityType.AREA_EFFECT_CLOUD) return false;
+        if (!(event.damager() instanceof AreaEffectCloud)) return false;
 
         PlayerData damagedData = dataStore.getPlayerData(damaged.getUniqueId());
 
@@ -448,58 +371,14 @@ public class EntityDamageHandler implements Listener
     /**
      * General PVP handler.
      *
-     * @param event the {@link EntityDamageByEntityEvent}
+     * @param event the {@link EntityDamageInstance}
      * @param attacker the attacking {@link Player}
      * @param defender the defending {@link Player}
      * @param sendMessages whether to send denial messages to users involved
      * @return true if the damage is handled
      */
     private boolean handlePvpDamageByPlayer(
-            @NotNull EntityDamageByEntityEvent event,
-            @NotNull Player attacker,
-            @NotNull Player defender,
-            boolean sendMessages)
-    {
-        if (attacker == defender) return false;
-
-        PlayerData defenderData = this.dataStore.getPlayerData(defender.getUniqueId());
-        PlayerData attackerData = this.dataStore.getPlayerData(attacker.getUniqueId());
-
-        //FEATURE: prevent pvp in the first minute after spawn and when one or both players have no inventory
-        if (instance.config_pvp_protectFreshSpawns)
-        {
-            if (attackerData.pvpImmune || defenderData.pvpImmune)
-            {
-                event.setCancelled(true);
-                if (sendMessages)
-                    GriefPrevention.sendMessage(
-                            attacker,
-                            TextMode.Err,
-                            attackerData.pvpImmune ? Messages.CantFightWhileImmune : Messages.ThatPlayerPvPImmune);
-                return true;
-            }
-        }
-
-        //FEATURE: prevent players from engaging in PvP combat inside land claims (when it's disabled)
-        // Ignoring claims bypasses this feature.
-        if (attackerData.ignoreClaims
-                || !instance.config_pvp_noCombatInPlayerLandClaims
-                && !instance.config_pvp_noCombatInAdminLandClaims)
-        {
-            return false;
-        }
-        Consumer<Messages> cancelHandler = message ->
-        {
-            event.setCancelled(true);
-            if (sendMessages) GriefPrevention.sendMessage(attacker, TextMode.Err, message);
-        };
-        // Return whether PVP is handled by a claim at the attacker or defender's locations.
-        return handlePvpInClaim(attacker, defender, attacker.getLocation(), attackerData, () -> cancelHandler.accept(Messages.CantFightWhileImmune))
-                || handlePvpInClaim(attacker, defender, defender.getLocation(), defenderData, () -> cancelHandler.accept(Messages.PlayerInPvPSafeZone));
-    }
-
-    private boolean handlePvpDamageByPlayer(
-            @NotNull EntityCombustByEntityEvent event,
+            @NotNull EntityDamageInstance event,
             @NotNull Player attacker,
             @NotNull Player defender,
             boolean sendMessages)
@@ -545,16 +424,16 @@ public class EntityDamageHandler implements Listener
     /**
      * Handle PVP damage caused by an owned pet.
      *
-     * @param event the {@link EntityDamageByEntityEvent}
+     * @param event the {@link EntityDamageInstance}
      * @param attacker the attacking {@link Player}, if any
      * @return true if the damage is handled
      */
     private boolean handlePvpDamageByPet(
-            @NotNull EntityDamageByEntityEvent event,
+            @NotNull EntityDamageInstance event,
             @Nullable Player attacker,
             @NotNull Player defender)
     {
-        if (!(event.getDamager() instanceof Tameable pet) || !pet.isTamed() || pet.getOwner() == null) return false;
+        if (!(event.damager() instanceof Tameable pet) || !pet.isTamed() || pet.getOwner() == null) return false;
 
         PlayerData defenderData = dataStore.getPlayerData(defender.getUniqueId());
         Runnable cancelHandler = () ->
@@ -577,14 +456,14 @@ public class EntityDamageHandler implements Listener
     /**
      * Handle PVP damage to an owned pet.
      *
-     * @param event the {@link EntityDamageByEntityEvent}
+     * @param event the {@link EntityDamageInstance}
      * @param pet the potential pet being damaged
      * @param attacker the attacking {@link Player}
      * @param sendMessages whether to send denial messages to users involved
      * @return true if the damage is handled
      */
     private boolean handlePvpPetDamageByPlayer(
-            @NotNull EntityDamageByEntityEvent event,
+            @NotNull EntityDamageInstance event,
             @NotNull Tameable pet,
             @NotNull Player attacker,
             boolean sendMessages)
@@ -612,13 +491,13 @@ public class EntityDamageHandler implements Listener
         }
 
         // Wolves are exempt from pet protections in PVP worlds when their target is the attacker
-        if (event.getEntity().getType() == EntityType.WOLF && pet.getTarget() == attacker) return true;
+        if (event.damaged().getType() == EntityType.WOLF && pet.getTarget() == attacker) return true;
 
         Claim claim;
         // Note: Internal name is not descriptive. Actual node is "GriefPrevention.PVP.ProtectPetsOutsideLandClaims"
         if (!instance.config_pvp_protectPets)
         {
-            claim = dataStore.getClaimAt(event.getEntity().getLocation(), false, attackerData.lastClaim);
+            claim = dataStore.getClaimAt(event.damaged().getLocation(), false, attackerData.lastClaim);
             if (claim == null)
             {
                 // Pet is not in a claim, allow attack.
@@ -629,7 +508,7 @@ public class EntityDamageHandler implements Listener
         else
         {
             // Create a dummy claim to signify blanket pet protection.
-            claim = new Claim(event.getEntity().getLocation(), event.getEntity().getLocation(), null, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), null);
+            claim = new Claim(event.damaged().getLocation(), event.damaged().getLocation(), null, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), null);
         }
 
         PreventPvPEvent pvpEvent = new PreventPvPEvent(claim, attacker, pet);
@@ -688,17 +567,17 @@ public class EntityDamageHandler implements Listener
     /**
      * Handle actions requiring build trust.
      *
-     * @param event the {@link EntityDamageByEntityEvent}
+     * @param event the {@link EntityDamageInstance}
      * @param attacker the attacking {@link Player}, if any
      * @param sendMessages whether to send denial messages to users involved
      * @return true if the damage is handled
      */
     private boolean handleClaimedBuildTrustDamageByEntity(
-            @NotNull EntityDamageByEntityEvent event,
+            @NotNull EntityDamageInstance event,
             @Nullable Player attacker,
             boolean sendMessages)
     {
-        EntityType entityType = event.getEntityType();
+        EntityType entityType = event.damaged().getType();
         if (entityType != EntityType.ITEM_FRAME
                 && entityType != EntityType.GLOW_ITEM_FRAME
                 && entityType != EntityType.ARMOR_STAND
@@ -713,11 +592,11 @@ public class EntityDamageHandler implements Listener
                 && (!instance.config_claims_protectCreatures
                 // Always allow zombies and raids to target villagers.
                 //why exception?  so admins can set up a village which can't be CHANGED by players, but must be "protected" by players.
-                || event.getDamager() instanceof Zombie
-                || event.getDamager() instanceof Raider
-                || event.getDamager() instanceof Vex
-                || event.getDamager() instanceof Projectile projectile && projectile.getShooter() instanceof Raider
-                || event.getDamager() instanceof EvokerFangs fangs && fangs.getOwner() instanceof Raider))
+                || event.damager() instanceof Zombie
+                || event.damager() instanceof Raider
+                || event.damager() instanceof Vex
+                || event.damager() instanceof Projectile projectile && projectile.getShooter() instanceof Raider
+                || event.damager() instanceof EvokerFangs fangs && fangs.getOwner() instanceof Raider))
         {
             return true;
         }
@@ -730,7 +609,7 @@ public class EntityDamageHandler implements Listener
             cachedClaim = playerData.lastClaim;
         }
 
-        Claim claim = this.dataStore.getClaimAt(event.getEntity().getLocation(), false, cachedClaim);
+        Claim claim = this.dataStore.getClaimAt(event.damaged().getLocation(), false, cachedClaim);
 
         // If the area is not claimed, do not handle.
         if (claim == null) return false;
@@ -742,66 +621,7 @@ public class EntityDamageHandler implements Listener
             return true;
         }
 
-        Supplier<String> failureReason = claim.checkPermission(attacker, ClaimPermission.Build, event);
-
-        // If player has build trust, fall through to next checks.
-        if (failureReason == null) return false;
-
-        event.setCancelled(true);
-        if (sendMessages) GriefPrevention.sendMessage(attacker, TextMode.Err, failureReason.get());
-        return true;
-    }
-
-    private boolean handleClaimedBuildTrustDamageByEntity(
-            @NotNull EntityCombustByEntityEvent event,
-            @Nullable Player attacker,
-            boolean sendMessages)
-    {
-        EntityType entityType = event.getEntityType();
-        if (entityType != EntityType.ITEM_FRAME
-                && entityType != EntityType.GLOW_ITEM_FRAME
-                && entityType != EntityType.ARMOR_STAND
-                && entityType != EntityType.VILLAGER
-                && entityType != EntityType.ENDER_CRYSTAL)
-        {
-            return false;
-        }
-
-        if (entityType == EntityType.VILLAGER
-                // Allow disabling villager protections in the config.
-                && (!instance.config_claims_protectCreatures
-                // Always allow zombies and raids to target villagers.
-                //why exception?  so admins can set up a village which can't be CHANGED by players, but must be "protected" by players.
-                || event.getCombuster() instanceof Zombie
-                || event.getCombuster() instanceof Raider
-                || event.getCombuster() instanceof Vex
-                || event.getCombuster() instanceof Projectile projectile && projectile.getShooter() instanceof Raider
-                || event.getCombuster() instanceof EvokerFangs fangs && fangs.getOwner() instanceof Raider))
-        {
-            return true;
-        }
-
-        // Use attacker's cached claim to speed up lookup.
-        Claim cachedClaim = null;
-        if (attacker != null)
-        {
-            PlayerData playerData = this.dataStore.getPlayerData(attacker.getUniqueId());
-            cachedClaim = playerData.lastClaim;
-        }
-
-        Claim claim = this.dataStore.getClaimAt(event.getEntity().getLocation(), false, cachedClaim);
-
-        // If the area is not claimed, do not handle.
-        if (claim == null) return false;
-
-        // If attacker isn't a player, cancel.
-        if (attacker == null)
-        {
-            event.setCancelled(true);
-            return true;
-        }
-
-        Supplier<String> failureReason = claim.checkPermission(attacker, ClaimPermission.Build, event);
+        Supplier<String> failureReason = claim.checkPermission(attacker, ClaimPermission.Build, event.original());
 
         // If player has build trust, fall through to next checks.
         if (failureReason == null) return false;
@@ -815,25 +635,29 @@ public class EntityDamageHandler implements Listener
      * Handle damage to a {@link Creature} by an {@link Entity}. Because monsters are
      * already discounted, any qualifying entity is livestock or a pet.
      *
-     * @param event the {@link EntityDamageByEntityEvent}
+     * @param event the {@link EntityDamageInstance}
      * @param attacker the attacking {@link Player}, if any
      * @param arrow the {@link Projectile} dealing the damage, if any
      * @param sendMessages whether to send denial messages to users involved
      * @return true if the damage is handled
      */
     private boolean handleCreatureDamageByEntity(
-            @NotNull EntityDamageByEntityEvent event,
+            @NotNull EntityDamageInstance event,
             @Nullable Player attacker,
             @Nullable Projectile arrow,
             boolean sendMessages)
     {
-        if (!(event.getEntity() instanceof Creature) || !instance.config_claims_protectCreatures)
+        if (!(event.damaged() instanceof Creature) || !instance.config_claims_protectCreatures)
             return false;
 
         //if entity is tameable and has an owner, apply special rules
         if (handlePetDamageByEntity(event, attacker, sendMessages)) return true;
 
-        Entity damageSource = event.getDamager();
+        Entity damageSource = event.damager();
+
+        // Can't be hit, but for simplicity
+        if (damageSource == null) return false;
+
         EntityType damageSourceType = damageSource.getType();
         //if not a player, explosive, or ranged/area of effect attack, allow
         if (attacker == null
@@ -857,7 +681,7 @@ public class EntityDamageHandler implements Listener
             cachedClaim = playerData.lastClaim;
         }
 
-        Claim claim = this.dataStore.getClaimAt(event.getEntity().getLocation(), false, cachedClaim);
+        Claim claim = this.dataStore.getClaimAt(event.damaged().getLocation(), false, cachedClaim);
 
         // Require a claim to handle.
         if (claim == null) return false;
@@ -891,7 +715,7 @@ public class EntityDamageHandler implements Listener
         }
 
         // Check for permission to access containers.
-        Supplier<String> noContainersReason = claim.checkPermission(attacker, ClaimPermission.Inventory, event, override);
+        Supplier<String> noContainersReason = claim.checkPermission(attacker, ClaimPermission.Inventory, event.original(), override);
 
         // If player has permission, action is allowed.
         if (noContainersReason == null) return true;
@@ -899,89 +723,7 @@ public class EntityDamageHandler implements Listener
         event.setCancelled(true);
 
         // Prevent projectiles from bouncing infinitely.
-        preventInfiniteBounce(arrow, event.getEntity());
-
-        if (sendMessages) GriefPrevention.sendMessage(attacker, TextMode.Err, noContainersReason.get());
-
-        return true;
-    }
-
-    private boolean handleCreatureDamageByEntity(
-            @NotNull EntityCombustByEntityEvent event,
-            @Nullable Player attacker,
-            @Nullable Projectile arrow,
-            boolean sendMessages)
-    {
-        if (!(event.getEntity() instanceof Creature) || !instance.config_claims_protectCreatures)
-            return false;
-
-        Entity damageSource = event.getCombuster();
-        EntityType damageSourceType = damageSource.getType();
-        //if not a player, explosive, or ranged/area of effect attack, allow
-        if (attacker == null
-                && damageSourceType != EntityType.CREEPER
-                && damageSourceType != EntityType.WITHER
-                && damageSourceType != EntityType.ENDER_CRYSTAL
-                && damageSourceType != EntityType.AREA_EFFECT_CLOUD
-                && damageSourceType != EntityType.WITCH
-                && !(damageSource instanceof Projectile)
-                && !(damageSource instanceof Explosive)
-                && !(damageSource instanceof ExplosiveMinecart))
-        {
-            return true;
-        }
-
-        Claim cachedClaim = null;
-        PlayerData playerData = null;
-        if (attacker != null)
-        {
-            playerData = this.dataStore.getPlayerData(attacker.getUniqueId());
-            cachedClaim = playerData.lastClaim;
-        }
-
-        Claim claim = this.dataStore.getClaimAt(event.getEntity().getLocation(), false, cachedClaim);
-
-        // Require a claim to handle.
-        if (claim == null) return false;
-
-        // If damaged by anything other than a player, cancel the event.
-        if (attacker == null)
-        {
-            event.setCancelled(true);
-            // Always remove projectiles shot by non-players.
-            if (arrow != null) arrow.remove();
-            return true;
-        }
-
-        //cache claim for later
-        playerData.lastClaim = claim;
-
-        // Do not message players about fireworks to prevent spam due to multi-hits.
-        sendMessages &= damageSourceType != EntityType.FIREWORK;
-
-        Supplier<String> override = null;
-        if (sendMessages)
-        {
-            final Player finalAttacker = attacker;
-            override = () ->
-            {
-                String message = dataStore.getMessage(Messages.NoDamageClaimedEntity, claim.getOwnerName());
-                if (finalAttacker.hasPermission("griefprevention.ignoreclaims"))
-                    message += "  " + dataStore.getMessage(Messages.IgnoreClaimsAdvertisement);
-                return message;
-            };
-        }
-
-        // Check for permission to access containers.
-        Supplier<String> noContainersReason = claim.checkPermission(attacker, ClaimPermission.Inventory, event, override);
-
-        // If player has permission, action is allowed.
-        if (noContainersReason == null) return true;
-
-        event.setCancelled(true);
-
-        // Prevent projectiles from bouncing infinitely.
-        preventInfiniteBounce(arrow, event.getEntity());
+        preventInfiniteBounce(arrow, event.damaged());
 
         if (sendMessages) GriefPrevention.sendMessage(attacker, TextMode.Err, noContainersReason.get());
 
@@ -991,20 +733,20 @@ public class EntityDamageHandler implements Listener
     /**
      * Handle damage to a {@link Tameable} by a {@link Player}.
      *
-     * @param event the {@link EntityDamageByEntityEvent}
+     * @param event the {@link EntityDamageInstance}
      * @param attacker the attacking {@link Player}, if any
      * @param sendMessages whether to send denial messages to users involved
      * @return true if the damage is handled
      */
     private boolean handlePetDamageByEntity(
-            @NotNull EntityDamageByEntityEvent event,
+            @NotNull EntityDamageInstance event,
             @Nullable Player attacker,
             boolean sendMessages)
     {
-        if (!(event.getEntity() instanceof Tameable tameable) || !tameable.isTamed())
+        if (!(event.damaged() instanceof Tameable tameable) || !tameable.isTamed())
         {
             // If the animal is not owned, specifically allow attacks only if the animal is a wolf.
-            return event.getEntityType() == EntityType.WOLF;
+            return event.damaged().getType() == EntityType.WOLF;
         }
 
         AnimalTamer owner = tameable.getOwner();
@@ -1286,6 +1028,39 @@ public class EntityDamageHandler implements Listener
                     handlePvpInClaim(thrower, affectedPlayer, affectedPlayer.getLocation(), playerData, () -> cancelHandler.accept(Messages.PlayerInPvPSafeZone));
                 }
             }
+        }
+    }
+
+    private record EntityDamageInstance(
+            @NotNull Entity damaged,
+            @Nullable Entity damager,
+            @NotNull EntityDamageEvent.DamageCause cause,
+            @NotNull Event original)
+    {
+
+        EntityDamageInstance(@NotNull EntityDamageEvent event)
+        {
+            this(
+                    event.getEntity(),
+                    event instanceof EntityDamageByEntityEvent damageBy ? damageBy.getDamager() : null,
+                    event.getCause(),
+                    event
+            );
+        }
+
+        EntityDamageInstance(@NotNull EntityCombustEvent event)
+        {
+            this(
+                    event.getEntity(),
+                    event instanceof EntityCombustByEntityEvent combustBy ? combustBy.getCombuster() : null,
+                    EntityDamageEvent.DamageCause.FIRE_TICK,
+                    event
+            );
+        }
+
+        public void setCancelled(boolean cancelled)
+        {
+            if (this.original instanceof Cancellable cancellable) cancellable.setCancelled(cancelled);
         }
     }
 


### PR DESCRIPTION
De-duplicates code by using a wrapper for the bits of damage events we care about.

Noticed that the environmental check (which probably should be ignored there anyway as we're only listening to the EntityCombustByEntityEvent aka not environment) wasn't actually preventing the environmental damage, just saying it was handled. https://github.com/GriefPrevention/GriefPrevention/blob/b384806e18bbd870e53323c1e8ac719d32bb33d2/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java#L364-L374 Didn't really feel like rereading all the bajillion duplicate lines to see if there were other potential bugs, just re-unified the code.