### PR TITLE
Modify claimblock accrual idle detection and handling

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
@@ -65,7 +65,7 @@ class DeliverClaimBlocksTask implements Runnable
         DataStore dataStore = instance.dataStore;
         PlayerData playerData = dataStore.getPlayerData(player.getUniqueId());
 
-        // check if player is idle. Considered idle if player's yaw has not changed
+        // check if player is idle. Considered idle if player's facing direction has not changed
         boolean isIdle = false;
         isIdle = !(playerData.lastAfkCheckLocation == null || playerData.lastAfkCheckLocation.getDirection().equals(player.getLocation().getDirection()));
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
@@ -67,7 +67,7 @@ class DeliverClaimBlocksTask implements Runnable
 
         // check if player is idle. Considered idle if player's yaw has not changed
         boolean isIdle = false;
-        isIdle = !(playerData.lastAfkCheckLocation == null || playerData.lastAfkCheckLocation.getYaw() != player.getLocation().getYaw());
+        isIdle = !(playerData.lastAfkCheckLocation == null || playerData.lastAfkCheckLocation.getDirection() != player.getLocation().getDirection());
 
         //remember current location for next time
         playerData.lastAfkCheckLocation = player.getLocation();

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
@@ -67,7 +67,7 @@ class DeliverClaimBlocksTask implements Runnable
 
         // check if player is idle. Considered idle if player's yaw has not changed
         boolean isIdle = false;
-        isIdle = !(playerData.lastAfkCheckLocation == null || playerData.lastAfkCheckLocation.getDirection() != player.getLocation().getDirection());
+        isIdle = !(playerData.lastAfkCheckLocation == null || playerData.lastAfkCheckLocation.getDirection().equals(player.getLocation().getDirection()));
 
         //remember current location for next time
         playerData.lastAfkCheckLocation = player.getLocation();

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
@@ -30,13 +30,11 @@ class DeliverClaimBlocksTask implements Runnable
 {
     private final Player player;
     private final GriefPrevention instance;
-    private final int idleThresholdSquared;
 
     public DeliverClaimBlocksTask(Player player, GriefPrevention instance)
     {
         this.player = player;
         this.instance = instance;
-        this.idleThresholdSquared = instance.config_claims_accruedIdleThreshold * instance.config_claims_accruedIdleThreshold;
     }
 
     @Override
@@ -67,45 +65,27 @@ class DeliverClaimBlocksTask implements Runnable
         DataStore dataStore = instance.dataStore;
         PlayerData playerData = dataStore.getPlayerData(player.getUniqueId());
 
-        // check if player is idle. considered idle if
-        //    in vehicle or is in water (pushed by water)
-        //    or has not moved at least defined blocks since last check
+        // check if player is idle. Considered idle if player's yaw has not changed
         boolean isIdle = false;
-        try
-        {
-            isIdle = player.isInsideVehicle() || player.getLocation().getBlock().isLiquid() ||
-                    !(playerData.lastAfkCheckLocation == null || playerData.lastAfkCheckLocation.distanceSquared(player.getLocation()) > idleThresholdSquared);
-        }
-        catch (IllegalArgumentException ignore) //can't measure distance when to/from are different worlds
-        {
-        }
+        isIdle = !(playerData.lastAfkCheckLocation == null || playerData.lastAfkCheckLocation.getYaw() != player.getLocation().getYaw());
 
         //remember current location for next time
         playerData.lastAfkCheckLocation = player.getLocation();
 
         try
         {
-            //determine how fast blocks accrue for this player //RoboMWM: addons determine this instead
+            //determine how fast blocks accrue for this player. Addons can modify this
             int accrualRate = instance.config_claims_blocksAccruedPerHour_default;
-
-            //determine idle accrual rate when idle
-            if (isIdle)
-            {
-                if (instance.config_claims_accruedIdlePercent <= 0)
-                {
-                    GriefPrevention.AddLogEntry(player.getName() + " wasn't active enough to accrue claim blocks this round.", CustomLogEntryTypes.Debug, true);
-                    return; //idle accrual percentage is disabled
-                }
-
-                accrualRate = (int) (accrualRate * (instance.config_claims_accruedIdlePercent / 100.0D));
-            }
 
             //fire event for addons
             AccrueClaimBlocksEvent event = new AccrueClaimBlocksEvent(player, accrualRate, isIdle);
             instance.getServer().getPluginManager().callEvent(event);
             if (event.isCancelled())
             {
-                GriefPrevention.AddLogEntry(player.getName() + " claim block delivery was canceled by another plugin.", CustomLogEntryTypes.Debug, true);
+                if (event.isIdle())
+                    GriefPrevention.AddLogEntry(player.getName() + " wasn't active enough to accrue claim blocks this round.", CustomLogEntryTypes.Debug, true);
+                else
+                    GriefPrevention.AddLogEntry(player.getName() + " claim block delivery was canceled by another plugin.", CustomLogEntryTypes.Debug, true);
                 return; //event was cancelled
             }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
@@ -65,7 +65,7 @@ class DeliverClaimBlocksTask implements Runnable
         DataStore dataStore = instance.dataStore;
         PlayerData playerData = dataStore.getPlayerData(player.getUniqueId());
 
-        // check if player is idle. Considered idle if player's facing direction has not changed
+        // check if player is idle (player's facing direction has not changed)
         boolean isIdle = false;
         isIdle = !(playerData.lastAfkCheckLocation == null || playerData.lastAfkCheckLocation.getDirection().equals(player.getLocation().getDirection()));
 
@@ -74,7 +74,7 @@ class DeliverClaimBlocksTask implements Runnable
 
         try
         {
-            //determine how fast blocks accrue for this player. Addons can modify this
+            //determine how fast blocks accrue for this player; can be modified by addons
             int accrualRate = instance.config_claims_blocksAccruedPerHour_default;
 
             //fire event for addons

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
@@ -65,7 +65,7 @@ class DeliverClaimBlocksTask implements Runnable
         DataStore dataStore = instance.dataStore;
         PlayerData playerData = dataStore.getPlayerData(player.getUniqueId());
 
-        // check if player is idle (player's facing direction has not changed)
+        // check if player is idle (considered idle if player's facing direction has not changed)
         boolean isIdle = false;
         isIdle = !(playerData.lastAfkCheckLocation == null || playerData.lastAfkCheckLocation.getDirection().equals(player.getLocation().getDirection()));
 
@@ -82,6 +82,7 @@ class DeliverClaimBlocksTask implements Runnable
             instance.getServer().getPluginManager().callEvent(event);
             if (event.isCancelled())
             {
+                //event is initialized as canceled if player is idle
                 if (event.isIdle())
                     GriefPrevention.AddLogEntry(player.getName() + " wasn't active enough to accrue claim blocks this round.", CustomLogEntryTypes.Debug, true);
                 else

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -130,8 +130,6 @@ public class GriefPrevention extends JavaPlugin
     public double config_claims_abandonReturnRatio;                 //the portion of claim blocks returned to a player when a claim is abandoned
     public int config_claims_blocksAccruedPerHour_default;            //how many additional blocks players get each hour of play (can be zero) without any special permissions
     public int config_claims_maxAccruedBlocks_default;                //the limit on accrued blocks (over time) for players without any special permissions.  doesn't limit purchased or admin-gifted blocks
-    public int config_claims_accruedIdleThreshold;                    //how far (in blocks) a player must move in order to not be considered afk/idle when determining accrued claim blocks
-    public int config_claims_accruedIdlePercent;                    //how much percentage of claim block accruals should idle players get
     public int config_claims_maxDepth;                                //limit on how deep claims can go
     public int config_claims_expirationDays;                        //how many days of inactivity before a player loses his claims
     public int config_claims_expirationExemptionTotalBlocks;        //total claim blocks amount which will exempt a player from claim expiration
@@ -547,9 +545,6 @@ public class GriefPrevention extends JavaPlugin
         this.config_claims_blocksAccruedPerHour_default = config.getInt("GriefPrevention.Claims.Claim Blocks Accrued Per Hour.Default", config_claims_blocksAccruedPerHour_default);
         this.config_claims_maxAccruedBlocks_default = config.getInt("GriefPrevention.Claims.MaxAccruedBlocks", 80000);
         this.config_claims_maxAccruedBlocks_default = config.getInt("GriefPrevention.Claims.Max Accrued Claim Blocks.Default", this.config_claims_maxAccruedBlocks_default);
-        this.config_claims_accruedIdleThreshold = config.getInt("GriefPrevention.Claims.AccruedIdleThreshold", 0);
-        this.config_claims_accruedIdleThreshold = config.getInt("GriefPrevention.Claims.Accrued Idle Threshold", this.config_claims_accruedIdleThreshold);
-        this.config_claims_accruedIdlePercent = config.getInt("GriefPrevention.Claims.AccruedIdlePercent", 0);
         this.config_claims_abandonReturnRatio = config.getDouble("GriefPrevention.Claims.AbandonReturnRatio", 1.0D);
         this.config_claims_automaticClaimsForNewPlayersRadius = config.getInt("GriefPrevention.Claims.AutomaticNewPlayerClaimsRadius", 4);
         this.config_claims_automaticClaimsForNewPlayersRadiusMin = Math.max(0, Math.min(this.config_claims_automaticClaimsForNewPlayersRadius,
@@ -713,8 +708,6 @@ public class GriefPrevention extends JavaPlugin
         outConfig.set("GriefPrevention.Claims.InitialBlocks", this.config_claims_initialBlocks);
         outConfig.set("GriefPrevention.Claims.Claim Blocks Accrued Per Hour.Default", this.config_claims_blocksAccruedPerHour_default);
         outConfig.set("GriefPrevention.Claims.Max Accrued Claim Blocks.Default", this.config_claims_maxAccruedBlocks_default);
-        outConfig.set("GriefPrevention.Claims.Accrued Idle Threshold", this.config_claims_accruedIdleThreshold);
-        outConfig.set("GriefPrevention.Claims.AccruedIdlePercent", this.config_claims_accruedIdlePercent);
         outConfig.set("GriefPrevention.Claims.AbandonReturnRatio", this.config_claims_abandonReturnRatio);
         outConfig.set("GriefPrevention.Claims.AutomaticNewPlayerClaimsRadius", this.config_claims_automaticClaimsForNewPlayersRadius);
         outConfig.set("GriefPrevention.Claims.AutomaticNewPlayerClaimsRadiusMinimum", this.config_claims_automaticClaimsForNewPlayersRadiusMin);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/AccrueClaimBlocksEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/AccrueClaimBlocksEvent.java
@@ -46,7 +46,7 @@ public class AccrueClaimBlocksEvent extends PlayerEvent implements Cancellable
      * 6 times per hour.
      * <br>To achieve a specific number of blocks to accrue, either multiply in advance or set
      * using {@link #setBlocksToAccrue(int)} after construction.
-     * <br>This event is initialized to canceled if @param isIdle is set to true.
+     * <br>This event is initialized as canceled if @param isIdle is set to true.
      *
      * @param player the {@link Player} receiving accruals
      * @param blocksToAccruePerHour the number of claim blocks to accrue multiplied by 6

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/AccrueClaimBlocksEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/AccrueClaimBlocksEvent.java
@@ -46,6 +46,7 @@ public class AccrueClaimBlocksEvent extends PlayerEvent implements Cancellable
      * 6 times per hour.
      * <br>To achieve a specific number of blocks to accrue, either multiply in advance or set
      * using {@link #setBlocksToAccrue(int)} after construction.
+     * <br>This event is initialized to canceled if @param isIdle is set to true.
      *
      * @param player the {@link Player} receiving accruals
      * @param blocksToAccruePerHour the number of claim blocks to accrue multiplied by 6
@@ -57,6 +58,8 @@ public class AccrueClaimBlocksEvent extends PlayerEvent implements Cancellable
         super(player);
         this.blocksToAccrue = blocksToAccruePerHour / 6;
         this.isIdle = isIdle;
+        if (isIdle)
+            this.setCancelled(true);
     }
 
     /**


### PR DESCRIPTION
- always call AccrueClaimBlocksEvent, even when player is detected as idle
- call AccrueClaimBlocksEvent as canceled if player is idle (default GP behavior)
- removes idle accrual and related config options
- only use player direction for idle detection

I'm bad at titles. While some stuff is removed, the event firing behavior has changed to allow more control to addons (API feature addition).