### PR TITLE
Players can re-enter and leash vehicles/mounts they've previously dismounted

### DIFF
--- a/src/main/java/com/griefprevention/handlers/RideableHandler.java
+++ b/src/main/java/com/griefprevention/handlers/RideableHandler.java
@@ -1,6 +1,5 @@
 package com.griefprevention.handlers;
 
-import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -12,7 +11,11 @@ import me.ryanhamshire.GriefPrevention.GriefPrevention;
 
 public class RideableHandler implements Listener {
 
-    private final NamespacedKey RIDEABLE_OWNER = new NamespacedKey(GriefPrevention.instance, "rideable_owner");
+    private final GriefPrevention instance;
+
+    public RideableHandler(GriefPrevention instance) {
+        this.instance = instance;
+    }
 
     @EventHandler(ignoreCancelled = true)
     public void onDismount(EntityDismountEvent event) {
@@ -22,6 +25,6 @@ public class RideableHandler implements Listener {
 
         // set rideable owner
         PersistentDataContainer pdc = event.getEntity().getPersistentDataContainer();
-        pdc.set(RIDEABLE_OWNER, PersistentDataType.STRING, playerId);
+        pdc.set(instance.RIDEABLE_OWNER, PersistentDataType.STRING, playerId);
     }
 }

--- a/src/main/java/com/griefprevention/handlers/RideableHandler.java
+++ b/src/main/java/com/griefprevention/handlers/RideableHandler.java
@@ -1,0 +1,27 @@
+package com.griefprevention.handlers;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDismountEvent;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import me.ryanhamshire.GriefPrevention.GriefPrevention;
+
+public class RideableHandler implements Listener {
+
+    private final NamespacedKey RIDEABLE_OWNER = new NamespacedKey(GriefPrevention.instance, "rideable_owner");
+
+    @EventHandler(ignoreCancelled = true)
+    public void onDismount(EntityDismountEvent event) {
+
+        if(!(event.getDismounted() instanceof Player player)) return;
+        String playerId = player.getUniqueId().toString();
+
+        // set rideable owner
+        PersistentDataContainer pdc = event.getEntity().getPersistentDataContainer();
+        pdc.set(RIDEABLE_OWNER, PersistentDataType.STRING, playerId);
+    }
+}

--- a/src/main/java/com/griefprevention/handlers/VehicleHandler.java
+++ b/src/main/java/com/griefprevention/handlers/VehicleHandler.java
@@ -14,7 +14,7 @@ import me.ryanhamshire.GriefPrevention.GriefPrevention;
 public class VehicleHandler implements Listener{
 
     private final NamespacedKey VEHICLE_OWNER = new NamespacedKey(GriefPrevention.instance, "vehicle_owner");
-
+    
     @EventHandler (ignoreCancelled = true)
     public void onExitVehicle(VehicleExitEvent event) {
 

--- a/src/main/java/com/griefprevention/handlers/VehicleHandler.java
+++ b/src/main/java/com/griefprevention/handlers/VehicleHandler.java
@@ -1,6 +1,5 @@
 package com.griefprevention.handlers;
 
-import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.event.EventHandler;
@@ -13,8 +12,12 @@ import me.ryanhamshire.GriefPrevention.GriefPrevention;
 
 public class VehicleHandler implements Listener{
 
-    private final NamespacedKey VEHICLE_OWNER = new NamespacedKey(GriefPrevention.instance, "vehicle_owner");
-    
+    private final GriefPrevention instance;
+
+    public VehicleHandler(GriefPrevention instance) {
+        this.instance = instance;
+    }
+
     @EventHandler (ignoreCancelled = true)
     public void onExitVehicle(VehicleExitEvent event) {
 
@@ -23,7 +26,7 @@ public class VehicleHandler implements Listener{
         String playerId = player.getUniqueId().toString();
         
         Vehicle vehicle = event.getVehicle();
-        vehicle.getPersistentDataContainer().set(VEHICLE_OWNER, PersistentDataType.STRING, playerId);
+        vehicle.getPersistentDataContainer().set(instance.VEHICLE_OWNER, PersistentDataType.STRING, playerId);
     }
 
     public void onEnterVehicle(VehicleEnterEvent event) {

--- a/src/main/java/com/griefprevention/handlers/VehicleHandler.java
+++ b/src/main/java/com/griefprevention/handlers/VehicleHandler.java
@@ -1,0 +1,35 @@
+package com.griefprevention.handlers;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Vehicle;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.vehicle.VehicleEnterEvent;
+import org.bukkit.event.vehicle.VehicleExitEvent;
+import org.bukkit.persistence.PersistentDataType;
+
+import me.ryanhamshire.GriefPrevention.GriefPrevention;
+
+public class VehicleHandler implements Listener{
+
+    private final NamespacedKey VEHICLE_OWNER = new NamespacedKey(GriefPrevention.instance, "vehicle_owner");
+
+    @EventHandler (ignoreCancelled = true)
+    public void onExitVehicle(VehicleExitEvent event) {
+
+        // only care about players
+        if(!(event.getExited() instanceof Player player)) return;
+        String playerId = player.getUniqueId().toString();
+        
+        Vehicle vehicle = event.getVehicle();
+        vehicle.getPersistentDataContainer().set(VEHICLE_OWNER, PersistentDataType.STRING, playerId);
+    }
+
+    public void onEnterVehicle(VehicleEnterEvent event) {
+
+        // only care about players
+        if(!(event.getEntered() instanceof Player player)) return;
+
+    }
+}

--- a/src/main/java/com/griefprevention/handlers/VehicleHandler.java
+++ b/src/main/java/com/griefprevention/handlers/VehicleHandler.java
@@ -4,7 +4,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.vehicle.VehicleEnterEvent;
 import org.bukkit.event.vehicle.VehicleExitEvent;
 import org.bukkit.persistence.PersistentDataType;
 
@@ -28,11 +27,5 @@ public class VehicleHandler implements Listener{
         Vehicle vehicle = event.getVehicle();
         vehicle.getPersistentDataContainer().set(instance.VEHICLE_OWNER, PersistentDataType.STRING, playerId);
     }
-
-    public void onEnterVehicle(VehicleEnterEvent event) {
-
-        // only care about players
-        if(!(event.getEntered() instanceof Player player)) return;
-
-    }
+    
 }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1165,10 +1165,6 @@ class PlayerEventHandler implements Listener
                 if(player.getUniqueId().toString().equals(playerId)) return;
             }
 
-            // ignore checks if vehicle's owner is the player interacting
-            String playerId = pdc.get(instance.VEHICLE_OWNER, PersistentDataType.STRING);
-            if(player.getUniqueId().toString().equals(playerId)) return;
-
             //if the entity is in a claim
             Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, null);
             if (claim != null)

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1154,16 +1154,14 @@ class PlayerEventHandler implements Listener
         if (instance.config_claims_preventTheft && entity instanceof Vehicle vehicle)
         {
             
-            // Checks if vehicle has owner.
-            // See: {@link VehicleHandler}
-
-            // gets pdc from vehicle
+            // lets player enter their own vehicles
+            // See {@link VehicleHandler} to see how vehicle owners are set
             PersistentDataContainer pdc = vehicle.getPersistentDataContainer();
             if(pdc.has(instance.VEHICLE_OWNER)) {
-                // ignore checks if vehicle's owner is the player interacting
                 String playerId = pdc.get(instance.VEHICLE_OWNER, PersistentDataType.STRING);
                 if(player.getUniqueId().toString().equals(playerId)) return;
             }
+            
 
             //if the entity is in a claim
             Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, null);
@@ -1186,6 +1184,15 @@ class PlayerEventHandler implements Listener
         //if the entity is an animal, apply container rules
         if ((instance.config_claims_preventTheft && (entity instanceof Animals || entity instanceof Fish)) || (entity.getType() == EntityType.VILLAGER && instance.config_claims_villagerTradingRequiresTrust))
         {
+
+            // lets player interact with their own animals
+            // See {@link RideableHandler} to see how animal owners are set (only on dismount)
+            PersistentDataContainer pdc = entity.getPersistentDataContainer();
+            if(pdc.has(instance.RIDEABLE_OWNER)) {
+                String playerId = pdc.get(instance.RIDEABLE_OWNER, PersistentDataType.STRING);
+                if(player.getUniqueId().toString().equals(playerId)) return;
+            }
+
             //if the entity is in a claim
             Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, null);
             if (claim != null)
@@ -1214,10 +1221,8 @@ class PlayerEventHandler implements Listener
         if (instance.config_claims_preventTheft && entity instanceof Creature && itemInHand.getType() == Material.LEAD)
         {
 
-            // Checks if rideable has owner.
-            // See: {@link RideableHandler}
-
-            // gets pdc from rideable
+            // lets player leash their own rideables
+            // See {@link RideableHandler} to see how rideable owners are set
             PersistentDataContainer pdc = entity.getPersistentDataContainer();
             if(pdc.has(instance.RIDEABLE_OWNER)) {
                 // ignore checks if rideable's owner is the player interacting

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -123,6 +123,7 @@ class PlayerEventHandler implements Listener
 
     //vehicle owner key
     private final NamespacedKey VEHICLE_OWNER;
+    private final NamespacedKey RIDEABLE_OWNER;
 
     //timestamps of login and logout notifications in the last minute
     private final ArrayList<Long> recentLoginLogoutNotifications = new ArrayList<>();
@@ -149,6 +150,7 @@ class PlayerEventHandler implements Listener
         this.dataStore = dataStore;
         this.instance = plugin;
         this.VEHICLE_OWNER = new NamespacedKey(instance, "vehicle_owner");
+        this.RIDEABLE_OWNER = new NamespacedKey(instance, "rideable_owner");
         // Initialize empty on load so never null just in case. Reload after plugins enable.
         this.bannedWordFinder = new WordFinder(List.of());
         this.pvpBlockedCommands = new MonitoredCommands(List.of());
@@ -1216,6 +1218,17 @@ class PlayerEventHandler implements Listener
         //if preventing theft, prevent leashing claimed creatures
         if (instance.config_claims_preventTheft && entity instanceof Creature && itemInHand.getType() == Material.LEAD)
         {
+
+
+            // Checks if rideable has owner.
+            // See: {@link RideableHandler}
+            PersistentDataContainer pdc = entity.getPersistentDataContainer();
+            if(!pdc.has(RIDEABLE_OWNER)) return;
+
+            // ignore checks if rideable owner is the player
+            String playerId = pdc.get(RIDEABLE_OWNER, PersistentDataType.STRING);
+            if(player.getUniqueId().toString().equals(playerId)) return;
+
             Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, playerData.lastClaim);
             if (claim != null)
             {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -38,7 +38,6 @@ import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Tag;
 import org.bukkit.World;
@@ -121,10 +120,6 @@ class PlayerEventHandler implements Listener
     //number of milliseconds in a day
     private final long MILLISECONDS_IN_DAY = 1000 * 60 * 60 * 24;
 
-    //vehicle owner key
-    private final NamespacedKey VEHICLE_OWNER;
-    private final NamespacedKey RIDEABLE_OWNER;
-
     //timestamps of login and logout notifications in the last minute
     private final ArrayList<Long> recentLoginLogoutNotifications = new ArrayList<>();
 
@@ -149,8 +144,6 @@ class PlayerEventHandler implements Listener
     {
         this.dataStore = dataStore;
         this.instance = plugin;
-        this.VEHICLE_OWNER = new NamespacedKey(instance, "vehicle_owner");
-        this.RIDEABLE_OWNER = new NamespacedKey(instance, "rideable_owner");
         // Initialize empty on load so never null just in case. Reload after plugins enable.
         this.bannedWordFinder = new WordFinder(List.of());
         this.pvpBlockedCommands = new MonitoredCommands(List.of());
@@ -1163,11 +1156,13 @@ class PlayerEventHandler implements Listener
             
             // Checks if vehicle has owner.
             // See: {@link VehicleHandler}
-            PersistentDataContainer pdc = vehicle.getPersistentDataContainer();
-            if(!pdc.has(VEHICLE_OWNER)) return;
 
-            // ignore checks if vehicle owner is the player
-            String playerId = pdc.get(VEHICLE_OWNER, PersistentDataType.STRING);
+            // gets pdc from vehicle
+            PersistentDataContainer pdc = vehicle.getPersistentDataContainer();
+            if(!pdc.has(instance.VEHICLE_OWNER)) return;
+
+            // ignore checks if vehicle's owner is the player interacting
+            String playerId = pdc.get(instance.VEHICLE_OWNER, PersistentDataType.STRING);
             if(player.getUniqueId().toString().equals(playerId)) return;
 
             //if the entity is in a claim
@@ -1222,11 +1217,13 @@ class PlayerEventHandler implements Listener
 
             // Checks if rideable has owner.
             // See: {@link RideableHandler}
-            PersistentDataContainer pdc = entity.getPersistentDataContainer();
-            if(!pdc.has(RIDEABLE_OWNER)) return;
 
-            // ignore checks if rideable owner is the player
-            String playerId = pdc.get(RIDEABLE_OWNER, PersistentDataType.STRING);
+            // gets pdc from rideable
+            PersistentDataContainer pdc = entity.getPersistentDataContainer();
+            if(!pdc.has(instance.RIDEABLE_OWNER)) return;
+
+            // ignore checks if rideable's owner is the player interacting
+            String playerId = pdc.get(instance.RIDEABLE_OWNER, PersistentDataType.STRING);
             if(player.getUniqueId().toString().equals(playerId)) return;
 
             Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, playerData.lastClaim);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1159,7 +1159,11 @@ class PlayerEventHandler implements Listener
 
             // gets pdc from vehicle
             PersistentDataContainer pdc = vehicle.getPersistentDataContainer();
-            if(!pdc.has(instance.VEHICLE_OWNER)) return;
+            if(pdc.has(instance.VEHICLE_OWNER)) {
+                // ignore checks if vehicle's owner is the player interacting
+                String playerId = pdc.get(instance.VEHICLE_OWNER, PersistentDataType.STRING);
+                if(player.getUniqueId().toString().equals(playerId)) return;
+            }
 
             // ignore checks if vehicle's owner is the player interacting
             String playerId = pdc.get(instance.VEHICLE_OWNER, PersistentDataType.STRING);
@@ -1214,17 +1218,16 @@ class PlayerEventHandler implements Listener
         if (instance.config_claims_preventTheft && entity instanceof Creature && itemInHand.getType() == Material.LEAD)
         {
 
-
             // Checks if rideable has owner.
             // See: {@link RideableHandler}
 
             // gets pdc from rideable
             PersistentDataContainer pdc = entity.getPersistentDataContainer();
-            if(!pdc.has(instance.RIDEABLE_OWNER)) return;
-
-            // ignore checks if rideable's owner is the player interacting
-            String playerId = pdc.get(instance.RIDEABLE_OWNER, PersistentDataType.STRING);
-            if(player.getUniqueId().toString().equals(playerId)) return;
+            if(pdc.has(instance.RIDEABLE_OWNER)) {
+                // ignore checks if rideable's owner is the player interacting
+                String playerId = pdc.get(instance.RIDEABLE_OWNER, PersistentDataType.STRING);
+                if(player.getUniqueId().toString().equals(playerId)) return;
+            }
 
             Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, playerData.lastClaim);
             if (claim != null)


### PR DESCRIPTION
I tested locally and it works, but this should get some more testing, but this should address #295. This can also be a good foundation to allow for a later PR for better leasehes handling to address #2503 

One thing to note, this uses PDC instead of caching in map in memory. My reason for this is to persist these across server restarts/crashes. 

This is a very friendly implementation to where the claim owner (or anyone with permission) still has full access to move and destroy the vehicles/rideables. And, only the most recent player who previously exited/dismounted can re-enter.

Also since we need handle to 2 new events I've split those off into the griefprevention namespace instead of creating ryanhamshire one.

Discussed this a fair bit in the discord but would like some thoughts from @Jikoo (I believe this is 