### PR TITLE
Events for when the player starts creating/editing a claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img alt="GriefPrevention" width=100% height=auto src="https://repository-images.githubusercontent.com/68339667/9b3f7c00-ce61-11ea-82d1-208eaa0606e8">
 </p>
 
-<h1 align="center">The self-service anti-griefing plugin for Minecraft servers since 2011 and Minemora uses it since 2015</h1>
+<h1 align="center">The self-service anti-griefing plugin for Minecraft servers since 2011</h1>
 
 <p align="center">
 <a href="https://github.com/TechFortress/GriefPrevention/releases/"><img alt="Downloads" src="https://img.shields.io/badge/Downloads-green" height="70px"></a>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img alt="GriefPrevention" width=100% height=auto src="https://repository-images.githubusercontent.com/68339667/9b3f7c00-ce61-11ea-82d1-208eaa0606e8">
 </p>
 
-<h1 align="center">The self-service anti-griefing plugin for Minecraft servers since 2011</h1>
+<h1 align="center">The self-service anti-griefing plugin for Minecraft servers since 2011 and Minemora uses it since 2015</h1>
 
 <p align="center">
 <a href="https://github.com/TechFortress/GriefPrevention/releases/"><img alt="Downloads" src="https://img.shields.io/badge/Downloads-green" height="70px"></a>

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -24,6 +24,9 @@ import com.griefprevention.util.command.MonitoredCommands;
 import com.griefprevention.visualization.BoundaryVisualization;
 import com.griefprevention.visualization.VisualizationType;
 import me.ryanhamshire.GriefPrevention.events.ClaimInspectionEvent;
+import me.ryanhamshire.GriefPrevention.events.StartClaimCreationEvent;
+import me.ryanhamshire.GriefPrevention.events.StartClaimResizeEvent;
+import me.ryanhamshire.GriefPrevention.events.StartSubdivideClaimCreationEvent;
 import me.ryanhamshire.GriefPrevention.util.BoundingBox;
 import org.bukkit.BanList;
 import org.bukkit.Bukkit;
@@ -1969,6 +1972,8 @@ class PlayerEventHandler implements Listener
                         playerData.claimResizing = claim;
                         playerData.lastShovelLocation = clickedBlock.getLocation();
                         GriefPrevention.sendMessage(player, TextMode.Instr, Messages.ResizeStart);
+
+                        Bukkit.getPluginManager().callEvent(new StartClaimResizeEvent(player, claim, clickedBlock));
                     }
 
                     //if he didn't click on a corner and is in subdivision mode, he's creating a new subdivision
@@ -1989,6 +1994,8 @@ class PlayerEventHandler implements Listener
                                 GriefPrevention.sendMessage(player, TextMode.Instr, Messages.SubdivisionStart);
                                 playerData.lastShovelLocation = clickedBlock.getLocation();
                                 playerData.claimSubdividing = claim;
+
+                                Bukkit.getPluginManager().callEvent(new StartSubdivideClaimCreationEvent(player, clickedBlock, claim));
                             }
                         }
 
@@ -2087,6 +2094,8 @@ class PlayerEventHandler implements Listener
 
                 //show him where he's working
                 BoundaryVisualization.visualizeArea(player, new BoundingBox(clickedBlock), VisualizationType.INITIALIZE_ZONE);
+
+                Bukkit.getPluginManager().callEvent(new StartClaimCreationEvent(player, clickedBlock));
             }
 
             //otherwise, he's trying to finish creating a claim by setting the other boundary corner

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/StartClaimCreationEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/StartClaimCreationEvent.java
@@ -1,0 +1,38 @@
+package me.ryanhamshire.GriefPrevention.events;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class StartClaimCreationEvent extends PlayerEvent
+{
+
+    private final @NotNull Block clickedBlock;
+
+    public StartClaimCreationEvent(@NotNull Player who, @NotNull Block clickedBlock)
+    {
+        super(who);
+        this.clickedBlock = clickedBlock;
+    }
+
+    public final @NotNull Block getClickedBlock()
+    {
+        return this.clickedBlock;
+    }
+
+    // Listenable event requirements
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    public static HandlerList getHandlerList()
+    {
+        return HANDLERS;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers()
+    {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/StartClaimResizeEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/StartClaimResizeEvent.java
@@ -1,0 +1,46 @@
+package me.ryanhamshire.GriefPrevention.events;
+
+import me.ryanhamshire.GriefPrevention.Claim;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class StartClaimResizeEvent extends PlayerEvent
+{
+
+    private final @NotNull Claim claim;
+    private final @NotNull Block clickedBlock;
+
+    public StartClaimResizeEvent(@NotNull Player who, @NotNull Claim claim, @NotNull Block clickedBlock)
+    {
+        super(who);
+        this.claim = claim;
+        this.clickedBlock = clickedBlock;
+    }
+
+    public final @NotNull Claim getClaim()
+    {
+        return this.claim;
+    }
+
+    public final @NotNull Block getClickedBlock()
+    {
+        return this.clickedBlock;
+    }
+
+    // Listenable event requirements
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    public static HandlerList getHandlerList()
+    {
+        return HANDLERS;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers()
+    {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/StartSubdivideClaimCreationEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/StartSubdivideClaimCreationEvent.java
@@ -1,0 +1,37 @@
+package me.ryanhamshire.GriefPrevention.events;
+
+import me.ryanhamshire.GriefPrevention.Claim;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class StartSubdivideClaimCreationEvent extends StartClaimCreationEvent {
+
+    private final @NotNull Claim parent;
+
+    public StartSubdivideClaimCreationEvent(@NotNull Player who, @NotNull Block clickedBlock, @NotNull Claim parent)
+    {
+        super(who, clickedBlock);
+        this.parent = parent;
+    }
+
+    public final @NotNull Claim getParent()
+    {
+        return this.parent;
+    }
+
+    // Listenable event requirements
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    public static HandlerList getHandlerList()
+    {
+        return HANDLERS;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers()
+    {
+        return HANDLERS;
+    }
+}


### PR DESCRIPTION
Useful events I needed to add some extra custom visualizations, may be useful for other people too

(ignore the test commit)

I needed the to detect the moment the player starts editing (creating extending) to start the visualization task (The green visuals that dinamically move with player targer block)

Example achieved with these events + custom BoundaryVisualization:
https://github.com/user-attachments/assets/98ee1a79-622e-4c26-9795-1d4d606cfada

