### PR TITLE
Remove end_of_line specification from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,5 @@
 [*]
 charset = utf-8
-end_of_line = crlf
 indent_size = 4
 indent_style = space
 insert_final_newline = false


### PR DESCRIPTION
As per https://github.com/GriefPrevention/GriefPrevention/pull/2269#issuecomment-2045408395