### PR TITLE
Fix worldborder claims in master

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -206,8 +206,25 @@ public class Claim
         this.id = id;
 
         //store corners
-        this.lesserBoundaryCorner = lesserBoundaryCorner;
-        this.greaterBoundaryCorner = greaterBoundaryCorner;
+        this.lesserBoundaryCorner = lesserBoundaryCorner.clone();
+        this.greaterBoundaryCorner = greaterBoundaryCorner.clone();
+
+        // Sanitize corners
+        int x1 = this.lesserBoundaryCorner.getBlockX();
+        int x2 = this.greaterBoundaryCorner.getBlockX();
+        if (x1 > x2)
+        {
+            this.greaterBoundaryCorner.setX(x1);
+            this.lesserBoundaryCorner.setX(x2);
+        }
+        int z1 = this.lesserBoundaryCorner.getBlockZ();
+        int z2 = this.greaterBoundaryCorner.getBlockZ();
+        if (z1 > z2)
+        {
+            this.greaterBoundaryCorner.setZ(z1);
+            this.lesserBoundaryCorner.setZ(z2);
+        }
+        this.lesserBoundaryCorner.setY(Math.min(this.lesserBoundaryCorner.getBlockY(), this.greaterBoundaryCorner.getBlockY()));
 
         //owner
         this.ownerID = ownerID;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -915,6 +915,14 @@ public abstract class DataStore
             smally = sanitizeClaimDepth(parent, smally);
         }
 
+        //claims can't be made outside the world border
+        final Location smallerBoundaryCorner = new Location(world, smallx, smally, smallz);
+        final Location greaterBoundaryCorner = new Location(world, bigx, bigy, bigz);
+        if(!world.getWorldBorder().isInside(smallerBoundaryCorner) || !world.getWorldBorder().isInside(greaterBoundaryCorner)){
+            result.succeeded = false;
+            return result;
+        }
+
         //creative mode claims always go to bedrock
         if (GriefPrevention.instance.config_claims_worldModes.get(world) == ClaimsMode.Creative)
         {
@@ -923,8 +931,8 @@ public abstract class DataStore
 
         //create a new claim instance (but don't save it, yet)
         Claim newClaim = new Claim(
-                new Location(world, smallx, smally, smallz),
-                new Location(world, bigx, bigy, bigz),
+                smallerBoundaryCorner,
+                greaterBoundaryCorner,
                 ownerID,
                 new ArrayList<>(),
                 new ArrayList<>(),

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1167,8 +1167,19 @@ public abstract class DataStore
         if (playerData.claimResizing.parent == null)
         {
             //measure new claim, apply size rules
-            int newWidth = (Math.abs(newx1 - newx2) + 1);
-            int newHeight = (Math.abs(newz1 - newz2) + 1);
+            int newWidth;
+            int newHeight;
+            try
+            {
+                newWidth = Math.abs(Math.subtractExact(newx1, newx2)) + 1;
+                newHeight = Math.abs(Math.subtractExact(newz1, newz2)) + 1;
+            }
+            catch (ArithmeticException e)
+            {
+                GriefPrevention.sendMessage(player, TextMode.Err, Messages.ResizeClaimInsufficientArea, String.valueOf(GriefPrevention.instance.config_claims_minArea));
+                return;
+            }
+
             boolean smaller = newWidth < playerData.claimResizing.getWidth() || newHeight < playerData.claimResizing.getHeight();
 
             if (!player.hasPermission("griefprevention.adminclaims") && !playerData.claimResizing.isAdminClaim() && smaller)
@@ -1190,8 +1201,17 @@ public abstract class DataStore
             //make sure player has enough blocks to make up the difference
             if (!playerData.claimResizing.isAdminClaim() && player.getName().equals(playerData.claimResizing.getOwnerName()))
             {
-                int newArea = newWidth * newHeight;
-                int blocksRemainingAfter = playerData.getRemainingClaimBlocks() + playerData.claimResizing.getArea() - newArea;
+                int newArea;
+                int blocksRemainingAfter;
+                try
+                {
+                    newArea = Math.multiplyExact(newWidth, newHeight);
+                    blocksRemainingAfter = playerData.getRemainingClaimBlocks() + (playerData.claimResizing.getArea() - newArea);
+                }
+                catch (ArithmeticException e)
+                {
+                    blocksRemainingAfter = -1;
+                }
 
                 if (blocksRemainingAfter < 0)
                 {


### PR DESCRIPTION
Fixes https://github.com/GriefPrevention/GriefPrevention/issues/1276

Claim creation now checks if the new claim is fully inside the world border. Since claim expansion technically creates a new claim, it also fixes /extendclaim being able to extend outside the border