### PR TITLE
Fix incorrect Y bounds check

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
@@ -137,11 +137,12 @@ class AutoExtendClaimTask implements Runnable
                     {
                         // If we've hit minimum Y we're done searching.
                         if (yTooSmall(newY)) return this.minY;
+                        newY--;
                     }
                     // Because we found a player block, repeatedly check the next block in the column.
-                    while (isPlayerBlock(chunkSnapshot, x, --newY, z));
+                    while (isPlayerBlock(chunkSnapshot, x, newY, z));
 
-                    // Undo increment for unsuccessful player block check.
+                    // Undo final decrement for unsuccessful player block check.
                     newY++;
 
                     // Move built level down to current level.

--- a/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
@@ -133,15 +133,13 @@ class AutoExtendClaimTask implements Runnable
                     // If the block is natural, ignore it and continue searching the same Y level.
                     if (!isPlayerBlock(chunkSnapshot, x, newY, z)) continue;
 
-                    // If the block is player-placed and we're at the minimum Y allowed, we're done searching.
-                    if (yTooSmall(y)) return this.minY;
-
-                    // Because we found a player block, repeatedly check the next block in the column.
-                    while (isPlayerBlock(chunkSnapshot, x, newY--, z))
+                    do
                     {
                         // If we've hit minimum Y we're done searching.
-                        if (yTooSmall(y)) return this.minY;
+                        if (yTooSmall(newY)) return this.minY;
                     }
+                    // Because we found a player block, repeatedly check the next block in the column.
+                    while (isPlayerBlock(chunkSnapshot, x, --newY, z));
 
                     // Undo increment for unsuccessful player block check.
                     newY++;


### PR DESCRIPTION
Fixes an error I made in #1839 - the Y being checked is not the Y being decremented. Nice and confusing!

I think `newY--` inside of the conditional might have actually been problematic, but I'm not sure. That's one of the "gotcha" tricks they like to pull in basic Java courses, because the behavior of the postfix tends to be that it happens after the operations complete, while the prefix operator would execute before. It's possible that we were checking the block above instead. I split it out into a separate line so we don't have to worry about it.

I also took the opportunity to use a do-while because I'm extra like that.

Closes #2529 