### PR TITLE
Allow setting `MaximumDepth` on a per-world basis

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
@@ -89,9 +89,10 @@ class AutoExtendClaimTask implements Runnable
         this.chunks = chunks;
         this.worldType = worldType;
         this.lowestExistingY = Math.min(lowestExistingY, claim.getLesserBoundaryCorner().getBlockY());
+        World world = Objects.requireNonNull(claim.getLesserBoundaryCorner().getWorld());
         this.minY = Math.max(
-                Objects.requireNonNull(claim.getLesserBoundaryCorner().getWorld()).getMinHeight(),
-                GriefPrevention.instance.config_claims_maxDepth);
+                world.getMinHeight(),
+                GriefPrevention.instance.getMaxDepth(world));
     }
 
     @Override

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -325,7 +325,7 @@ public class BlockEventHandler implements Listener
         else if (GriefPrevention.instance.config_claims_automaticClaimsForNewPlayersRadius > -1 && player.hasPermission("griefprevention.createclaims") && block.getType() == Material.CHEST)
         {
             //if the chest is too deep underground, don't create the claim and explain why
-            if (GriefPrevention.instance.config_claims_preventTheft && block.getY() < GriefPrevention.instance.config_claims_maxDepth)
+            if (GriefPrevention.instance.config_claims_preventTheft && block.getY() < GriefPrevention.instance.getMaxDepth(block.getWorld()))
             {
                 GriefPrevention.sendMessage(player, TextMode.Warn, Messages.TooDeepToClaim);
                 return;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -881,8 +881,8 @@ public abstract class DataStore
         int smallx, bigx, smally, bigy, smallz, bigz;
 
         int worldMinY = world.getMinHeight();
-        y1 = Math.max(worldMinY, Math.max(GriefPrevention.instance.config_claims_maxDepth, y1));
-        y2 = Math.max(worldMinY, Math.max(GriefPrevention.instance.config_claims_maxDepth, y2));
+        y1 = Math.max(worldMinY, Math.max(GriefPrevention.instance.getMaxDepth(world), y1));
+        y2 = Math.max(worldMinY, Math.max(GriefPrevention.instance.getMaxDepth(world), y2));
 
         //determine small versus big inputs
         if (x1 < x2)
@@ -1111,10 +1111,10 @@ public abstract class DataStore
 
         // Use the lowest of the old and new depths.
         newDepth = Math.min(newDepth, oldDepth);
-        // Cap depth to maximum depth allowed by the configuration.
-        newDepth = Math.max(newDepth, GriefPrevention.instance.config_claims_maxDepth);
         // Cap the depth to the world's minimum height.
         World world = Objects.requireNonNull(claim.getLesserBoundaryCorner().getWorld());
+        // Cap depth to maximum depth allowed by the configuration.
+        newDepth = Math.max(newDepth, GriefPrevention.instance.getMaxDepth(world));
         newDepth = Math.max(newDepth, world.getMinHeight());
 
         return newDepth;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -232,6 +232,7 @@ public class GriefPrevention extends JavaPlugin
     public boolean config_silenceBans;                              //whether to remove quit messages on banned players
 
     public HashMap<String, Integer> config_seaLevelOverride;        //override for sea level, because bukkit doesn't report the right value for all situations
+    public HashMap<String, Integer> config_claims_maxDepthOverride; //per-world override for maximum claim depth
 
     public boolean config_limitTreeGrowth;                          //whether trees should be prevented from growing into a claim from outside
     public PistonMode config_pistonMovement;                            //Setting for piston check options
@@ -596,6 +597,25 @@ public class GriefPrevention extends JavaPlugin
             this.config_claims_maxDepth = Integer.MIN_VALUE;
             AddLogEntry("Updated default value for GriefPrevention.Claims.MaximumDepth to " + Integer.MIN_VALUE);
         }
+
+        //maximum depth per world
+        this.config_claims_maxDepthOverride = new HashMap<>();
+        for (World world : worlds)
+        {
+            String configPath = "GriefPrevention.Claims.MaximumDepthOverrides." + world.getName();
+            if (config.contains(configPath))
+            {
+                int maxDepthOverride = config.getInt(configPath);
+                outConfig.set(configPath, maxDepthOverride);
+                this.config_claims_maxDepthOverride.put(world.getName(), maxDepthOverride);
+            }
+            else
+            {
+                // Don't write default values to config - absence means "use global setting"
+                outConfig.set(configPath, null);
+            }
+        }
+
         this.config_claims_chestClaimExpirationDays = config.getInt("GriefPrevention.Claims.Expiration.ChestClaimDays", 7);
         this.config_claims_unusedClaimExpirationDays = config.getInt("GriefPrevention.Claims.Expiration.UnusedClaimDays", 14);
         this.config_claims_expirationDays = config.getInt("GriefPrevention.Claims.Expiration.AllClaims.DaysInactive", 60);
@@ -3831,6 +3851,11 @@ public class GriefPrevention extends JavaPlugin
         {
             return overrideValue;
         }
+    }
+
+    public int getMaxDepth(World world)
+    {
+        return this.config_claims_maxDepthOverride.getOrDefault(world.getName(), this.config_claims_maxDepth);
     }
 
     public boolean containsBlockedIP(String message)


### PR DESCRIPTION
Adds support for setting different maximum claim depths on a per-world basis. This lets server admins fine-tune claim depth limits for each world instead of using a single global setting everywhere. For example, admins might want claims in the overworld to go down as much as they can, to bedrock level, but in the nether you only want claims down to `Y=127`, so players can build safely on the nether roof while leaving the lower areas available for everyone to explore and mine.

This change will not affect default and existing configs — interested admins will need to **manually add overrides** for the worlds in the config, e.g.:
```
GriefPrevention:
  Claims:
    MaximumDepth: 16          # Global default
    MaximumDepthOverrides:
      world_nether: 127            # Nether-specific limit
      creative_world: -2147483648  # No depth limit in creative world
```