### PR TITLE
[legacy] Update to 1.20.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,21 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 16, 17 ]
+        java: [ 21 ]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Set up JDK ${{ matrix.java }}"
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-          distribution: adopt
-      - name: "Cache local Maven repository"
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          distribution: temurin
+          cache: maven
       - name: "Test"
         run: mvn --batch-mode verify

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- Worldguard dependency -->

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
@@ -41,6 +41,7 @@ import org.bukkit.event.vehicle.VehicleDamageEvent;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.potion.PotionEffectTypeCategory;
 import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
@@ -59,33 +60,12 @@ public class EntityDamageHandler implements Listener
 
     private static final Set<PotionEffectType> GRIEF_EFFECTS = Set.of(
             // Damaging effects
-            PotionEffectType.HARM,
+            PotionEffectType.INSTANT_DAMAGE,
             PotionEffectType.POISON,
             PotionEffectType.WITHER,
             // Effects that could remove entities from normally-secure pens
-            PotionEffectType.JUMP,
+            PotionEffectType.JUMP_BOOST,
             PotionEffectType.LEVITATION
-    );
-    private static final Set<PotionEffectType> POSITIVE_EFFECTS = Set.of(
-            PotionEffectType.ABSORPTION,
-            PotionEffectType.CONDUIT_POWER,
-            PotionEffectType.DAMAGE_RESISTANCE,
-            PotionEffectType.DOLPHINS_GRACE,
-            PotionEffectType.FAST_DIGGING,
-            PotionEffectType.FIRE_RESISTANCE,
-            PotionEffectType.HEAL,
-            PotionEffectType.HEALTH_BOOST,
-            PotionEffectType.HERO_OF_THE_VILLAGE,
-            PotionEffectType.INCREASE_DAMAGE,
-            PotionEffectType.INVISIBILITY,
-            PotionEffectType.JUMP,
-            PotionEffectType.LUCK,
-            PotionEffectType.NIGHT_VISION,
-            PotionEffectType.REGENERATION,
-            PotionEffectType.SATURATION,
-            PotionEffectType.SLOW_FALLING,
-            PotionEffectType.SPEED,
-            PotionEffectType.WATER_BREATHING
     );
     private static final Set<EntityType> TEMPTABLE_SEMI_HOSTILES = Set.of(
             EntityType.HOGLIN,
@@ -146,7 +126,7 @@ public class EntityDamageHandler implements Listener
         if (event.getEntity() instanceof Mule && !instance.config_claims_protectDonkeys) return;
         if (event.getEntity() instanceof Llama && !instance.config_claims_protectLlamas) return;
         //protected death loot can't be destroyed, only picked up or despawned due to expiration
-        if (event.getEntityType() == EntityType.DROPPED_ITEM)
+        if (event.getEntityType() == EntityType.ITEM)
         {
             if (event.getEntity().hasMetadata("GP_ITEMOWNER"))
             {
@@ -214,7 +194,7 @@ public class EntityDamageHandler implements Listener
         if (event.getEntity() instanceof Mule && !instance.config_claims_protectDonkeys) return;
         if (event.getEntity() instanceof Llama && !instance.config_claims_protectLlamas) return;
         //protected death loot can't be destroyed, only picked up or despawned due to expiration
-        if (event.getEntityType() == EntityType.DROPPED_ITEM)
+        if (event.getEntityType() == EntityType.ITEM)
         {
             if (event.getEntity().hasMetadata("GP_ITEMOWNER"))
             {
@@ -702,7 +682,7 @@ public class EntityDamageHandler implements Listener
                 && entityType != EntityType.GLOW_ITEM_FRAME
                 && entityType != EntityType.ARMOR_STAND
                 && entityType != EntityType.VILLAGER
-                && entityType != EntityType.ENDER_CRYSTAL)
+                && entityType != EntityType.END_CRYSTAL)
         {
             return false;
         }
@@ -760,7 +740,7 @@ public class EntityDamageHandler implements Listener
                 && entityType != EntityType.GLOW_ITEM_FRAME
                 && entityType != EntityType.ARMOR_STAND
                 && entityType != EntityType.VILLAGER
-                && entityType != EntityType.ENDER_CRYSTAL)
+                && entityType != EntityType.END_CRYSTAL)
         {
             return false;
         }
@@ -838,7 +818,7 @@ public class EntityDamageHandler implements Listener
         if (attacker == null
                 && damageSourceType != EntityType.CREEPER
                 && damageSourceType != EntityType.WITHER
-                && damageSourceType != EntityType.ENDER_CRYSTAL
+                && damageSourceType != EntityType.END_CRYSTAL
                 && damageSourceType != EntityType.AREA_EFFECT_CLOUD
                 && damageSourceType != EntityType.WITCH
                 && !(damageSource instanceof Projectile)
@@ -874,7 +854,7 @@ public class EntityDamageHandler implements Listener
         playerData.lastClaim = claim;
 
         // Do not message players about fireworks to prevent spam due to multi-hits.
-        sendMessages &= damageSourceType != EntityType.FIREWORK;
+        sendMessages &= damageSourceType != EntityType.FIREWORK_ROCKET;
 
         Supplier<String> override = null;
         if (sendMessages)
@@ -920,7 +900,7 @@ public class EntityDamageHandler implements Listener
         if (attacker == null
                 && damageSourceType != EntityType.CREEPER
                 && damageSourceType != EntityType.WITHER
-                && damageSourceType != EntityType.ENDER_CRYSTAL
+                && damageSourceType != EntityType.END_CRYSTAL
                 && damageSourceType != EntityType.AREA_EFFECT_CLOUD
                 && damageSourceType != EntityType.WITCH
                 && !(damageSource instanceof Projectile)
@@ -956,7 +936,7 @@ public class EntityDamageHandler implements Listener
         playerData.lastClaim = claim;
 
         // Do not message players about fireworks to prevent spam due to multi-hits.
-        sendMessages &= damageSourceType != EntityType.FIREWORK;
+        sendMessages &= damageSourceType != EntityType.FIREWORK_ROCKET;
 
         Supplier<String> override = null;
         if (sendMessages)
@@ -1137,7 +1117,7 @@ public class EntityDamageHandler implements Listener
         }
 
         //if not a player and not an explosion, always allow
-        if (attacker == null && damageSourceType != EntityType.CREEPER && damageSourceType != EntityType.WITHER && damageSourceType != EntityType.PRIMED_TNT)
+        if (attacker == null && damageSourceType != EntityType.CREEPER && damageSourceType != EntityType.WITHER && damageSourceType != EntityType.TNT)
         {
             return;
         }
@@ -1256,7 +1236,7 @@ public class EntityDamageHandler implements Listener
             if (thrower == null) return;
 
             //otherwise, no restrictions for positive effects
-            if (POSITIVE_EFFECTS.contains(effectType)) continue;
+            if (effectType.getCategory() == PotionEffectTypeCategory.BENEFICIAL) continue;
 
             for (LivingEntity affected : event.getAffectedEntities())
             {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -3496,7 +3496,17 @@ public class GriefPrevention extends JavaPlugin
             playerData.lastClaim = claim;
             Block block = location.getBlock();
 
-            Supplier<String> supplier = claim.checkPermission(player, ClaimPermission.Build, new BlockPlaceEvent(block, block.getState(), block, new ItemStack(material), player, true, EquipmentSlot.HAND));
+            var type = material.asItemType();
+            ItemStack itemStack;
+            if (type != null) {
+                // Some materials are block-only and have a separate item material, i.e. WALL_SIGN variants.
+                // The only API-based conversion from block to item material available is the experimental ItemType.
+                itemStack = type.createItemStack();
+            } else {
+                itemStack = new ItemStack(Material.DIRT);
+            }
+
+            Supplier<String> supplier = claim.checkPermission(player, ClaimPermission.Build, new BlockPlaceEvent(block, block.getState(), block, itemStack, player, true, EquipmentSlot.HAND));
 
             if (supplier == null) return null;
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -3496,14 +3496,22 @@ public class GriefPrevention extends JavaPlugin
             playerData.lastClaim = claim;
             Block block = location.getBlock();
 
-            var type = material.asItemType();
             ItemStack itemStack;
-            if (type != null) {
-                // Some materials are block-only and have a separate item material, i.e. WALL_SIGN variants.
-                // The only API-based conversion from block to item material available is the experimental ItemType.
-                itemStack = type.createItemStack();
-            } else {
-                itemStack = new ItemStack(Material.DIRT);
+            if (material.isItem())
+            {
+                itemStack = new ItemStack(material);
+            }
+            else
+            {
+                var blockType = material.asBlockType();
+                if (blockType != null && blockType.hasItemType())
+                {
+                    itemStack = blockType.getItemType().createItemStack();
+                }
+                else
+                {
+                    itemStack = new ItemStack(Material.DIRT);
+                }
             }
 
             Supplier<String> supplier = claim.checkPermission(player, ClaimPermission.Build, new BlockPlaceEvent(block, block.getState(), block, itemStack, player, true, EquipmentSlot.HAND));

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -58,8 +58,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerBucketEmptyEvent;
@@ -2653,10 +2651,8 @@ class PlayerEventHandler implements Listener
         {
             result = iterator.next();
             Material type = result.getType();
-            if (type != Material.AIR &&
-                    (!passThroughWater || type != Material.WATER) &&
-                    type != Material.GRASS &&
-                    type != Material.SNOW) return result;
+            if ((!passThroughWater || type != Material.WATER) &&
+                    !Tag.REPLACEABLE.isTagged(type)) return result;
         }
 
         return result;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -2651,8 +2651,7 @@ class PlayerEventHandler implements Listener
         {
             result = iterator.next();
             Material type = result.getType();
-            if ((!passThroughWater || type != Material.WATER) &&
-                    !Tag.REPLACEABLE.isTagged(type)) return result;
+            if (!Tag.REPLACEABLE.isTagged(type) || (!passThroughWater && type == Material.WATER)) return result;
         }
 
         return result;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: me.ryanhamshire.GriefPrevention.GriefPrevention
 softdepend: [Vault, Multiverse-Core, My_Worlds, MystCraft, Transporter, WorldGuard, WorldEdit, RoyalCommands, MultiWorld, Denizen, CommandHelper]
 dev-url: https://dev.bukkit.org/projects/grief-prevention
 version: '${git.commit.id.describe}'
-api-version: '1.17'
+api-version: '1.20.6'
 commands:
     abandonclaim:
       description: Deletes a claim.


### PR DESCRIPTION
* Require 1.20.6 or higher
  * `api-version` supports minor version as of 1.20.5. There is no reason for people to be running 1.20.5 (.6 was a quick bugfix) so there is no reason to support it.
* Move to new `PotionEffectTypeCategory` API for beneficial potions. Sadly, since `JUMP_BOOST` enables theft over fences we can't get rid of all of our own definitions here, but it's progress.
* Make a best effort to sanitize material to item in `GriefPrevention#allowBuild`
  * If we can't convert the block to an in-inventory item defaults to dirt. This is a trash block, so it may be allowed in certain extra situations, but the alternative was risking a more valuable block being added to the player inventory if a plugin considers the event to be real and does funky cancellation stuff.
  * This does require the now-experimental ItemType API, but there is no alternative other than maintaining our own conversion list, which feels a bit silly.
* Update CI action to use Java 21
  * While actions aren't enabled here, I do have them enabled on my fork to double check me, so it'd be nice to have it functional.

Addresses #2308 from the legacy side. I'd like to do the v17 side differently because this seems like a great opportunity to remove these methods rather than keep the hacky workarounds used to keep them alive when the ClaimPermissionCheckEvent was added.