### PR TITLE
Add configuration option to disable pet protection entirely

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -112,6 +112,7 @@ public class GriefPrevention extends JavaPlugin
 
     public boolean config_claims_preventGlobalMonsterEggs; //whether monster eggs can be placed regardless of trust.
     public boolean config_claims_preventTheft;                        //whether containers and crafting blocks are protectable
+    public boolean config_claims_ownablePets;                             //whether pets are owned
     public boolean config_claims_protectCreatures;                    //whether claimed animals may be injured by players without permission
     public boolean config_claims_protectHorses;                        //whether horses on a claim should be protected by that claim's rules
     public boolean config_claims_protectDonkeys;                    //whether donkeys on a claim should be protected by that claim's rules
@@ -529,6 +530,7 @@ public class GriefPrevention extends JavaPlugin
 
         this.config_claims_preventGlobalMonsterEggs = config.getBoolean("GriefPrevention.Claims.PreventGlobalMonsterEggs", true);
         this.config_claims_preventTheft = config.getBoolean("GriefPrevention.Claims.PreventTheft", true);
+        this.config_claims_ownablePets = config.getBoolean("GriefPrevention.Claims.OwnablePets", true);
         this.config_claims_protectCreatures = config.getBoolean("GriefPrevention.Claims.ProtectCreatures", true);
         this.config_claims_protectHorses = config.getBoolean("GriefPrevention.Claims.ProtectHorses", true);
         this.config_claims_protectDonkeys = config.getBoolean("GriefPrevention.Claims.ProtectDonkeys", true);
@@ -695,6 +697,7 @@ public class GriefPrevention extends JavaPlugin
 
         outConfig.set("GriefPrevention.Claims.PreventGlobalMonsterEggs", this.config_claims_preventGlobalMonsterEggs);
         outConfig.set("GriefPrevention.Claims.PreventTheft", this.config_claims_preventTheft);
+        outConfig.set("GriefPrevention.Claims.OwnablePets", this.config_claims_ownablePets);
         outConfig.set("GriefPrevention.Claims.ProtectCreatures", this.config_claims_protectCreatures);
         outConfig.set("GriefPrevention.Claims.PreventButtonsSwitches", this.config_claims_preventButtonsSwitches);
         outConfig.set("GriefPrevention.Claims.LockWoodenDoors", this.config_claims_lockWoodenDoors);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1090,7 +1090,8 @@ class PlayerEventHandler implements Listener
                     UUID ownerID = tameable.getOwner().getUniqueId();
 
                     //if the player interacting is the owner or an admin in ignore claims mode, always allow
-                    if (player.getUniqueId().equals(ownerID) || playerData.ignoreClaims)
+                    //also if onwnable pets has been disabled
+                    if (player.getUniqueId().equals(ownerID) || playerData.ignoreClaims || !instance.config_claims_ownablePets)
                     {
                         return;
                     }


### PR DESCRIPTION
This adds the option `GriefPrevention.Claims.OwnablePets` (defaults to `true`) to the config. If set to `false`, every player can interact with pets regardless of ownership. Otherwise the behaviour is unchanged to the current one.

I needed this for my server and figured it might be useful for others too.

I am not sure where the documentation should go. Happy to add it, if I get some instructions.