### PR TITLE
update the git commit id plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,9 +67,9 @@
             </plugin>
             <!-- Append git commit hash to version -->
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>4.0.3</version>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>9.0.1</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>


### PR DESCRIPTION
- the old used version is from Jun 09, 2021
- the project got renamed to https://github.com/git-commit-id/git-commit-id-maven-plugin and updated. 
- as far as i can see there is no extra change needed 
- I built the jar locally with commit id f2ca7ea and it was shown correctly on bstats

<img width="551" alt="image" src="https://github.com/user-attachments/assets/e28d3941-1490-4d28-a7c9-ca36cbae21cd">
