### PR TITLE
Make Refunding Enderpearls on Failed Teleportation Configurable 

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -122,6 +122,7 @@ public class GriefPrevention extends JavaPlugin
     public boolean config_claims_lockFenceGates;                    //whether fence gates should be locked by default (require /accesstrust)
     public boolean config_claims_preventNonPlayerCreatedPortals;    // whether portals where we cannot determine the creating player should be prevented from creation in claims
     public boolean config_claims_enderPearlsRequireAccessTrust;        //whether teleporting into a claim with a pearl requires access trust
+    public boolean config_claims_refundEnderPearls;                   // Whether to refund ender pearls after failing to teleport into a claim that requires trust
     public boolean config_claims_raidTriggersRequireBuildTrust;      //whether raids are triggered by a player that doesn't have build permission in that claim
     public int config_claims_maxClaimsPerPlayer;                    //maximum number of claims per player
     public boolean config_claims_villagerTradingRequiresTrust;      //whether trading with a claimed villager requires permission
@@ -539,6 +540,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_claims_lockFenceGates = config.getBoolean("GriefPrevention.Claims.LockFenceGates", true);
         this.config_claims_preventNonPlayerCreatedPortals = config.getBoolean("GriefPrevention.Claims.PreventNonPlayerCreatedPortals", false);
         this.config_claims_enderPearlsRequireAccessTrust = config.getBoolean("GriefPrevention.Claims.EnderPearlsRequireAccessTrust", true);
+        this.config_claims_refundEnderPearls = config.getBoolean("GriefPrevention.Claims.EnderPearlsRefund", true);
         this.config_claims_raidTriggersRequireBuildTrust = config.getBoolean("GriefPrevention.Claims.RaidTriggersRequireBuildTrust", true);
         this.config_claims_initialBlocks = config.getInt("GriefPrevention.Claims.InitialBlocks", 100);
         this.config_claims_blocksAccruedPerHour_default = config.getInt("GriefPrevention.Claims.BlocksAccruedPerHour", 100);
@@ -701,6 +703,7 @@ public class GriefPrevention extends JavaPlugin
         outConfig.set("GriefPrevention.Claims.LockTrapDoors", this.config_claims_lockTrapDoors);
         outConfig.set("GriefPrevention.Claims.LockFenceGates", this.config_claims_lockFenceGates);
         outConfig.set("GriefPrevention.Claims.EnderPearlsRequireAccessTrust", this.config_claims_enderPearlsRequireAccessTrust);
+        outConfig.set("GriefPrevention.Claims.EnderPearlsRefund", this.config_claims_refundEnderPearls);
         outConfig.set("GriefPrevention.Claims.RaidTriggersRequireBuildTrust", this.config_claims_raidTriggersRequireBuildTrust);
         outConfig.set("GriefPrevention.Claims.ProtectHorses", this.config_claims_protectHorses);
         outConfig.set("GriefPrevention.Claims.ProtectDonkeys", this.config_claims_protectDonkeys);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1028,7 +1028,10 @@ class PlayerEventHandler implements Listener
         GriefPrevention.sendMessage(player, TextMode.Err, noAccessReason.get());
         event.setCancelled(true);
         if (cause == TeleportCause.ENDER_PEARL)
+        {
+            if (!instance.config_claims_refundEnderPearls) return;
             player.getInventory().addItem(new ItemStack(Material.ENDER_PEARL));
+        }
     }
 
     //when a player triggers a raid (in a claim)


### PR DESCRIPTION
This seeks to make the refunding of ender pearls when a teleportation fails in a claim (specifically if they use an ender pearl) a configurable config option.

It's small, however, certain servers have infinite ender pearls, which causes friction with Grief Prevention because this isn't configurable. 