### PR TITLE
Extendclaim enhancement

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -43,6 +43,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockExplodeEvent;
+import org.bukkit.event.block.CauldronLevelChangeEvent;
 import org.bukkit.event.block.EntityBlockFormEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
@@ -776,6 +777,26 @@ public class EntityEventHandler implements Listener
 
         // FEATURE: Protect freshly-spawned players from PVP.
         preventPvpSpawnCamp(event, player);
+    }
+
+    @EventHandler
+    public void onCauldron(@NotNull CauldronLevelChangeEvent event)
+    {
+        //don't track in worlds where claims are not enabled
+        if (!GriefPrevention.instance.claimsEnabledForWorld(event.getBlock().getWorld())) return;
+
+        // Check if the entity is a player
+        Entity entity = event.getEntity();
+        if (entity == null) return;
+        if (!(entity instanceof Player player)) return;
+
+        //if the player doesn't have build permission, don't allow the interaction
+        Supplier<String> noBuildReason = ProtectionHelper.checkPermission(player, player.getLocation(), ClaimPermission.Build, event);
+        if (noBuildReason != null)
+        {
+            event.setCancelled(true);
+            GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason.get());
+        }
     }
 
     private void protectLockedDrops(@NotNull EntityPickupItemEvent event, @Nullable Player player)

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -984,7 +984,7 @@ public class GriefPrevention extends JavaPlugin
                 return false;
             }
 
-            // Unless the player has the extendclaim permission, he requires claim modification tool in hand
+            //requires claim modification tool in hand, except if player has the extendclaim permission.
             if (player.getGameMode() != GameMode.CREATIVE
                     && player.getItemInHand().getType() != GriefPrevention.instance.config_claims_modificationTool
                     && !player.hasPermission("griefprevention.extendclaim.toolbypass")) {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -984,7 +984,7 @@ public class GriefPrevention extends JavaPlugin
                 return false;
             }
 
-            //requires claim modification tool in hand, except if player has the extendclaim permission.
+            //requires claim modification tool in hand, except if player is in creative or has the extendclaim permission.
             if (player.getGameMode() != GameMode.CREATIVE
                     && player.getItemInHand().getType() != GriefPrevention.instance.config_claims_modificationTool
                     && !player.hasPermission("griefprevention.extendclaim.toolbypass")) {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -987,7 +987,7 @@ public class GriefPrevention extends JavaPlugin
             // Unless the player has the extendclaim permission, he requires claim modification tool in hand
             if (player.getGameMode() != GameMode.CREATIVE
                     && player.getItemInHand().getType() != GriefPrevention.instance.config_claims_modificationTool
-                    && !player.hasPermission("griefprevention.extendclaim.no_tool")) {
+                    && !player.hasPermission("griefprevention.extendclaim.toolbypass")) {
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.MustHoldModificationToolForThat);
                 return true;
             }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -941,8 +941,9 @@ public class GriefPrevention extends JavaPlugin
             }
 
             // Unless the player has the extendclaim permission, he requires claim modification tool in hand
-            if (player.getGameMode() != GameMode.CREATIVE && (player.getItemInHand().getType() != GriefPrevention.instance.config_claims_modificationTool && !player.hasPermission("griefprevention.extendclaim")))
-            {
+            if (player.getGameMode() != GameMode.CREATIVE
+                    && player.getItemInHand().getType() != GriefPrevention.instance.config_claims_modificationTool
+                    && !player.hasPermission("griefprevention.extendclaim.no_tool")) {
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.MustHoldModificationToolForThat);
                 return true;
             }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -940,8 +940,8 @@ public class GriefPrevention extends JavaPlugin
                 return false;
             }
 
-            //requires claim modification tool in hand
-            if (player.getGameMode() != GameMode.CREATIVE && player.getItemInHand().getType() != GriefPrevention.instance.config_claims_modificationTool)
+            // Unless the player has the extendclaim permission, he requires claim modification tool in hand
+            if (player.getGameMode() != GameMode.CREATIVE && (player.getItemInHand().getType() != GriefPrevention.instance.config_claims_modificationTool && !player.hasPermission("griefprevention.extendclaim")))
             {
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.MustHoldModificationToolForThat);
                 return true;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -211,6 +211,9 @@ permissions:
             griefprevention.deleteclaimsinworld: true
             griefprevention.unlockothersdrops: true
             griefprevention.seeclaimsize: true
+    griefprevention.extendclaim.toolbypass:
+        description: Allows a player to extend a claim without a golden shovel.
+        default: op
     griefprevention.unlockdrops:
         description: Grants permission to use /unlockdrops.
         default: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -213,7 +213,7 @@ permissions:
             griefprevention.seeclaimsize: true
     griefprevention.extendclaim.toolbypass:
         description: Allows a player to extend a claim without a modification tool.
-        default: op
+        default: false
     griefprevention.unlockdrops:
         description: Grants permission to use /unlockdrops.
         default: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -212,7 +212,7 @@ permissions:
             griefprevention.unlockothersdrops: true
             griefprevention.seeclaimsize: true
     griefprevention.extendclaim.toolbypass:
-        description: Allows a player to extend a claim without a golden shovel.
+        description: Allows a player to extend a claim without a modification tool.
         default: op
     griefprevention.unlockdrops:
         description: Grants permission to use /unlockdrops.


### PR DESCRIPTION
added permission for extendclaim to not require modification tool. In my case, people wished for expanding without the tool and I think its a benefit for the plugin too.

Dont know if `griefprevention.extendclaim` is appropriate to you, this is something that just came in my mind