### PR TITLE
Migrate database configuration to separate file

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -901,6 +901,11 @@ public class GriefPrevention extends JavaPlugin
         databaseProps.setProperty("username", databaseUserName);
         databaseProps.setProperty("password", databasePassword);
 
+        // If not in use already, database settings are "secret" to discourage adoption until datastore is rewritten.
+        if (databaseUrl.isBlank()) {
+            return;
+        }
+
         // Write properties file for future usage.
         try (FileWriter writer = new FileWriter(databasePropsFile, StandardCharsets.UTF_8))
         {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -896,15 +896,15 @@ public class GriefPrevention extends JavaPlugin
         databaseUserName = legacyConfig.getString("GriefPrevention.Database.UserName", "");
         databasePassword = legacyConfig.getString("GriefPrevention.Database.Password", "");
 
-        // Set properties to loaded values.
-        databaseProps.setProperty("jdbcUrl", databaseUrl);
-        databaseProps.setProperty("username", databaseUserName);
-        databaseProps.setProperty("password", databasePassword);
-
         // If not in use already, database settings are "secret" to discourage adoption until datastore is rewritten.
         if (databaseUrl.isBlank()) {
             return;
         }
+
+        // Set properties to loaded values.
+        databaseProps.setProperty("jdbcUrl", databaseUrl);
+        databaseProps.setProperty("username", databaseUserName);
+        databaseProps.setProperty("password", databasePassword);
 
         // Write properties file for future usage.
         try (FileWriter writer = new FileWriter(databasePropsFile, StandardCharsets.UTF_8))

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -59,7 +59,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -67,12 +70,14 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -671,9 +676,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_pvp_protectPets = config.getBoolean("GriefPrevention.PvP.ProtectPetsOutsideLandClaims", false);
 
         //optional database settings
-        this.databaseUrl = config.getString("GriefPrevention.Database.URL", "");
-        this.databaseUserName = config.getString("GriefPrevention.Database.UserName", "");
-        this.databasePassword = config.getString("GriefPrevention.Database.Password", "");
+        loadDatabaseSettings(config);
 
         this.config_advanced_fixNegativeClaimblockAmounts = config.getBoolean("GriefPrevention.Advanced.fixNegativeClaimblockAmounts", true);
         this.config_advanced_claim_expiration_check_rate = config.getInt("GriefPrevention.Advanced.ClaimExpirationCheckRate", 60);
@@ -800,10 +803,6 @@ public class GriefPrevention extends JavaPlugin
         outConfig.set("GriefPrevention.HardModeZombiesBreakDoors", this.config_zombiesBreakDoors);
         outConfig.set("GriefPrevention.MobProjectilesChangeBlocks", this.config_mobProjectilesChangeBlocks);
 
-        outConfig.set("GriefPrevention.Database.URL", this.databaseUrl);
-        outConfig.set("GriefPrevention.Database.UserName", this.databaseUserName);
-        outConfig.set("GriefPrevention.Database.Password", this.databasePassword);
-
         outConfig.set("GriefPrevention.UseBanCommand", this.config_ban_useCommand);
         outConfig.set("GriefPrevention.BanCommandPattern", this.config_ban_commandFormat);
 
@@ -862,6 +861,54 @@ public class GriefPrevention extends JavaPlugin
         for (String command : commands)
         {
             this.config_pvp_blockedCommands.add(command.trim().toLowerCase());
+        }
+    }
+
+    private void loadDatabaseSettings(@NotNull FileConfiguration legacyConfig)
+    {
+        File databasePropsFile = new File(DataStore.dataLayerFolderPath, "database.properties");
+        Properties databaseProps = new Properties();
+
+        // If properties file exists, use it - old config has already been migrated.
+        if (databasePropsFile.exists() && databasePropsFile.isFile())
+        {
+            try (FileReader reader = new FileReader(databasePropsFile, StandardCharsets.UTF_8))
+            {
+                // Load properties from file.
+                databaseProps.load(reader);
+
+                // Set values from loaded properties.
+                databaseUrl = databaseProps.getProperty("jdbcUrl", "");
+                databaseUserName = databaseProps.getProperty("username", "");
+                databasePassword = databaseProps.getProperty("password", "");
+            }
+            catch (IOException e)
+            {
+                getLogger().log(Level.SEVERE, "Unable to read database.properties", e);
+            }
+
+            return;
+        }
+
+        // Otherwise, database details may not have been migrated from legacy configuration.
+        // Try to load them.
+        databaseUrl = legacyConfig.getString("GriefPrevention.Database.URL", "");
+        databaseUserName = legacyConfig.getString("GriefPrevention.Database.UserName", "");
+        databasePassword = legacyConfig.getString("GriefPrevention.Database.Password", "");
+
+        // Set properties to loaded values.
+        databaseProps.setProperty("jdbcUrl", databaseUrl);
+        databaseProps.setProperty("username", databaseUserName);
+        databaseProps.setProperty("password", databasePassword);
+
+        // Write properties file for future usage.
+        try (FileWriter writer = new FileWriter(databasePropsFile, StandardCharsets.UTF_8))
+        {
+            databaseProps.store(writer, null);
+        }
+        catch (IOException e)
+        {
+            getLogger().log(Level.SEVERE, "Unable to write database.properties", e);
         }
     }
 


### PR DESCRIPTION
Uses a properties file modeled after HikariCP's [configuration](https://github.com/brettwooldridge/HikariCP#gear-configuration-knobs-baby). Ideally will mean plug-and-play support where we don't actually have to load individual properties ourselves and translate them when the database datastore rewrite comes around.

Food for thought: Should loading fail more explosively when database.properties is unreadable/unwritable? I imagine that would only be able to happen during first time setup or migrations where file permissions might be expected to change, so I don't think it's a big deal, but I'm interested in others' opinions.

I don't foresee any issues, but I haven't tested this yet.

Closes #2331