### PR TITLE
Fix inverted isIdle condition

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DeliverClaimBlocksTask.java
@@ -66,8 +66,7 @@ class DeliverClaimBlocksTask implements Runnable
         PlayerData playerData = dataStore.getPlayerData(player.getUniqueId());
 
         // check if player is idle (considered idle if player's facing direction has not changed)
-        boolean isIdle = false;
-        isIdle = !(playerData.lastAfkCheckLocation == null || playerData.lastAfkCheckLocation.getDirection().equals(player.getLocation().getDirection()));
+        boolean isIdle = playerData.lastAfkCheckLocation != null && playerData.lastAfkCheckLocation.getDirection().equals(player.getLocation().getDirection());
 
         //remember current location for next time
         playerData.lastAfkCheckLocation = player.getLocation();


### PR DESCRIPTION
> direction check should be inverted, because if their direction is changed they shouldn't be idle.

Use Jikoo's newly-learned DeMorgan's law for better readability

closes #2512
fixes bug introduced in b6512aa8d21417ba17cb32a82ca244b088f14c3b