### PR TITLE
Add more checks to claim creation/resize

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Claim.java
@@ -25,8 +25,6 @@ import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
-import org.bukkit.World.Environment;
-import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -201,10 +199,17 @@ public class Claim
     //measurements.  all measurements are in blocks
     public int getArea()
     {
-        int claimWidth = this.greaterBoundaryCorner.getBlockX() - this.lesserBoundaryCorner.getBlockX() + 1;
-        int claimHeight = this.greaterBoundaryCorner.getBlockZ() - this.lesserBoundaryCorner.getBlockZ() + 1;
-
-        return claimWidth * claimHeight;
+        try
+        {
+            int dX = Math.addExact(Math.subtractExact(greaterBoundaryCorner.getBlockX(), lesserBoundaryCorner.getBlockX()), 1);
+            int dZ = Math.addExact(Math.subtractExact(greaterBoundaryCorner.getBlockZ(), lesserBoundaryCorner.getBlockZ()), 1);
+            return Math.multiplyExact(dX, dZ);
+        }
+        catch (ArithmeticException e)
+        {
+            // If a claim's area exceeds the max value an int can hold, return max value.
+            return Integer.MAX_VALUE;
+        }
     }
 
     public int getWidth()

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1166,7 +1166,7 @@ public abstract class DataStore
             }
             catch (ArithmeticException e)
             {
-                GriefPrevention.sendMessage(player, TextMode.Err, Messages.ResizeClaimInsufficientArea, String.valueOf(GriefPrevention.instance.config_claims_minArea));
+                GriefPrevention.sendMessage(player, TextMode.Err, Messages.ResizeNeedMoreBlocks, String.valueOf(Integer.MAX_VALUE));
                 return;
             }
 
@@ -1180,7 +1180,16 @@ public abstract class DataStore
                     return;
                 }
 
-                int newArea = newWidth * newHeight;
+                int newArea;
+                try
+                {
+                    newArea = Math.multiplyExact(newWidth, newHeight);
+                }
+                catch (ArithmeticException e)
+                {
+                    GriefPrevention.sendMessage(player, TextMode.Err, Messages.ResizeNeedMoreBlocks, String.valueOf(Integer.MAX_VALUE));
+                    return;
+                }
                 if (newArea < GriefPrevention.instance.config_claims_minArea)
                 {
                     GriefPrevention.sendMessage(player, TextMode.Err, Messages.ResizeClaimInsufficientArea, String.valueOf(GriefPrevention.instance.config_claims_minArea));
@@ -1200,7 +1209,7 @@ public abstract class DataStore
                 }
                 catch (ArithmeticException e)
                 {
-                    blocksRemainingAfter = -1;
+                    blocksRemainingAfter = Integer.MIN_VALUE + 1;
                 }
 
                 if (blocksRemainingAfter < 0)

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerData.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerData.java
@@ -150,11 +150,30 @@ public class PlayerData
     //the number of claim blocks a player has available for claiming land
     public int getRemainingClaimBlocks()
     {
-        int remainingBlocks = this.getAccruedClaimBlocks() + this.getBonusClaimBlocks() + GriefPrevention.instance.dataStore.getGroupBonusBlocks(this.playerID);
-        for (int i = 0; i < this.getClaims().size(); i++)
+        int remainingBlocks;
+        try
         {
-            Claim claim = this.getClaims().get(i);
-            remainingBlocks -= claim.getArea();
+            remainingBlocks = Math.addExact(
+                    Math.addExact(this.getAccruedClaimBlocks(), this.getBonusClaimBlocks()),
+                    GriefPrevention.instance.dataStore.getGroupBonusBlocks(this.playerID));
+        }
+        catch (ArithmeticException e)
+        {
+            // If there is an overflow adding the player's available blocks, use max value.
+            remainingBlocks = Integer.MAX_VALUE;
+        }
+        try
+        {
+            for (int i = 0; i < this.getClaims().size(); i++)
+            {
+                Claim claim = this.getClaims().get(i);
+                remainingBlocks = Math.subtractExact(remainingBlocks, claim.getArea());
+            }
+        }
+        catch (ArithmeticException e)
+        {
+            // If there is an overflow subtracting the player's claims, they don't have any blocks left.
+            return 0;
         }
 
         return remainingBlocks;


### PR DESCRIPTION
* Addresses user-facing issues in #2382
  * I don't think it's fully solved in terms of v18 readiness because we need to add sanity to the claim creation process for addons (i.e. an addon can currently create a claim with bounds that exceed a min/max int) but GP should theoretically not be capable of causing overflows by itself at this point.
* Addresses some confusing displays during overflow by presenting them as a max integer

Admin claims via /claim are still unrestricted beyond requiring that their bounds not exceed min/max integer. ~~Additional TODO for me: Does clamping claim to world border still affect /claim and/or admin claims in general?~~ Yes, all claims are limited to the world border, so that shouldn't be a concern.

This should be able to be cherry picked onto legacy if we're happy with it.