### PR TITLE
Fix NPE with golden shovel

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1914,6 +1914,8 @@ class PlayerEventHandler implements Listener
                 return;
             }
 
+            playerData = this.dataStore.getPlayerData(player.getUniqueId());
+
             //if he's resizing a claim and that claim hasn't been deleted since he started resizing it
             if (playerData.claimResizing != null && playerData.claimResizing.inDataStore)
             {


### PR DESCRIPTION
Restores initialization missed here: https://github.com/GriefPrevention/GriefPrevention/commit/5d0ebdec36cd9c043d855c6ace15029709ec7c69#diff-3e987f7e8304fdcbd9f9f571afbbebec186bc70583b97676a68c6b5aac604478L1924

Personally, due to the rigid if-else structure of the PlayerInteractEvent handling, I believe the PlayerData variable declaration should be done inline with initialization to prevent missing cases like this in the future. There are no cases where a PlayerData fetched from the DataStore is reused in this handler.

Closes #2358