### PR TITLE
make permissiontrust a hierarchal permission

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/ClaimPermission.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/ClaimPermission.java
@@ -28,22 +28,25 @@ public enum ClaimPermission
      */
     Edit(Messages.OnlyOwnersModifyClaims),
     /**
+     * ClaimPermission that allows users to grant ClaimPermissions. Grants {@link #Build}, {@link #Inventory}, and {@link #Access}.
+     * Command: /permissiontrust or /managetrust
+     */
+    Manage(Messages.NoPermissionTrust),
+    /**
      * ClaimPermission used for building checks. Grants {@link #Inventory} and {@link #Access}.
+     * Command: /trust
      */
     Build(Messages.NoBuildPermission),
     /**
-     * ClaimPermission used for inventory management checks. Grants {@link #Access}.
+     * ClaimPermission used for inventory management, such as containers and farming. Grants {@link #Access}.
+     * Command: /containertrust
      */
     Inventory(Messages.NoContainersPermission),
     /**
      * ClaimPermission used for basic access.
+     * Command: /accesstrust
      */
-    Access(Messages.NoAccessPermission),
-    /**
-     * ClaimPermission that allows users to grant ClaimPermissions. Uses a separate track from normal
-     * permissions and does not grant any other permissions.
-     */
-    Manage(Messages.NoPermissionTrust);
+    Access(Messages.NoAccessPermission);
 
     private final Messages denialMessage;
 
@@ -68,7 +71,6 @@ public enum ClaimPermission
      */
     public boolean isGrantedBy(ClaimPermission other)
     {
-        if (other == Manage || this == Manage) return other == this || other == Edit;
         // This uses declaration order to compare! If trust levels are reordered this method must be rewritten.
         return other != null && other.ordinal() <= this.ordinal();
     }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1524,7 +1524,7 @@ public class GriefPrevention extends JavaPlugin
             //requires exactly one parameter, the other player's name
             if (args.length != 1) return false;
 
-            this.handleTrustCommand(player, null, args[0]);  //null indicates permissiontrust to the helper method
+            this.handleTrustCommand(player, ClaimPermission.Manage, args[0]);
 
             return true;
         }
@@ -2413,32 +2413,6 @@ public class GriefPrevention extends JavaPlugin
             if (claim.checkPermission(player, ClaimPermission.Manage, null) != null)
             {
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.NoPermissionTrust, claim.getOwnerName());
-                return;
-            }
-
-            //see if the player has the level of permission he's trying to grant
-            Supplier<String> errorMessage;
-
-            //permission level null indicates granting permission trust
-            if (permissionLevel == null)
-            {
-                errorMessage = claim.checkPermission(player, ClaimPermission.Edit, null);
-                if (errorMessage != null)
-                {
-                    errorMessage = () -> "Only " + claim.getOwnerName() + " can grant /PermissionTrust here.";
-                }
-            }
-
-            //otherwise just use the ClaimPermission enum values
-            else
-            {
-                errorMessage = claim.checkPermission(player, permissionLevel, null);
-            }
-
-            //error message for trying to grant a permission the player doesn't have
-            if (errorMessage != null)
-            {
-                GriefPrevention.sendMessage(player, TextMode.Err, Messages.CantGrantThatPermission);
                 return;
             }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
@@ -60,7 +60,6 @@ public enum Messages
     DeleteTopLevelClaim("To delete a subdivision, stand inside it.  Otherwise, use /abandontoplevelclaim to delete this claim and all subdivisions."),
     AbandonSuccess("Claim abandoned.  You now have {0} available claim blocks.", "0: remaining claim blocks"),
     ConfirmAbandonAllClaims("Are you sure you want to abandon ALL of your claims?  Please confirm with /abandonallclaims confirm"),
-    CantGrantThatPermission("You can't grant a permission you don't have yourself."),
     GrantPermissionNoClaim("Stand inside the claim where you want to grant permission."),
     GrantPermissionConfirmation("Granted {0} permission to {1} {2}.", "0: target player; 1: permission description; 2: scope (changed claims)"),
     ManageUniversalPermissionsInstruction("To manage permissions for ALL your claims, stand outside them."),

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -39,9 +39,9 @@ commands:
       aliases: at
       permission: griefprevention.claims
     permissiontrust:
-      description: Grants a player permission to grant his level of permission to others.
-      usage: /<command> <player>.  Permits a player to share his permission level with others.
-      aliases: pt
+      description: Grants a player permission to manage the claim trustlist.
+      usage: /<command> <player>.  Permits a player to /trust and /untrust players in the claim.
+      aliases: [pt, managetrust]
       permission: griefprevention.claims
     subdivideclaims:
       description: Switches the shovel tool to subdivision mode, used to subdivide your claims.


### PR DESCRIPTION
I guess I'll do this first, closing #2367 and then simplify more of the permission system (removing permission handling #2326 and the like) later.

- place in proper order in ClaimPermission
    - remove special logic for Manage permission
- GriefPrevention#handleTrustCommand (guh these giant classes)
    - Remove extra logic for permissiontrust exception
- Remove Messages#CantGrantThatPermission enum
- update description in plugin.yml, add managetrust alias

I haven't checked through the untrust logic yet.