### PR TITLE
Allow modification of maximum allowed claims and world permission through new ClaimStartEvent

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -23,6 +23,7 @@ import com.griefprevention.util.command.MonitoredCommands;
 import com.griefprevention.visualization.BoundaryVisualization;
 import com.griefprevention.visualization.VisualizationType;
 import me.ryanhamshire.GriefPrevention.events.ClaimInspectionEvent;
+import me.ryanhamshire.GriefPrevention.events.ClaimStartEvent;
 import me.ryanhamshire.GriefPrevention.util.BoundingBox;
 import org.bukkit.BanList;
 import org.bukkit.Bukkit;
@@ -2237,17 +2238,30 @@ class PlayerEventHandler implements Listener
             Location lastShovelLocation = playerData.lastShovelLocation;
             if (lastShovelLocation == null)
             {
+                boolean claimsEnabledForWorld = instance.claimsEnabledForWorld(player.getWorld());
+                int maxClaims = instance.config_claims_maxClaimsPerPlayer;
+                
+                ClaimStartEvent claimStart = new ClaimStartEvent(claimsEnabledForWorld, maxClaims, event.getPlayer());
+                
+                Bukkit.getPluginManager().callEvent(claimStart);
+                if (!claimStart.isCancelled())
+                {
+                    claimsEnabledForWorld = claimStart.isEnabledForWorld();
+                    maxClaims = claimStart.getMaxClaims();
+                }
+                
                 //if claims are not enabled in this world and it's not an administrative claim, display an error message and stop
-                if (!instance.claimsEnabledForWorld(player.getWorld()))
+                if (!claimsEnabledForWorld &&
+                        !player.hasPermission("griefprevention.overrideworldrestriction"))
                 {
                     GriefPrevention.sendMessage(player, TextMode.Err, Messages.ClaimsDisabledWorld);
                     return;
                 }
-
+                
                 //if he's at the claim count per player limit already and doesn't have permission to bypass, display an error message
-                if (instance.config_claims_maxClaimsPerPlayer > 0 &&
+                if (maxClaims > 0 &&
                         !player.hasPermission("griefprevention.overrideclaimcountlimit") &&
-                        playerData.getClaims().size() >= instance.config_claims_maxClaimsPerPlayer)
+                        playerData.getClaims().size() >= maxClaims)
                 {
                     GriefPrevention.sendMessage(player, TextMode.Err, Messages.ClaimCreationFailedOverClaimCountLimit);
                     return;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -2244,11 +2244,10 @@ class PlayerEventHandler implements Listener
                 ClaimStartEvent claimStart = new ClaimStartEvent(claimsEnabledForWorld, maxClaims, event.getPlayer());
                 
                 Bukkit.getPluginManager().callEvent(claimStart);
-                if (!claimStart.isCancelled())
-                {
-                    claimsEnabledForWorld = claimStart.isEnabledForWorld();
-                    maxClaims = claimStart.getMaxClaims();
-                }
+                if (claimStart.isCancelled()) return;
+                
+                claimsEnabledForWorld = claimStart.isEnabledForWorld();
+                maxClaims = claimStart.getMaxClaims();
                 
                 //if claims are not enabled in this world and it's not an administrative claim, display an error message and stop
                 if (!claimsEnabledForWorld &&

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -2240,15 +2240,15 @@ class PlayerEventHandler implements Listener
             {
                 boolean claimsEnabledForWorld = instance.claimsEnabledForWorld(player.getWorld());
                 int maxClaims = instance.config_claims_maxClaimsPerPlayer;
-                
+
                 ClaimStartEvent claimStart = new ClaimStartEvent(claimsEnabledForWorld, maxClaims, event.getPlayer());
-                
+
                 Bukkit.getPluginManager().callEvent(claimStart);
                 if (claimStart.isCancelled()) return;
-                
+
                 claimsEnabledForWorld = claimStart.isEnabledForWorld();
                 maxClaims = claimStart.getMaxClaims();
-                
+
                 //if claims are not enabled in this world and it's not an administrative claim, display an error message and stop
                 if (!claimsEnabledForWorld &&
                         !player.hasPermission("griefprevention.overrideworldrestriction"))
@@ -2256,7 +2256,7 @@ class PlayerEventHandler implements Listener
                     GriefPrevention.sendMessage(player, TextMode.Err, Messages.ClaimsDisabledWorld);
                     return;
                 }
-                
+
                 //if he's at the claim count per player limit already and doesn't have permission to bypass, display an error message
                 if (maxClaims > 0 &&
                         !player.hasPermission("griefprevention.overrideclaimcountlimit") &&

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimStartEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/ClaimStartEvent.java
@@ -1,0 +1,111 @@
+package me.ryanhamshire.GriefPrevention.events;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An {@link org.bukkit.event.Event Event} called when a player starts the claim process by clicking with the claim tool.
+ *
+ * <p>If cancelled, the value returned by getMaxClaims() should not be used.
+ *
+ * @author codespunk on 5/04/2024.
+ */
+public class ClaimStartEvent extends Event implements Cancellable
+{
+
+    private final @NotNull Player player;
+    private @NotNull Boolean claimsEnabledForWorld;
+    private  @NotNull Integer maxClaims;
+
+    /**
+     * Construct a new {@code ClaimStartEvent}.
+     *
+     * @param maxClaims the maximum number of claims allowed for this player
+     * @param player the {@link Player} starting the claim process
+     */
+    public ClaimStartEvent(@NotNull Boolean claimsEnabledForWorld, @NotNull Integer maxClaims, @NotNull Player player)
+    {
+        this.player = player;
+        this.claimsEnabledForWorld = claimsEnabledForWorld;
+        this.maxClaims = maxClaims;
+    }
+
+    /**
+     * Get the {@link Player} who initiated the claim process with the claim tool.
+     *
+     * @return the player starting the claim process
+     */
+    public @NotNull Player getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * Get whether claims are enabled for the player in their current world
+     *
+     * @return whether claims are enabled for this world
+     */
+    public @NotNull Boolean isEnabledForWorld()
+    {
+        return claimsEnabledForWorld;
+    }
+
+    /**
+     * Get the maximum number of claims allowed for this player
+     *
+     * @return the maximum allowed claims
+     */
+    public @NotNull Integer getMaxClaims()
+    {
+        return maxClaims;
+    }
+
+    // Listenable event requirements
+    private static final @NotNull HandlerList HANDLERS = new HandlerList();
+
+    public static HandlerList getHandlerList()
+    {
+        return HANDLERS;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers()
+    {
+        return HANDLERS;
+    }
+
+    // Cancellable requirements
+    private boolean cancelled = false;
+
+    @Override
+    public boolean isCancelled()
+    {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled)
+    {
+        this.cancelled = cancelled;
+    }
+
+    /**
+     * Set whether claims are enabled for the player in their current world
+     */
+    public void setEnabledForWorld(@NotNull Boolean isEnabled)
+    {
+        this.claimsEnabledForWorld = isEnabled;
+    }
+
+    /**
+     * Set the maximum number of claims allowed for this player
+     */
+    public void setMaxClaims(@NotNull Integer maxClaims)
+    {
+        this.maxClaims = maxClaims;
+    }
+
+}


### PR DESCRIPTION
Added additional features to new ClaimStartEvent to allow overriding the maximum number of claims and whether a claim can be made in the player's world. This change also introduces an additional permission "griefprevention.overrideworldrestriction" check to bypass all world restrictions for claim creation.

This purpose of this feature is to allow other plugins to control and override the maximum number of claims allowed for a given player, as well as whether or not they can create a claim in a given world.
