### PR TITLE
Revise the ROOTED_DIRT dupe fix

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -39,6 +39,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Waterlogged;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Animals;
 import org.bukkit.entity.Creature;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1564,7 +1564,7 @@ class PlayerEventHandler implements Listener
                                 clickedBlockType == Material.LOOM ||
                                 clickedBlockType == Material.PUMPKIN ||
                                 clickedBlockType == Material.RESPAWN_ANCHOR ||
-                                clickedBlockType == Material.ROOTED_DIRT ||
+                                (clickedBlockType == Material.ROOTED_DIRT && player.getInventory().getItemInMainHand().getType().toString().toLowerCase().endsWith("_hoe") && player.getInventory().getItemInMainHand().containsEnchantment(Enchantment.SILK_TOUCH)) ||
                                 clickedBlockType == Material.STONECUTTER ||
                                 clickedBlockType == Material.SWEET_BERRY_BUSH ||
                                 clickedBlockType == Material.DECORATED_POT

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1565,7 +1565,7 @@ class PlayerEventHandler implements Listener
                                 clickedBlockType == Material.LOOM ||
                                 clickedBlockType == Material.PUMPKIN ||
                                 clickedBlockType == Material.RESPAWN_ANCHOR ||
-                                (clickedBlockType == Material.ROOTED_DIRT && player.getInventory().getItemInMainHand().getType().toString().toLowerCase().endsWith("_hoe") && player.getInventory().getItemInMainHand().containsEnchantment(Enchantment.SILK_TOUCH)) ||
+                                (clickedBlockType == Material.ROOTED_DIRT && player.getInventory().getItemInMainHand().getType().toString().toLowerCase().endsWith("_hoe")) ||
                                 clickedBlockType == Material.STONECUTTER ||
                                 clickedBlockType == Material.SWEET_BERRY_BUSH ||
                                 clickedBlockType == Material.DECORATED_POT

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1564,7 +1564,7 @@ class PlayerEventHandler implements Listener
                                 clickedBlockType == Material.LOOM ||
                                 clickedBlockType == Material.PUMPKIN ||
                                 clickedBlockType == Material.RESPAWN_ANCHOR ||
-                                (clickedBlockType == Material.ROOTED_DIRT && player.getInventory().getItemInMainHand().getType().toString().toLowerCase().endsWith("_hoe")) ||
+                                (clickedBlockType == Material.ROOTED_DIRT && (Tag.ITEMS_HOES.isTagged(player.getInventory().getItemInMainHand().getType()) || Tag.ITEMS_HOES.isTagged(player.getInventory().getItemInOffHand().getType()))) ||
                                 clickedBlockType == Material.STONECUTTER ||
                                 clickedBlockType == Material.SWEET_BERRY_BUSH ||
                                 clickedBlockType == Material.DECORATED_POT

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1564,7 +1564,7 @@ class PlayerEventHandler implements Listener
                                 clickedBlockType == Material.LOOM ||
                                 clickedBlockType == Material.PUMPKIN ||
                                 clickedBlockType == Material.RESPAWN_ANCHOR ||
-                                (clickedBlockType == Material.ROOTED_DIRT && (Tag.ITEMS_HOES.isTagged(player.getInventory().getItemInMainHand().getType()) || Tag.ITEMS_HOES.isTagged(player.getInventory().getItemInOffHand().getType()))) ||
+                                (clickedBlockType == Material.ROOTED_DIRT && Tag.ITEMS_HOES.isTagged(event.getMaterial())) ||
                                 clickedBlockType == Material.STONECUTTER ||
                                 clickedBlockType == Material.SWEET_BERRY_BUSH ||
                                 clickedBlockType == Material.DECORATED_POT

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -39,7 +39,6 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Waterlogged;
-import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Animals;
 import org.bukkit.entity.Creature;


### PR DESCRIPTION
The current fix to #1535 just makes it so ROOTED_DIRT can't be right-clicked at all if it's protected. My server is currently experiencing an issue caused by this approach. We have Rooted Dirt in our PvP arena and when players right-click it, with or without an item in hand, such as to throw a splash potion or to eat, the action is canceled and they are told they cannot open containers while combat tagged.

This adjustment will still address the dupe glitch but will do so specifically for that purpose. Any other interactions where the player needs to aim at ROOTED_DIRT will still function.