### PR TITLE
Fixed compiler errors due to null annotations

### DIFF
--- a/src/main/java/com/griefprevention/commands/ClaimCommand.java
+++ b/src/main/java/com/griefprevention/commands/ClaimCommand.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.Objects;
 
 public class ClaimCommand extends CommandHandler
 {
@@ -150,7 +151,7 @@ public class ClaimCommand extends CommandHandler
             {
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.CreateClaimFailOverlapShort);
 
-                BoundaryVisualization.visualizeClaim(player, result.claim, VisualizationType.CONFLICT_ZONE);
+                BoundaryVisualization.visualizeClaim(player, Objects.requireNonNull(result.claim), VisualizationType.CONFLICT_ZONE);
             }
             else
             {
@@ -162,7 +163,7 @@ public class ClaimCommand extends CommandHandler
             GriefPrevention.sendMessage(player, TextMode.Success, Messages.CreateClaimSuccess);
 
             //link to a video demo of land claiming, based on world type
-            if (plugin.creativeRulesApply(player.getLocation()))
+            if (plugin.creativeRulesApply(Objects.requireNonNull(player.getLocation())))
             {
                 GriefPrevention.sendMessage(player, TextMode.Instr, Messages.CreativeBasicsVideo2, DataStore.CREATIVE_VIDEO_URL);
             }
@@ -170,11 +171,11 @@ public class ClaimCommand extends CommandHandler
             {
                 GriefPrevention.sendMessage(player, TextMode.Instr, Messages.SurvivalBasicsVideo2, DataStore.SURVIVAL_VIDEO_URL);
             }
-            BoundaryVisualization.visualizeClaim(player, result.claim, VisualizationType.CLAIM);
+            BoundaryVisualization.visualizeClaim(player, Objects.requireNonNull(result.claim), VisualizationType.CLAIM);
             playerData.claimResizing = null;
             playerData.lastShovelLocation = null;
 
-            AutoExtendClaimTask.scheduleAsync(result.claim);
+            AutoExtendClaimTask.scheduleAsync(Objects.requireNonNull(result.claim));
 
         }
     }

--- a/src/main/java/com/griefprevention/commands/CommandHandler.java
+++ b/src/main/java/com/griefprevention/commands/CommandHandler.java
@@ -42,7 +42,7 @@ public abstract class CommandHandler implements TabExecutor
         }
         command.setExecutor(this);
     }
-
+    
     @Override
     public @Nullable List<String> onTabComplete(
             @NotNull CommandSender sender,

--- a/src/main/java/com/griefprevention/events/BoundaryVisualizationEvent.java
+++ b/src/main/java/com/griefprevention/events/BoundaryVisualizationEvent.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
 
 /**
  * An {@link org.bukkit.event.Event Event} called when a {@link Player} receives {@link Boundary} visuals.
@@ -89,7 +90,7 @@ public class BoundaryVisualizationEvent extends PlayerEvent
      */
     public @NotNull IntVector getCenter()
     {
-        return new IntVector(player.getLocation());
+        return new IntVector(Objects.requireNonNull(player.getLocation()));
     }
 
     /**

--- a/src/main/java/com/griefprevention/visualization/BlockBoundaryVisualization.java
+++ b/src/main/java/com/griefprevention/visualization/BlockBoundaryVisualization.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.function.Consumer;
+import java.util.Objects;
 
 public abstract class BlockBoundaryVisualization extends BoundaryVisualization
 {
@@ -159,7 +160,7 @@ public abstract class BlockBoundaryVisualization extends BoundaryVisualization
         }
 
         // Elements do not track the boundary they're attached to - all elements are reverted individually instead.
-        this.elements.forEach(element -> element.erase(player, world));
+        this.elements.forEach(element -> element.erase(Objects.requireNonNull(player), world));
     }
 
     @Override

--- a/src/main/java/com/griefprevention/visualization/BoundaryVisualization.java
+++ b/src/main/java/com/griefprevention/visualization/BoundaryVisualization.java
@@ -120,7 +120,7 @@ public abstract class BoundaryVisualization
         }
 
         // Revert data as necessary for any sent elements.
-        elements.forEach(element -> erase(player, element));
+        elements.forEach(element -> erase(Objects.requireNonNull(player), element));
     }
 
     /**

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -394,7 +394,7 @@ public class BlockEventHandler implements Listener
                             GriefPrevention.sendMessage(player, TextMode.Success, Messages.AutomaticClaimNotification);
 
                             //show the player the protected area
-                            BoundaryVisualization.visualizeClaim(player, result.claim, VisualizationType.CLAIM, block);
+                            BoundaryVisualization.visualizeClaim(player, Objects.requireNonNull(result.claim), VisualizationType.CLAIM, block);
                         }
                         else
                         {
@@ -402,7 +402,7 @@ public class BlockEventHandler implements Listener
                             GriefPrevention.sendMessage(player, TextMode.Err, Messages.AutomaticClaimOtherClaimTooClose);
 
                             //show the player the protected area
-                            BoundaryVisualization.visualizeClaim(player, result.claim, VisualizationType.CONFLICT_ZONE, block);
+                            BoundaryVisualization.visualizeClaim(player, Objects.requireNonNull(result.claim), VisualizationType.CONFLICT_ZONE, block);
                         }
                     }
                 }
@@ -788,9 +788,9 @@ public class BlockEventHandler implements Listener
             {
                 // Set lit for resulting data in event. Currently unused, but may be in the future.
                 lightable.setLit(true);
-
+                
                 // Call event.
-                EntityChangeBlockEvent changeBlockEvent = new EntityChangeBlockEvent(igniteEvent.getIgnitingEntity(), igniteEvent.getBlock(), blockData);
+                EntityChangeBlockEvent changeBlockEvent = new EntityChangeBlockEvent(Objects.requireNonNull(igniteEvent.getIgnitingEntity()), igniteEvent.getBlock(), blockData);
                 GriefPrevention.instance.entityEventHandler.onEntityChangeBLock(changeBlockEvent);
 
                 // Respect event result.

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -294,8 +294,8 @@ public class Claim
     public boolean isNear(Location location, int howNear)
     {
         Claim claim = new Claim
-                (new Location(this.lesserBoundaryCorner.getWorld(), this.lesserBoundaryCorner.getBlockX() - howNear, this.lesserBoundaryCorner.getBlockY(), this.lesserBoundaryCorner.getBlockZ() - howNear),
-                        new Location(this.greaterBoundaryCorner.getWorld(), this.greaterBoundaryCorner.getBlockX() + howNear, this.greaterBoundaryCorner.getBlockY(), this.greaterBoundaryCorner.getBlockZ() + howNear),
+                (new Location(Objects.requireNonNull(this.lesserBoundaryCorner.getWorld()), this.lesserBoundaryCorner.getBlockX() - howNear, this.lesserBoundaryCorner.getBlockY(), this.lesserBoundaryCorner.getBlockZ() - howNear),
+                        new Location(Objects.requireNonNull(this.greaterBoundaryCorner.getWorld()), this.greaterBoundaryCorner.getBlockX() + howNear, this.greaterBoundaryCorner.getBlockY(), this.greaterBoundaryCorner.getBlockZ() + howNear),
                         null, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), null);
 
         return claim.contains(location, false, true);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1262,7 +1262,7 @@ public abstract class DataStore
 
             //inform about success, visualize, communicate remaining blocks available
             GriefPrevention.sendMessage(player, TextMode.Success, Messages.ClaimResizeSuccess, String.valueOf(claimBlocksRemaining));
-            BoundaryVisualization.visualizeClaim(player, result.claim, VisualizationType.CLAIM);
+            BoundaryVisualization.visualizeClaim(player, Objects.requireNonNull(result.claim), VisualizationType.CLAIM);
 
             //if resizing someone else's claim, make a log entry
             if (!player.getUniqueId().equals(playerData.claimResizing.ownerID) && playerData.claimResizing.parent == null)
@@ -1297,7 +1297,7 @@ public abstract class DataStore
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.ResizeFailOverlap);
 
                 //show the player the conflicting claim
-                BoundaryVisualization.visualizeClaim(player, result.claim, VisualizationType.CONFLICT_ZONE);
+                BoundaryVisualization.visualizeClaim(player, Objects.requireNonNull(result.claim), VisualizationType.CONFLICT_ZONE);
             }
             else
             {
@@ -1666,7 +1666,7 @@ public abstract class DataStore
     Set<Claim> getNearbyClaims(Location location)
     {
         return getChunkClaims(
-                location.getWorld(),
+                Objects.requireNonNull(location.getWorld()),
                 new BoundingBox(location.subtract(150, 0, 150), location.clone().add(300, 0, 300)));
     }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
@@ -22,6 +22,7 @@ import me.ryanhamshire.GriefPrevention.events.AccrueClaimBlocksEvent;
 import org.bukkit.entity.Player;
 
 import java.util.Collection;
+import java.util.Objects;
 
 //FEATURE: give players claim blocks for playing, as long as they're not away from their computer
 
@@ -74,7 +75,7 @@ class DeliverClaimBlocksTask implements Runnable
         try
         {
             isIdle = player.isInsideVehicle() || player.getLocation().getBlock().isLiquid() ||
-                    !(playerData.lastAfkCheckLocation == null || playerData.lastAfkCheckLocation.distanceSquared(player.getLocation()) > idleThresholdSquared);
+                    !(playerData.lastAfkCheckLocation == null || playerData.lastAfkCheckLocation.distanceSquared(Objects.requireNonNull(player.getLocation())) > idleThresholdSquared);
         }
         catch (IllegalArgumentException ignore) //can't measure distance when to/from are different worlds
         {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
@@ -57,6 +57,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.Objects;
 
 public class EntityDamageHandler implements Listener
 {
@@ -417,8 +418,8 @@ public class EntityDamageHandler implements Listener
             if (sendMessages) GriefPrevention.sendMessage(attacker, TextMode.Err, message);
         };
         // Return whether PVP is handled by a claim at the attacker or defender's locations.
-        return handlePvpInClaim(attacker, defender, attacker.getLocation(), attackerData, () -> cancelHandler.accept(Messages.CantFightWhileImmune))
-                || handlePvpInClaim(attacker, defender, defender.getLocation(), defenderData, () -> cancelHandler.accept(Messages.PlayerInPvPSafeZone));
+        return handlePvpInClaim(attacker, defender, Objects.requireNonNull(attacker.getLocation()), attackerData, () -> cancelHandler.accept(Messages.CantFightWhileImmune))
+                || handlePvpInClaim(attacker, defender, Objects.requireNonNull(defender.getLocation()), defenderData, () -> cancelHandler.accept(Messages.PlayerInPvPSafeZone));
     }
 
     /**
@@ -450,7 +451,7 @@ public class EntityDamageHandler implements Listener
         }
 
         // Return whether PVP is handled by a claim at the defender's location.
-        return handlePvpInClaim(attacker, defender, defender.getLocation(), defenderData, cancelHandler);
+        return handlePvpInClaim(attacker, defender, Objects.requireNonNull(defender.getLocation()), defenderData, cancelHandler);
     }
 
     /**
@@ -1020,12 +1021,12 @@ public class EntityDamageHandler implements Listener
                         if (messagedPlayer.compareAndSet(false, true))
                             GriefPrevention.sendMessage(thrower, TextMode.Err, message);
                     };
-                    if (handlePvpInClaim(thrower, affectedPlayer, thrower.getLocation(), playerData, () -> cancelHandler.accept(Messages.CantFightWhileImmune)))
+                    if (handlePvpInClaim(thrower, affectedPlayer, Objects.requireNonNull(thrower.getLocation()), playerData, () -> cancelHandler.accept(Messages.CantFightWhileImmune)))
                     {
                         continue;
                     }
                     playerData = this.dataStore.getPlayerData(affectedPlayer.getUniqueId());
-                    handlePvpInClaim(thrower, affectedPlayer, affectedPlayer.getLocation(), playerData, () -> cancelHandler.accept(Messages.PlayerInPvPSafeZone));
+                    handlePvpInClaim(thrower, affectedPlayer, Objects.requireNonNull(affectedPlayer.getLocation()), playerData, () -> cancelHandler.accept(Messages.PlayerInPvPSafeZone));
                 }
             }
         }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EquipShovelProcessingTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EquipShovelProcessingTask.java
@@ -23,6 +23,8 @@ import com.griefprevention.visualization.VisualizationType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
 
+import java.util.Objects;
+
 //tells a player about how many claim blocks he has, etc
 //implemented as a task so that it can be delayed
 //otherwise, it's spammy when players mouse-wheel past the shovel in their hot bars
@@ -61,7 +63,7 @@ class EquipShovelProcessingTask implements Runnable
         GriefPrevention.sendMessage(player, TextMode.Instr, Messages.RemainingBlocks, String.valueOf(remainingBlocks));
 
         //link to a video demo of land claiming, based on world type
-        if (GriefPrevention.instance.creativeRulesApply(player.getLocation()))
+        if (GriefPrevention.instance.creativeRulesApply(Objects.requireNonNull(player.getLocation())))
         {
             GriefPrevention.sendMessage(player, TextMode.Instr, Messages.CreativeBasicsVideo2, DataStore.CREATIVE_VIDEO_URL);
         }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -75,6 +75,7 @@ import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.Objects;
 
 public class GriefPrevention extends JavaPlugin
 {
@@ -915,7 +916,7 @@ public class GriefPrevention extends JavaPlugin
             if (args.length < 1)
             {
                 //link to a video demo of land claiming, based on world type
-                if (GriefPrevention.instance.creativeRulesApply(player.getLocation()))
+                if (GriefPrevention.instance.creativeRulesApply(Objects.requireNonNull(player.getLocation())))
                 {
                     GriefPrevention.sendMessage(player, TextMode.Instr, Messages.CreativeBasicsVideo2, DataStore.CREATIVE_VIDEO_URL);
                 }
@@ -934,7 +935,7 @@ public class GriefPrevention extends JavaPlugin
             catch (NumberFormatException e)
             {
                 //link to a video demo of land claiming, based on world type
-                if (GriefPrevention.instance.creativeRulesApply(player.getLocation()))
+                if (GriefPrevention.instance.creativeRulesApply(Objects.requireNonNull(player.getLocation())))
                 {
                     GriefPrevention.sendMessage(player, TextMode.Instr, Messages.CreativeBasicsVideo2, DataStore.CREATIVE_VIDEO_URL);
                 }
@@ -1699,7 +1700,7 @@ public class GriefPrevention extends JavaPlugin
             //delete all that player's claims
             this.dataStore.deleteClaimsForPlayer(otherPlayer.getUniqueId(), true);
 
-            GriefPrevention.sendMessage(player, TextMode.Success, Messages.DeleteAllSuccess, otherPlayer.getName());
+            GriefPrevention.sendMessage(player, TextMode.Success, Messages.DeleteAllSuccess, Objects.requireNonNull(otherPlayer.getName()));
             if (player != null)
             {
                 GriefPrevention.AddLogEntry(player.getName() + " deleted all claims belonging to " + otherPlayer.getName() + ".", CustomLogEntryTypes.AdminActivity);
@@ -1967,7 +1968,7 @@ public class GriefPrevention extends JavaPlugin
             playerData.setBonusClaimBlocks(playerData.getBonusClaimBlocks() + adjustment);
             this.dataStore.savePlayerData(targetPlayer.getUniqueId(), playerData);
 
-            GriefPrevention.sendMessage(player, TextMode.Success, Messages.AdjustBlocksSuccess, targetPlayer.getName(), String.valueOf(adjustment), String.valueOf(playerData.getBonusClaimBlocks()));
+            GriefPrevention.sendMessage(player, TextMode.Success, Messages.AdjustBlocksSuccess, Objects.requireNonNull(targetPlayer.getName()), String.valueOf(adjustment), String.valueOf(playerData.getBonusClaimBlocks()));
             if (player != null)
                 GriefPrevention.AddLogEntry(player.getName() + " adjusted " + targetPlayer.getName() + "'s bonus claim blocks by " + adjustment + ".", CustomLogEntryTypes.AdminActivity);
 
@@ -2112,7 +2113,7 @@ public class GriefPrevention extends JavaPlugin
             boolean isMuted = this.dataStore.toggleSoftMute(targetPlayer.getUniqueId());
             if (isMuted)
             {
-                GriefPrevention.sendMessage(player, TextMode.Success, Messages.SoftMuted, targetPlayer.getName());
+                GriefPrevention.sendMessage(player, TextMode.Success, Messages.SoftMuted, Objects.requireNonNull(targetPlayer.getName()));
                 String executorName = "console";
                 if (player != null)
                 {
@@ -2123,7 +2124,7 @@ public class GriefPrevention extends JavaPlugin
             }
             else
             {
-                GriefPrevention.sendMessage(player, TextMode.Success, Messages.UnSoftMuted, targetPlayer.getName());
+                GriefPrevention.sendMessage(player, TextMode.Success, Messages.UnSoftMuted, Objects.requireNonNull(targetPlayer.getName()));
             }
 
             return true;
@@ -2861,7 +2862,7 @@ public class GriefPrevention extends JavaPlugin
             //if there's a claim here, keep looking
             if (claim != null)
             {
-                candidateLocation = new Location(claim.lesserBoundaryCorner.getWorld(), claim.lesserBoundaryCorner.getBlockX() - 1, claim.lesserBoundaryCorner.getBlockY(), claim.lesserBoundaryCorner.getBlockZ() - 1);
+                candidateLocation = new Location(Objects.requireNonNull(claim.lesserBoundaryCorner.getWorld()), claim.lesserBoundaryCorner.getBlockX() - 1, claim.lesserBoundaryCorner.getBlockY(), claim.lesserBoundaryCorner.getBlockZ() - 1);
                 continue;
             }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -104,6 +104,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import java.util.Objects;
 
 class PlayerEventHandler implements Listener
 {
@@ -301,7 +302,7 @@ class PlayerEventHandler implements Listener
 
         if (this.howToClaimPattern.matcher(message).matches())
         {
-            if (instance.creativeRulesApply(player.getLocation()))
+            if (instance.creativeRulesApply(Objects.requireNonNull(player.getLocation())))
             {
                 GriefPrevention.sendMessage(player, TextMode.Info, Messages.CreativeBasicsVideo2, 10L, DataStore.CREATIVE_VIDEO_URL);
             }
@@ -686,7 +687,7 @@ class PlayerEventHandler implements Listener
                             if (info2.address.toString().equals(address))
                             {
                                 OfflinePlayer bannedAccount = instance.getServer().getOfflinePlayer(info2.bannedAccountName);
-                                instance.getServer().getBanList(BanList.Type.NAME).pardon(bannedAccount.getName());
+                                instance.getServer().getBanList(BanList.Type.NAME).pardon(Objects.requireNonNull(bannedAccount.getName()));
                                 this.tempBannedIps.remove(j--);
                             }
                         }
@@ -798,7 +799,7 @@ class PlayerEventHandler implements Listener
                 if (taskID != null && Bukkit.getScheduler().isQueued(taskID))
                 {
                     Bukkit.getScheduler().cancelTask(taskID);
-                    player.sendMessage(event.getJoinMessage());
+                    player.sendMessage(Objects.requireNonNull(event.getJoinMessage()));
                     event.setJoinMessage("");
                 }
             }
@@ -836,7 +837,7 @@ class PlayerEventHandler implements Listener
         long now = Calendar.getInstance().getTimeInMillis();
         if (lastDeathTime != null && now - lastDeathTime < instance.config_spam_deathMessageCooldownSeconds * 1000 && event.getDeathMessage() != null)
         {
-            player.sendMessage(event.getDeathMessage());  //let the player assume his death message was broadcasted to everyone
+            player.sendMessage(Objects.requireNonNull(event.getDeathMessage()));  //let the player assume his death message was broadcasted to everyone
             event.setDeathMessage(null);
         }
 
@@ -970,7 +971,7 @@ class PlayerEventHandler implements Listener
         Player player = event.getPlayer();
 
         //in creative worlds, dropping items is blocked
-        if (instance.creativeRulesApply(player.getLocation()))
+        if (instance.creativeRulesApply(Objects.requireNonNull(player.getLocation())))
         {
             event.setCancelled(true);
             return;
@@ -2219,7 +2220,7 @@ class PlayerEventHandler implements Listener
                                 if (result.claim != null)
                                 {
                                     GriefPrevention.sendMessage(player, TextMode.Err, Messages.CreateSubdivisionOverlap);
-                                    BoundaryVisualization.visualizeClaim(player, result.claim, VisualizationType.CONFLICT_ZONE, clickedBlock);
+                                    BoundaryVisualization.visualizeClaim(player, Objects.requireNonNull(result.claim), VisualizationType.CONFLICT_ZONE, clickedBlock);
                                 }
                                 else
                                 {
@@ -2233,7 +2234,7 @@ class PlayerEventHandler implements Listener
                             else
                             {
                                 GriefPrevention.sendMessage(player, TextMode.Success, Messages.SubdivisionSuccess);
-                                BoundaryVisualization.visualizeClaim(player, result.claim, VisualizationType.CLAIM, clickedBlock);
+                                BoundaryVisualization.visualizeClaim(player, Objects.requireNonNull(result.claim), VisualizationType.CLAIM, clickedBlock);
                                 playerData.lastShovelLocation = null;
                                 playerData.claimSubdividing = null;
                             }
@@ -2368,7 +2369,7 @@ class PlayerEventHandler implements Listener
                     if (result.claim != null)
                     {
                         GriefPrevention.sendMessage(player, TextMode.Err, Messages.CreateClaimFailOverlapShort);
-                        BoundaryVisualization.visualizeClaim(player, result.claim, VisualizationType.CONFLICT_ZONE, clickedBlock);
+                        BoundaryVisualization.visualizeClaim(player, Objects.requireNonNull(result.claim), VisualizationType.CONFLICT_ZONE, clickedBlock);
                     }
                     else
                     {
@@ -2382,7 +2383,7 @@ class PlayerEventHandler implements Listener
                 else
                 {
                     GriefPrevention.sendMessage(player, TextMode.Success, Messages.CreateClaimSuccess);
-                    BoundaryVisualization.visualizeClaim(player, result.claim, VisualizationType.CLAIM, clickedBlock);
+                    BoundaryVisualization.visualizeClaim(player, Objects.requireNonNull(result.claim), VisualizationType.CLAIM, clickedBlock);
                     playerData.lastShovelLocation = null;
 
                     //if it's a big claim, tell the player about subdivisions
@@ -2392,7 +2393,7 @@ class PlayerEventHandler implements Listener
                         GriefPrevention.sendMessage(player, TextMode.Instr, Messages.SubdivisionVideo2, 201L, DataStore.SUBDIVISION_VIDEO_URL);
                     }
 
-                    AutoExtendClaimTask.scheduleAsync(result.claim);
+                    AutoExtendClaimTask.scheduleAsync(Objects.requireNonNull(result.claim));
                 }
             }
         }
@@ -2465,7 +2466,7 @@ class PlayerEventHandler implements Listener
         Location eye = player.getEyeLocation();
         Material eyeMaterial = eye.getBlock().getType();
         boolean passThroughWater = (eyeMaterial == Material.WATER);
-        BlockIterator iterator = new BlockIterator(player.getLocation(), player.getEyeHeight(), maxDistance);
+        BlockIterator iterator = new BlockIterator(Objects.requireNonNull(player.getLocation()), player.getEyeHeight(), maxDistance);
         Block result = player.getLocation().getBlock().getRelative(BlockFace.UP);
         while (iterator.hasNext())
         {


### PR DESCRIPTION
I was unable to compile GriefPrevention due to compiler errors resulting from unhandled null annotation conflicts. I have wrapped all instances where potential null objects are being passed to methods which explicitly require non-null values in Objects.requireNonNull().

This does not solve the issue of nulls being passed where they shouldn't be, but rather causes the error to fail early to help identify the source of the problem as it occurs. I am not familiar enough with the preferred method of error handling or the code base itself to address the problem more gracefully.
