### PR TITLE
Add a configuration flag GriefPrevention.Claims.ProtectVehicles

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
@@ -1105,8 +1105,8 @@ public class EntityDamageHandler implements Listener
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
     public void onVehicleDamage(@NotNull VehicleDamageEvent event)
     {
-        //all of this is anti theft code
-        if (!instance.config_claims_preventTheft) return;
+        //all of this is vehicle anti theft code
+        if (!instance.config_claims_preventTheft || !instance.config_claims_protectVehicles) return;
 
         //don't track in worlds where claims are not enabled
         if (!instance.claimsEnabledForWorld(event.getVehicle().getWorld())) return;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -111,6 +111,7 @@ public class GriefPrevention extends JavaPlugin
     public boolean config_claims_protectHorses;                        //whether horses on a claim should be protected by that claim's rules
     public boolean config_claims_protectDonkeys;                    //whether donkeys on a claim should be protected by that claim's rules
     public boolean config_claims_protectLlamas;                        //whether llamas on a claim should be protected by that claim's rules
+    public boolean config_claims_protectVehicles;                      //whether vehicles on a claim should be protected by that claim's rules
     public boolean config_claims_preventButtonsSwitches;            //whether buttons and switches are protectable
     public boolean config_claims_lockWoodenDoors;                    //whether wooden doors should be locked by default (require /accesstrust)
     public boolean config_claims_lockTrapDoors;                        //whether trap doors should be locked by default (require /accesstrust)
@@ -559,6 +560,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_claims_protectHorses = config.getBoolean("GriefPrevention.Claims.ProtectHorses", true);
         this.config_claims_protectDonkeys = config.getBoolean("GriefPrevention.Claims.ProtectDonkeys", true);
         this.config_claims_protectLlamas = config.getBoolean("GriefPrevention.Claims.ProtectLlamas", true);
+        this.config_claims_protectVehicles = config.getBoolean("GriefPrevention.Claims.ProtectVehicles", true);
         this.config_claims_preventButtonsSwitches = config.getBoolean("GriefPrevention.Claims.PreventButtonsSwitches", true);
         this.config_claims_lockWoodenDoors = config.getBoolean("GriefPrevention.Claims.LockWoodenDoors", false);
         this.config_claims_lockTrapDoors = config.getBoolean("GriefPrevention.Claims.LockTrapDoors", false);
@@ -830,6 +832,7 @@ public class GriefPrevention extends JavaPlugin
         outConfig.set("GriefPrevention.Claims.ProtectHorses", this.config_claims_protectHorses);
         outConfig.set("GriefPrevention.Claims.ProtectDonkeys", this.config_claims_protectDonkeys);
         outConfig.set("GriefPrevention.Claims.ProtectLlamas", this.config_claims_protectLlamas);
+        outConfig.set("GriefPrevention.Claims.ProtectVehicles", this.config_claims_protectVehicles);
         outConfig.set("GriefPrevention.Claims.InitialBlocks", this.config_claims_initialBlocks);
         outConfig.set("GriefPrevention.Claims.Claim Blocks Accrued Per Hour.Default", this.config_claims_blocksAccruedPerHour_default);
         outConfig.set("GriefPrevention.Claims.Max Accrued Claim Blocks.Default", this.config_claims_maxAccruedBlocks_default);


### PR DESCRIPTION
This flag could that allows users to toggle GriefPrevention on vehicles similar to the existing ProtectHorses flag, primarily because at present if a vehicle moves onto another person's claim the vehicle becomes irretrievable to its original user/rider.

The should default to true as this is a more conservative option for most servers.