### PR TITLE
Add claim inspection cooldown

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1888,8 +1888,8 @@ class PlayerEventHandler implements Listener
 
                 // If investigation tool is on cooldown, do nothing.
                 if (player.getCooldown(instance.config_claims_investigationTool) > 0) return;
-                // Set investigation tool on cooldown for 1 second to prevent spamming.
-                player.setCooldown(instance.config_claims_investigationTool, 20);
+                // Set investigation tool on cooldown to prevent spamming.
+                player.setCooldown(instance.config_claims_investigationTool, 1);
 
                 //if holding shift (sneaking), show all claims in area
                 if (player.isSneaking() && player.hasPermission("griefprevention.visualizenearbyclaims"))

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1886,6 +1886,11 @@ class PlayerEventHandler implements Listener
                 //if claims are disabled in this world, do nothing
                 if (!instance.claimsEnabledForWorld(player.getWorld())) return;
 
+                // If investigation tool is on cooldown, do nothing.
+                if (player.getCooldown(instance.config_claims_investigationTool) > 0) return;
+                // Set investigation tool on cooldown for 1 second to prevent spamming.
+                player.setCooldown(instance.config_claims_investigationTool, 20);
+
                 //if holding shift (sneaking), show all claims in area
                 if (player.isSneaking() && player.hasPermission("griefprevention.visualizenearbyclaims"))
                 {


### PR DESCRIPTION
I forgot this was a feature of vanilla and had been putting off this aspect because I thought it would be a whole new system. No spammy messages because it's visually represented on the client! It will likely eventually need to be a new system because we have an open request for custom tools (making setting an entire material on cooldown less great) but that's a bridge we can cross when dealing with that idea.

I hardcoded a 20-tick cooldown because I feel like that's a good balance between not waiting too long if you misclick/find nothing and not spamming the server. Since the client could previously visualize multiple times per tick with high clicks per second, even a 1-tick cooldown is effectively a resolution of the underlying problem.

Closes #1986