### PR TITLE
Fix for cauldron interactions on claims

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -43,6 +43,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockExplodeEvent;
+import org.bukkit.event.block.CauldronLevelChangeEvent;
 import org.bukkit.event.block.EntityBlockFormEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
@@ -776,6 +777,26 @@ public class EntityEventHandler implements Listener
 
         // FEATURE: Protect freshly-spawned players from PVP.
         preventPvpSpawnCamp(event, player);
+    }
+
+    @EventHandler
+    public void onCauldron(@NotNull CauldronLevelChangeEvent event)
+    {
+        //don't track in worlds where claims are not enabled
+        if (!GriefPrevention.instance.claimsEnabledForWorld(event.getBlock().getWorld())) return;
+
+        // Check if the entity is a player
+        Entity entity = event.getEntity();
+        if (entity == null) return;
+        if (!(entity instanceof Player player)) return;
+
+        //if the player doesn't have build permission, don't allow the interaction
+        Supplier<String> noBuildReason = ProtectionHelper.checkPermission(player, player.getLocation(), ClaimPermission.Build, event);
+        if (noBuildReason != null)
+        {
+            event.setCancelled(true);
+            GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason.get());
+        }
     }
 
     private void protectLockedDrops(@NotNull EntityPickupItemEvent event, @Nullable Player player)


### PR DESCRIPTION
Addresses #2353 in order to prevent untrusted people from interacting with cauldrons on other claims.