### PR TITLE
Fix missed console colors

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -253,7 +253,7 @@ public class GriefPrevention extends JavaPlugin
         {
             GriefPrevention.instance.customLogger.AddEntry(entry, customLogType);
         }
-        if (!excludeFromServerLogs) log.info(entry);
+        if (!excludeFromServerLogs) Bukkit.getConsoleSender().sendMessage(entry);
     }
 
     public static synchronized void AddLogEntry(String entry, CustomLogEntryTypes customLogType)
@@ -2906,7 +2906,7 @@ public class GriefPrevention extends JavaPlugin
 
         if (player == null)
         {
-            Bukkit.getConsoleSender().sendMessage(message);
+            Bukkit.getConsoleSender().sendMessage(color + message);
             GriefPrevention.AddLogEntry(message, CustomLogEntryTypes.Debug, true);
         }
         else


### PR DESCRIPTION
Some mistakes from #2251:
Fix color missing from console messaging for #sendMessage.
Fix color not working if included in #AddLogEntry. GP doesn't internally add colors to direct calls to this method, but addons could. Keep things pretty and clean even if people are doing weird things.