### PR TITLE
Update build process

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
 build_script:
   - mvn clean package -DskipTests --batch-mode
 test_script:
-  - mvn surefire:test --batch-mode
+  - mvn dependency:properties surefire:test --batch-mode
 cache:
   - C:\Users\appveyor\.m2
 artifacts:

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <!-- Default empty argument line to prevent Surefire config causing crashes if no other JVM args are set. -->
+        <argLine/>
     </properties>
 
     <issueManagement>
@@ -82,6 +84,18 @@
                     <allowTimestampedSnapshots>true</allowTimestampedSnapshots>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <!-- Required to inflate Mockito jar location. -->
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
         <pluginManagement>
@@ -93,13 +107,21 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.8.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.5.2</version>
                     <configuration>
+                        <!-- Add Mockito agent and retain existing JVM args, if any. -->
+                        <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} -Xshare:off</argLine>
                         <!-- GitHub Actions offers 2 cores for Linux. -->
                         <forkCount>2</forkCount>
                         <!--
@@ -109,7 +131,6 @@
                          -->
                         <reuseForks>false</reuseForks>
                     </configuration>
-                    <version>3.5.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,22 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Add Mockito agent and retain existing JVM args, if any. -->
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} -Xshare:off</argLine>
+                    <!-- GitHub Actions offers 2 cores for Linux. -->
+                    <forkCount>2</forkCount>
+                    <!--
+                        This is somewhat required for testing Bukkit code due to Bukkit's design.
+                        There are so many static fields so deeply intertwined with each other
+                        that correctly initializing everything is a huge hassle.
+                     -->
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
         </plugins>
 
         <pluginManagement>
@@ -119,18 +135,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.5.2</version>
-                    <configuration>
-                        <!-- Add Mockito agent and retain existing JVM args, if any. -->
-                        <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} -Xshare:off</argLine>
-                        <!-- GitHub Actions offers 2 cores for Linux. -->
-                        <forkCount>2</forkCount>
-                        <!--
-                            This is somewhat required for testing Bukkit code due to Bukkit's design.
-                            There are so many static fields so deeply intertwined with each other
-                            that correctly initializing everything is a huge hassle.
-                         -->
-                        <reuseForks>false</reuseForks>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.14.0</version>
             </plugin>
             <!-- Append git commit hash to version -->
             <plugin>
@@ -76,7 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <tagNameFormat>@{project.version}</tagNameFormat>
                     <allowTimestampedSnapshots>true</allowTimestampedSnapshots>
@@ -89,17 +89,16 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.4.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.1.2</version>
                     <configuration>
                         <!-- GitHub Actions offers 2 cores for Linux. -->
                         <forkCount>2</forkCount>
@@ -110,21 +109,22 @@
                          -->
                         <reuseForks>false</reuseForks>
                     </configuration>
+                    <version>3.5.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.4.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
+                    <version>3.1.4</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>23.0.0</version>
+            <version>26.0.2</version>
             <!-- Annotations are not required at runtime, only during compilation. -->
             <scope>provided</scope>
         </dependency>
@@ -150,13 +150,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.3</version>
+            <version>5.12.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.4.0</version>
+            <version>5.16.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -35,10 +35,6 @@
 
     <repositories>
         <repository>
-            <id>paper-repo</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
-        </repository>
-        <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     </licenses>
 
     <properties>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -56,10 +57,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
-                <configuration>
-                    <source>21</source>
-                    <target>21</target>
-                </configuration>
             </plugin>
             <!-- Append git commit hash to version -->
             <plugin>


### PR DESCRIPTION
* Drop unnecessary and outdated Paper repo
* Use release option when compiling instead of source/target
  * The release option supersedes source and target. It performs their functions and also ensures that API added in later Java versions is not in use. https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html#option-release
* Update Maven plugins and non-Spigot dependencies
* Fix warnings about Mockito injecting its own agent (and prevent failure when agent injection is disabled in future Java releases)
* Fix warnings about resource sharing when forking