### PR TITLE
Update to 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 17 ]
+        java: [ 21 ]
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_depth: 10
 environment:
   matrix:
     - appveyor_build_worker_image: Visual Studio 2022
-      JAVA_HOME: C:\Program Files\Java\jdk17
+      JAVA_HOME: C:\Program Files\Java\jdk21
 branches:
   only:
     - master

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,4 @@
 before_install:
-  - sdk install java 17.0.1-open
-  - sdk use java 17.0.1-open
+  - sdk install java 21.0.3-tem
+  - sdk use java 21.0.3-tem
+  - mvn wrapper:wrapper -Dmaven=3.6.3

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>16</source>
-                    <target>16</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
             <!-- Append git commit hash to version -->
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- Annotations for nullity and other behaviors -->

--- a/src/main/java/com/griefprevention/protection/ProtectionHelper.java
+++ b/src/main/java/com/griefprevention/protection/ProtectionHelper.java
@@ -1,0 +1,108 @@
+package com.griefprevention.protection;
+
+import me.ryanhamshire.GriefPrevention.Claim;
+import me.ryanhamshire.GriefPrevention.ClaimPermission;
+import me.ryanhamshire.GriefPrevention.ClaimsMode;
+import me.ryanhamshire.GriefPrevention.DataStore;
+import me.ryanhamshire.GriefPrevention.GriefPrevention;
+import me.ryanhamshire.GriefPrevention.Messages;
+import me.ryanhamshire.GriefPrevention.PlayerData;
+import me.ryanhamshire.GriefPrevention.events.PreventBlockBreakEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Supplier;
+
+/**
+ * A utility used to simplify various protection-related checks.
+ */
+public final class ProtectionHelper
+{
+
+    private ProtectionHelper() {}
+
+    /**
+     * Check the {@link ClaimPermission} state for a {@link Player} at a particular {@link Location}.
+     *
+     * <p>This respects ignoring claims, wilderness rules, etc.</p>
+     *
+     * @param player the person performing the action
+     * @param location the affected {@link Location}
+     * @param permission the required permission
+     * @param trigger the triggering {@link Event}, if any
+     * @return the denial message supplier, or {@code null} if the action is not denied
+     */
+    public static @Nullable Supplier<String> checkPermission(
+            @NotNull Player player,
+            @NotNull Location location,
+            @NotNull ClaimPermission permission,
+            @Nullable Event trigger)
+    {
+        World world = location.getWorld();
+        if (world == null || !GriefPrevention.instance.claimsEnabledForWorld(world)) return null;
+
+        PlayerData playerData = GriefPrevention.instance.dataStore.getPlayerData(player.getUniqueId());
+
+        // Administrators ignoring claims always have permission.
+        if (playerData.ignoreClaims) return null;
+
+        Claim claim = GriefPrevention.instance.dataStore.getClaimAt(location, false, playerData.lastClaim);
+
+
+        // If there is no claim here, use wilderness rules.
+        if (claim == null)
+        {
+            ClaimsMode mode = GriefPrevention.instance.config_claims_worldModes.get(world);
+            if (mode == ClaimsMode.Creative || mode == ClaimsMode.SurvivalRequiringClaims)
+            {
+                // Allow placing chest if it would create an automatic claim.
+                if (trigger instanceof BlockPlaceEvent placeEvent
+                        && placeEvent.getBlock().getType() == Material.CHEST
+                        && playerData.getClaims().isEmpty()
+                        && GriefPrevention.instance.config_claims_automaticClaimsForNewPlayersRadius > -1)
+                    return null;
+
+                // If claims are required, provide relevant information.
+                return () ->
+                {
+                    String reason = GriefPrevention.instance.dataStore.getMessage(Messages.NoBuildOutsideClaims);
+                    if (player.hasPermission("griefprevention.ignoreclaims"))
+                        reason += "  " + GriefPrevention.instance.dataStore.getMessage(Messages.IgnoreClaimsAdvertisement);
+                    reason += "  " + GriefPrevention.instance.dataStore.getMessage(Messages.CreativeBasicsVideo2, DataStore.CREATIVE_VIDEO_URL);
+                    return reason;
+                };
+            }
+
+            // If claims are not required, then the player has permission.
+            return null;
+        }
+
+        // Update cached claim.
+        playerData.lastClaim = claim;
+
+        // Apply claim rules.
+        Supplier<String> cancel = claim.checkPermission(player, permission, trigger);
+
+        // Apply additional specific rules.
+        if (cancel != null && trigger instanceof BlockBreakEvent breakEvent)
+        {
+            PreventBlockBreakEvent preventionEvent = new PreventBlockBreakEvent(breakEvent);
+            Bukkit.getPluginManager().callEvent(preventionEvent);
+            if (preventionEvent.isCancelled())
+            {
+                cancel = null;
+            }
+        }
+
+        return cancel;
+    }
+
+}

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -21,6 +21,7 @@ package me.ryanhamshire.GriefPrevention;
 import com.griefprevention.visualization.BoundaryVisualization;
 import com.griefprevention.visualization.VisualizationType;
 import me.ryanhamshire.GriefPrevention.util.BoundingBox;
+import com.griefprevention.protection.ProtectionHelper;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
@@ -126,10 +127,10 @@ public class BlockEventHandler implements Listener
         Block block = breakEvent.getBlock();
 
         //make sure the player is allowed to break at the location
-        String noBuildReason = GriefPrevention.instance.allowBreak(player, block, block.getLocation(), breakEvent);
+        Supplier<String> noBuildReason = ProtectionHelper.checkPermission(player, block.getLocation(), ClaimPermission.Build, breakEvent);
         if (noBuildReason != null)
         {
-            GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason);
+            GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason.get());
             breakEvent.setCancelled(true);
             return;
         }
@@ -144,10 +145,10 @@ public class BlockEventHandler implements Listener
 
         if (player == null || sign == null) return;
 
-        String noBuildReason = GriefPrevention.instance.allowBuild(player, sign.getLocation(), sign.getType());
+        Supplier<String> noBuildReason = ProtectionHelper.checkPermission(player, sign.getLocation(), ClaimPermission.Build, event);
         if (noBuildReason != null)
         {
-            GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason);
+            GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason.get());
             event.setCancelled(true);
             return;
         }
@@ -213,10 +214,10 @@ public class BlockEventHandler implements Listener
         //make sure the player is allowed to build at the location
         for (BlockState block : placeEvent.getReplacedBlockStates())
         {
-            String noBuildReason = GriefPrevention.instance.allowBuild(player, block.getLocation(), block.getType());
+            Supplier<String> noBuildReason = ProtectionHelper.checkPermission(player, block.getLocation(), ClaimPermission.Build, placeEvent);
             if (noBuildReason != null)
             {
-                GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason);
+                GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason.get());
                 placeEvent.setCancelled(true);
                 return;
             }
@@ -271,7 +272,7 @@ public class BlockEventHandler implements Listener
         if (!GriefPrevention.instance.claimsEnabledForWorld(placeEvent.getBlock().getWorld())) return;
 
         //make sure the player is allowed to build at the location
-        String noBuildReason = GriefPrevention.instance.allowBuild(player, block.getLocation(), block.getType());
+        Supplier<String> noBuildReason = ProtectionHelper.checkPermission(player, block.getLocation(), ClaimPermission.Build, placeEvent);
         if (noBuildReason != null)
         {
             // Allow players with container trust to place books in lecterns
@@ -291,7 +292,7 @@ public class BlockEventHandler implements Listener
                     return;
                 }
             }
-            GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason);
+            GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason.get());
             placeEvent.setCancelled(true);
             return;
         }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
@@ -45,6 +45,7 @@ import org.bukkit.event.vehicle.VehicleDamageEvent;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.potion.PotionEffectTypeCategory;
 import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
@@ -63,33 +64,12 @@ public class EntityDamageHandler implements Listener
 
     private static final Set<PotionEffectType> GRIEF_EFFECTS = Set.of(
             // Damaging effects
-            PotionEffectType.HARM,
+            PotionEffectType.INSTANT_DAMAGE,
             PotionEffectType.POISON,
             PotionEffectType.WITHER,
             // Effects that could remove entities from normally-secure pens
-            PotionEffectType.JUMP,
+            PotionEffectType.JUMP_BOOST,
             PotionEffectType.LEVITATION
-    );
-    private static final Set<PotionEffectType> POSITIVE_EFFECTS = Set.of(
-            PotionEffectType.ABSORPTION,
-            PotionEffectType.CONDUIT_POWER,
-            PotionEffectType.DAMAGE_RESISTANCE,
-            PotionEffectType.DOLPHINS_GRACE,
-            PotionEffectType.FAST_DIGGING,
-            PotionEffectType.FIRE_RESISTANCE,
-            PotionEffectType.HEAL,
-            PotionEffectType.HEALTH_BOOST,
-            PotionEffectType.HERO_OF_THE_VILLAGE,
-            PotionEffectType.INCREASE_DAMAGE,
-            PotionEffectType.INVISIBILITY,
-            PotionEffectType.JUMP,
-            PotionEffectType.LUCK,
-            PotionEffectType.NIGHT_VISION,
-            PotionEffectType.REGENERATION,
-            PotionEffectType.SATURATION,
-            PotionEffectType.SLOW_FALLING,
-            PotionEffectType.SPEED,
-            PotionEffectType.WATER_BREATHING
     );
     private static final Set<EntityType> TEMPTABLE_SEMI_HOSTILES = Set.of(
             EntityType.HOGLIN,
@@ -150,7 +130,7 @@ public class EntityDamageHandler implements Listener
         if (event.damaged() instanceof Mule && !instance.config_claims_protectDonkeys) return;
         if (event.damaged() instanceof Llama && !instance.config_claims_protectLlamas) return;
         //protected death loot can't be destroyed, only picked up or despawned due to expiration
-        if (event.damaged().getType() == EntityType.DROPPED_ITEM)
+        if (event.damaged().getType() == EntityType.ITEM)
         {
             if (event.damaged().hasMetadata("GP_ITEMOWNER"))
             {
@@ -582,7 +562,7 @@ public class EntityDamageHandler implements Listener
                 && entityType != EntityType.GLOW_ITEM_FRAME
                 && entityType != EntityType.ARMOR_STAND
                 && entityType != EntityType.VILLAGER
-                && entityType != EntityType.ENDER_CRYSTAL)
+                && entityType != EntityType.END_CRYSTAL)
         {
             return false;
         }
@@ -663,7 +643,7 @@ public class EntityDamageHandler implements Listener
         if (attacker == null
                 && damageSourceType != EntityType.CREEPER
                 && damageSourceType != EntityType.WITHER
-                && damageSourceType != EntityType.ENDER_CRYSTAL
+                && damageSourceType != EntityType.END_CRYSTAL
                 && damageSourceType != EntityType.AREA_EFFECT_CLOUD
                 && damageSourceType != EntityType.WITCH
                 && !(damageSource instanceof Projectile)
@@ -699,7 +679,7 @@ public class EntityDamageHandler implements Listener
         playerData.lastClaim = claim;
 
         // Do not message players about fireworks to prevent spam due to multi-hits.
-        sendMessages &= damageSourceType != EntityType.FIREWORK;
+        sendMessages &= damageSourceType != EntityType.FIREWORK_ROCKET;
 
         Supplier<String> override = null;
         if (sendMessages)
@@ -880,7 +860,7 @@ public class EntityDamageHandler implements Listener
         }
 
         //if not a player and not an explosion, always allow
-        if (attacker == null && damageSourceType != EntityType.CREEPER && damageSourceType != EntityType.WITHER && damageSourceType != EntityType.PRIMED_TNT)
+        if (attacker == null && damageSourceType != EntityType.CREEPER && damageSourceType != EntityType.WITHER && damageSourceType != EntityType.TNT)
         {
             return;
         }
@@ -999,7 +979,7 @@ public class EntityDamageHandler implements Listener
             if (thrower == null) return;
 
             //otherwise, no restrictions for positive effects
-            if (POSITIVE_EFFECTS.contains(effectType)) continue;
+            if (effectType.getCategory() == PotionEffectTypeCategory.BENEFICIAL) continue;
 
             for (LivingEntity affected : event.getAffectedEntities())
             {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -53,6 +53,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.profile.PlayerProfile;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -2998,7 +2999,19 @@ public class GriefPrevention extends JavaPlugin
             playerData.lastClaim = claim;
             Block block = location.getBlock();
 
-            Supplier<String> supplier = claim.checkPermission(player, ClaimPermission.Build, new BlockPlaceEvent(block, block.getState(), block, new ItemStack(material), player, true, EquipmentSlot.HAND));
+            ItemStack itemStack;
+            if (material.isItem()) {
+                itemStack = new ItemStack(material);
+            } else {
+                var blockType = material.asBlockType();
+                if (blockType != null && blockType.hasItemType()) {
+                    itemStack = blockType.getItemType().createItemStack();
+                } else {
+                    itemStack = new ItemStack(Material.DIRT);
+                }
+            }
+
+            Supplier<String> supplier = claim.checkPermission(player, ClaimPermission.Build, new BlockPlaceEvent(block, block.getState(), block, itemStack, player, true, EquipmentSlot.HAND));
 
             if (supplier == null) return null;
 
@@ -3219,8 +3232,8 @@ public class GriefPrevention extends JavaPlugin
         }
         else
         {
-            BanList bans = Bukkit.getServer().getBanList(Type.NAME);
-            bans.addBan(player.getName(), reason, (Date) null, source);
+            BanList<PlayerProfile> bans = Bukkit.getServer().getBanList(Type.PROFILE);
+            bans.addBan(player.getPlayerProfile(), reason, (Date) null, source);
 
             //kick
             if (player.isOnline())

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -22,8 +22,8 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.griefprevention.commands.ClaimCommand;
 import com.griefprevention.metrics.MetricsHandler;
+import com.griefprevention.protection.ProtectionHelper;
 import me.ryanhamshire.GriefPrevention.DataStore.NoTransferException;
-import me.ryanhamshire.GriefPrevention.events.PreventBlockBreakEvent;
 import me.ryanhamshire.GriefPrevention.events.SaveTrappedPlayerEvent;
 import me.ryanhamshire.GriefPrevention.events.TrustChangedEvent;
 import org.bukkit.BanList;
@@ -2948,137 +2948,72 @@ public class GriefPrevention extends JavaPlugin
         return this.config_claims_worldModes.get(location.getWorld()) == ClaimsMode.Creative;
     }
 
-    public String allowBuild(Player player, Location location)
+    /**
+     * @deprecated use {@link ProtectionHelper#checkPermission(Player, Location, ClaimPermission, org.bukkit.event.Event)}
+     */
+    @Deprecated(forRemoval = true, since = "17.0.0")
+    public @Nullable String allowBuild(Player player, Location location)
     {
-        // TODO check all derivatives and rework API
         return this.allowBuild(player, location, location.getBlock().getType());
     }
 
-    public String allowBuild(Player player, Location location, Material material)
+    /**
+     * @deprecated use {@link ProtectionHelper#checkPermission(Player, Location, ClaimPermission, org.bukkit.event.Event)}
+     */
+    @Deprecated(forRemoval = true, since = "17.0.0")
+    public @Nullable String allowBuild(Player player, Location location, Material material)
     {
         if (!GriefPrevention.instance.claimsEnabledForWorld(location.getWorld())) return null;
 
-        PlayerData playerData = this.dataStore.getPlayerData(player.getUniqueId());
-        Claim claim = this.dataStore.getClaimAt(location, false, playerData.lastClaim);
-
-        //exception: administrators in ignore claims mode
-        if (playerData.ignoreClaims) return null;
-
-        //wilderness rules
-        if (claim == null)
+        ItemStack placed;
+        if (material.isItem())
         {
-            //no building in the wilderness in creative mode
-            if (this.creativeRulesApply(location) || this.config_claims_worldModes.get(location.getWorld()) == ClaimsMode.SurvivalRequiringClaims)
-            {
-                //exception: when chest claims are enabled, players who have zero land claims and are placing a chest
-                if (material != Material.CHEST || playerData.getClaims().size() > 0 || GriefPrevention.instance.config_claims_automaticClaimsForNewPlayersRadius == -1)
-                {
-                    String reason = this.dataStore.getMessage(Messages.NoBuildOutsideClaims);
-                    if (player.hasPermission("griefprevention.ignoreclaims"))
-                        reason += "  " + this.dataStore.getMessage(Messages.IgnoreClaimsAdvertisement);
-                    reason += "  " + this.dataStore.getMessage(Messages.CreativeBasicsVideo2, DataStore.CREATIVE_VIDEO_URL);
-                    return reason;
-                }
-                else
-                {
-                    return null;
-                }
-            }
-
-            //but it's fine in survival mode
-            else
-            {
-                return null;
-            }
+            placed = new ItemStack(material);
         }
-
-        //if not in the wilderness, then apply claim rules (permissions, etc)
         else
         {
-            //cache the claim for later reference
-            playerData.lastClaim = claim;
-            Block block = location.getBlock();
-
-            ItemStack itemStack;
-            if (material.isItem()) {
-                itemStack = new ItemStack(material);
-            } else {
-                var blockType = material.asBlockType();
-                if (blockType != null && blockType.hasItemType()) {
-                    itemStack = blockType.getItemType().createItemStack();
-                } else {
-                    itemStack = new ItemStack(Material.DIRT);
-                }
+            var blockType = material.asBlockType();
+            if (blockType != null && blockType.hasItemType())
+            {
+                placed = blockType.getItemType().createItemStack();
             }
-
-            Supplier<String> supplier = claim.checkPermission(player, ClaimPermission.Build, new BlockPlaceEvent(block, block.getState(), block, itemStack, player, true, EquipmentSlot.HAND));
-
-            if (supplier == null) return null;
-
-            return supplier.get();
+            else
+            {
+                placed = new ItemStack(Material.DIRT);
+            }
         }
+
+        Block block = location.getBlock();
+        Supplier<String> result = ProtectionHelper.checkPermission(player, location, ClaimPermission.Build, new BlockPlaceEvent(block, block.getState(), block, placed, player, true, EquipmentSlot.HAND));
+        return result == null ? null : result.get();
     }
 
-    public String allowBreak(Player player, Block block, Location location)
+    /**
+     * @deprecated use {@link ProtectionHelper#checkPermission(Player, Location, ClaimPermission, org.bukkit.event.Event)}
+     */
+    @Deprecated(forRemoval = true, since = "17.0.0")
+    public @Nullable String allowBreak(Player player, Block block, Location location)
     {
         return this.allowBreak(player, block, location, new BlockBreakEvent(block, player));
     }
 
-    public String allowBreak(Player player, Material material, Location location, BlockBreakEvent breakEvent)
+    /**
+     * @deprecated use {@link ProtectionHelper#checkPermission(Player, Location, ClaimPermission, org.bukkit.event.Event)}
+     */
+    @Deprecated(forRemoval = true, since = "17.0.0")
+    public @Nullable String allowBreak(Player player, Material material, Location location, BlockBreakEvent breakEvent)
     {
         return this.allowBreak(player, location.getBlock(), location, breakEvent);
     }
 
-    public String allowBreak(Player player, Block block, Location location, BlockBreakEvent breakEvent)
+    /**
+     * @deprecated use {@link ProtectionHelper#checkPermission(Player, Location, ClaimPermission, org.bukkit.event.Event)}
+     */
+    @Deprecated(forRemoval = true, since = "17.0.0")
+    public @Nullable String allowBreak(Player player, Block block, Location location, BlockBreakEvent breakEvent)
     {
-        if (!GriefPrevention.instance.claimsEnabledForWorld(location.getWorld())) return null;
-
-        PlayerData playerData = this.dataStore.getPlayerData(player.getUniqueId());
-        Claim claim = this.dataStore.getClaimAt(location, false, playerData.lastClaim);
-
-        //exception: administrators in ignore claims mode
-        if (playerData.ignoreClaims) return null;
-
-        //wilderness rules
-        if (claim == null)
-        {
-            //no building in the wilderness in creative mode
-            if (this.creativeRulesApply(location) || this.config_claims_worldModes.get(location.getWorld()) == ClaimsMode.SurvivalRequiringClaims)
-            {
-                String reason = this.dataStore.getMessage(Messages.NoBuildOutsideClaims);
-                if (player.hasPermission("griefprevention.ignoreclaims"))
-                    reason += "  " + this.dataStore.getMessage(Messages.IgnoreClaimsAdvertisement);
-                reason += "  " + this.dataStore.getMessage(Messages.CreativeBasicsVideo2, DataStore.CREATIVE_VIDEO_URL);
-                return reason;
-            }
-
-            //but it's fine in survival mode
-            else
-            {
-                return null;
-            }
-        }
-        else
-        {
-            //cache the claim for later reference
-            playerData.lastClaim = claim;
-
-            //if not in the wilderness, then apply claim rules (permissions, etc)
-            Supplier<String> cancel = claim.checkPermission(player, ClaimPermission.Build, breakEvent);
-            if (cancel != null && breakEvent != null)
-            {
-                PreventBlockBreakEvent preventionEvent = new PreventBlockBreakEvent(breakEvent);
-                Bukkit.getPluginManager().callEvent(preventionEvent);
-                if (preventionEvent.isCancelled())
-                {
-                    cancel = null;
-                }
-            }
-
-            if (cancel == null) return null;
-
-            return cancel.get();
-        }
+        Supplier<String> result = ProtectionHelper.checkPermission(player, location, ClaimPermission.Build, breakEvent);
+        return result == null ? null : result.get();
     }
 
     //restores nature in multiple chunks, as described by a claim instance

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -2437,10 +2437,7 @@ class PlayerEventHandler implements Listener
         {
             result = iterator.next();
             Material type = result.getType();
-            if (type != Material.AIR &&
-                    (!passThroughWater || type != Material.WATER) &&
-                    type != Material.SHORT_GRASS &&
-                    type != Material.SNOW) return result;
+            if (!Tag.REPLACEABLE.isTagged(type) || (!passThroughWater && type == Material.WATER)) return result;
         }
 
         return result;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -88,6 +88,7 @@ import org.bukkit.event.raid.RaidTriggerEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.profile.PlayerProfile;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.BlockIterator;
 import org.jetbrains.annotations.NotNull;
@@ -687,7 +688,8 @@ class PlayerEventHandler implements Listener
                             if (info2.address.toString().equals(address))
                             {
                                 OfflinePlayer bannedAccount = instance.getServer().getOfflinePlayer(info2.bannedAccountName);
-                                instance.getServer().getBanList(BanList.Type.NAME).pardon(bannedAccount.getName());
+                                BanList<PlayerProfile> banList = instance.getServer().getBanList(BanList.Type.PROFILE);
+                                banList.pardon(bannedAccount.getPlayerProfile());
                                 this.tempBannedIps.remove(j--);
                             }
                         }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -24,6 +24,7 @@ import com.griefprevention.visualization.BoundaryVisualization;
 import com.griefprevention.visualization.VisualizationType;
 import me.ryanhamshire.GriefPrevention.events.ClaimInspectionEvent;
 import me.ryanhamshire.GriefPrevention.util.BoundingBox;
+import com.griefprevention.protection.ProtectionHelper;
 import org.bukkit.BanList;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -1136,10 +1137,10 @@ class PlayerEventHandler implements Listener
         //don't allow interaction with item frames or armor stands in claimed areas without build permission
         if (entity.getType() == EntityType.ARMOR_STAND || entity instanceof Hanging)
         {
-            String noBuildReason = instance.allowBuild(player, entity.getLocation(), Material.ITEM_FRAME);
+            Supplier<String> noBuildReason = ProtectionHelper.checkPermission(player, entity.getLocation(), ClaimPermission.Build, event);
             if (noBuildReason != null)
             {
-                GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason);
+                GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason.get());
                 event.setCancelled(true);
                 return;
             }
@@ -1358,10 +1359,10 @@ class PlayerEventHandler implements Listener
         }
 
         //make sure the player is allowed to build at the location
-        String noBuildReason = instance.allowBuild(player, block.getLocation(), Material.WATER);
+        Supplier<String> noBuildReason = ProtectionHelper.checkPermission(player, block.getLocation(), ClaimPermission.Build, bucketEvent);
         if (noBuildReason != null)
         {
-            GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason);
+            GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason.get());
             bucketEvent.setCancelled(true);
             return;
         }
@@ -1457,22 +1458,22 @@ class PlayerEventHandler implements Listener
 
         if (!instance.claimsEnabledForWorld(block.getWorld())) return;
 
+        //exemption for cow milking (permissions will be handled by player interact with entity event instead)
+        Material blockType = block.getType();
+        if (blockType == Material.AIR)
+            return;
+        if (blockType.isSolid())
+        {
+            BlockData blockData = block.getBlockData();
+            if (!(blockData instanceof Waterlogged) || !((Waterlogged) blockData).isWaterlogged())
+                return;
+        }
+
         //make sure the player is allowed to build at the location
-        String noBuildReason = instance.allowBuild(player, block.getLocation(), Material.AIR);
+        Supplier<String> noBuildReason = ProtectionHelper.checkPermission(player, block.getLocation(), ClaimPermission.Build, bucketEvent);
         if (noBuildReason != null)
         {
-            //exemption for cow milking (permissions will be handled by player interact with entity event instead)
-            Material blockType = block.getType();
-            if (blockType == Material.AIR)
-                return;
-            if (blockType.isSolid())
-            {
-                BlockData blockData = block.getBlockData();
-                if (!(blockData instanceof Waterlogged) || !((Waterlogged) blockData).isWaterlogged())
-                    return;
-            }
-
-            GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason);
+            GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason.get());
             bucketEvent.setCancelled(true);
             return;
         }
@@ -1489,14 +1490,14 @@ class PlayerEventHandler implements Listener
         }
 
         Player player = event.getPlayer();
-        String denial = instance.allowBuild(player, event.getSign().getLocation(), event.getSign().getType());
+        Supplier<String> denial = ProtectionHelper.checkPermission(player, event.getSign().getLocation(), ClaimPermission.Build, event);
 
         // If user is allowed to build, do nothing.
         if (denial == null)
             return;
 
         // If user is not allowed to build, prevent sign UI opening and send message.
-        GriefPrevention.sendMessage(player, TextMode.Err, denial);
+        GriefPrevention.sendMessage(player, TextMode.Err, denial.get());
         event.setCancelled(true);
     }
 
@@ -1729,13 +1730,10 @@ class PlayerEventHandler implements Listener
                     || materialInHand == Material.HONEYCOMB
                     || dyes.contains(materialInHand)))
             {
-                String noBuildReason = instance
-                        .allowBuild(player, clickedBlock
-                                        .getLocation(),
-                                clickedBlockType);
+                Supplier<String> noBuildReason = ProtectionHelper.checkPermission(player, event.getClickedBlock().getLocation(), ClaimPermission.Build, event);
                 if (noBuildReason != null)
                 {
-                    GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason);
+                    GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason.get());
                     event.setCancelled(true);
                 }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/PreventBlockBreakEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/PreventBlockBreakEvent.java
@@ -7,9 +7,10 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * An {@link Event} called when GriefPrevention prevents a {@link BlockBreakEvent}.
- * If cancelled, GriefPrevention will allow the event to complete normally.
+ * @deprecated Listen to {@link ClaimPermissionCheckEvent} and check if
+ * {@link ClaimPermissionCheckEvent#getTriggeringEvent()} {@code instanceof} {@link BlockBreakEvent}.
  */
+@Deprecated(forRemoval = true, since = "17.0.0")
 public class PreventBlockBreakEvent extends Event implements Cancellable
 {
     private final @NotNull BlockBreakEvent innerEvent;


### PR DESCRIPTION
* Update to 1.21
* Update to Java 21
  * 1.21 is compiled with Java 21
* Move to more maintainable `PotionEffectTypeCategory` for potion handling
* Use `Tag.REPLACEABLE` instead of manual material listing
  * This is the tag of blocks where placement on any surface becomes `BlockFace.SELF`. Includes long grass, dead shrubs, snow, short grass, the works.
* Extract `GriefPrevention#allowBuild`/`GriefPrevention#allowBreak` to a helper method
  * These methods have been hacky since the introduction of the `ClaimPermissionCheckEvent`, and as we saw with damage events, Spigot is serious about event constructors not being API. Moving away from constructing events is a good idea in general.
  * Improves accuracy of event funnel by not masking various events with fake `BlockPlaceEvent`/`BlockBreakEvent` constructions.
* Deprecate `PreventBlockBreakEvent`
  * Listen to `ClaimPermissionCheckEvent`, check `#getTriggeringEvent`, profit.
* Prevent claim lookup if ignoring the result anyway when milking cows (this probably should have been a separate PR, whoops)
* Update BanList to use modern version
* Fix wind charges being blocked without `/claimexplosions` enabled

This requires a recent build of Spigot - explosion type was only added to the API in [`a4ee40b7`](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/a4ee40b749f614482f5b5e52cda1b35c19df75be), 4 days ago as of this edit.