### PR TITLE
Add Hoppers require build trust setting

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1683,7 +1683,7 @@ public abstract class DataStore
         this.addDefault(defaults, Messages.ManageOneClaimPermissionsInstruction, "To manage permissions for a specific claim, stand inside it.", null);
         this.addDefault(defaults, Messages.CollectivePublic, "the public", "as in 'granted the public permission to...'");
         this.addDefault(defaults, Messages.BuildPermission, "build", null);
-        this.addDefault(defaults, Messages.ContainersPermission, "access containers and animals (hoppers may require build trust when configured)", null);
+        this.addDefault(defaults, Messages.ContainersPermission, "access containers and animals", null);
         this.addDefault(defaults, Messages.AccessPermission, "use buttons and levers", null);
         this.addDefault(defaults, Messages.PermissionsPermission, "manage permissions", null);
         this.addDefault(defaults, Messages.LocationCurrentClaim, "in this claim", null);
@@ -1754,7 +1754,7 @@ public abstract class DataStore
         this.addDefault(defaults, Messages.NoOwnerBuildUnderSiege, "You can't make changes while under siege.", null);
         this.addDefault(defaults, Messages.NoAccessPermission, "You don't have {0}'s permission to use that.", "0: owner name.  access permission controls buttons, levers, and beds");
         this.addDefault(defaults, Messages.NoContainersSiege, "This claim is under siege by {0}.  No one can access containers here right now.", "0: attacker name");
-        this.addDefault(defaults, Messages.NoContainersPermission, "You don't have {0}'s permission to use that.", "0: owner's name.  containers also include crafting blocks and may include hoppers requiring build trust when configured");
+        this.addDefault(defaults, Messages.NoContainersPermission, "You don't have {0}'s permission to use that.", "0: owner's name.  containers also include crafting blocks");
         this.addDefault(defaults, Messages.OwnerNameForAdminClaims, "an administrator", "as in 'You don't have an administrator's permission to build here.'");
         this.addDefault(defaults, Messages.UnknownPlayerName, "someone", "Name used for unknown players. UUID will be appended if available: \"someone (01234567-0123-0123-0123-0123456789ab)\"");
         this.addDefault(defaults, Messages.ClaimTooSmallForEntities, "This claim isn't big enough for that.  Try enlarging it.", null);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1683,7 +1683,7 @@ public abstract class DataStore
         this.addDefault(defaults, Messages.ManageOneClaimPermissionsInstruction, "To manage permissions for a specific claim, stand inside it.", null);
         this.addDefault(defaults, Messages.CollectivePublic, "the public", "as in 'granted the public permission to...'");
         this.addDefault(defaults, Messages.BuildPermission, "build", null);
-        this.addDefault(defaults, Messages.ContainersPermission, "access containers and animals", null);
+        this.addDefault(defaults, Messages.ContainersPermission, "access containers and animals (hoppers may require build trust when configured)", null);
         this.addDefault(defaults, Messages.AccessPermission, "use buttons and levers", null);
         this.addDefault(defaults, Messages.PermissionsPermission, "manage permissions", null);
         this.addDefault(defaults, Messages.LocationCurrentClaim, "in this claim", null);
@@ -1754,7 +1754,7 @@ public abstract class DataStore
         this.addDefault(defaults, Messages.NoOwnerBuildUnderSiege, "You can't make changes while under siege.", null);
         this.addDefault(defaults, Messages.NoAccessPermission, "You don't have {0}'s permission to use that.", "0: owner name.  access permission controls buttons, levers, and beds");
         this.addDefault(defaults, Messages.NoContainersSiege, "This claim is under siege by {0}.  No one can access containers here right now.", "0: attacker name");
-        this.addDefault(defaults, Messages.NoContainersPermission, "You don't have {0}'s permission to use that.", "0: owner's name.  containers also include crafting blocks");
+        this.addDefault(defaults, Messages.NoContainersPermission, "You don't have {0}'s permission to use that.", "0: owner's name.  containers also include crafting blocks and may include hoppers requiring build trust when configured");
         this.addDefault(defaults, Messages.OwnerNameForAdminClaims, "an administrator", "as in 'You don't have an administrator's permission to build here.'");
         this.addDefault(defaults, Messages.UnknownPlayerName, "someone", "Name used for unknown players. UUID will be appended if available: \"someone (01234567-0123-0123-0123-0123456789ab)\"");
         this.addDefault(defaults, Messages.ClaimTooSmallForEntities, "This claim isn't big enough for that.  Try enlarging it.", null);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -115,6 +115,7 @@ public class GriefPrevention extends JavaPlugin
 
     public boolean config_claims_preventGlobalMonsterEggs; //whether monster eggs can be placed regardless of trust.
     public boolean config_claims_preventTheft;                        //whether containers and crafting blocks are protectable
+    public boolean config_claims_hoppersRequireBuildTrust;            //whether hoppers require build trust instead of container trust
     public boolean config_claims_protectCreatures;                    //whether claimed animals may be injured by players without permission
     public boolean config_claims_protectHorses;                        //whether horses on a claim should be protected by that claim's rules
     public boolean config_claims_protectDonkeys;                    //whether donkeys on a claim should be protected by that claim's rules
@@ -564,6 +565,7 @@ public class GriefPrevention extends JavaPlugin
 
         this.config_claims_preventGlobalMonsterEggs = config.getBoolean("GriefPrevention.Claims.PreventGlobalMonsterEggs", true);
         this.config_claims_preventTheft = config.getBoolean("GriefPrevention.Claims.PreventTheft", true);
+        this.config_claims_hoppersRequireBuildTrust = config.getBoolean("GriefPrevention.Claims.HoppersRequireBuildTrust", false);
         this.config_claims_protectCreatures = config.getBoolean("GriefPrevention.Claims.ProtectCreatures", true);
         this.config_claims_protectHorses = config.getBoolean("GriefPrevention.Claims.ProtectHorses", true);
         this.config_claims_protectDonkeys = config.getBoolean("GriefPrevention.Claims.ProtectDonkeys", true);
@@ -828,6 +830,7 @@ public class GriefPrevention extends JavaPlugin
 
         outConfig.set("GriefPrevention.Claims.PreventGlobalMonsterEggs", this.config_claims_preventGlobalMonsterEggs);
         outConfig.set("GriefPrevention.Claims.PreventTheft", this.config_claims_preventTheft);
+        outConfig.set("GriefPrevention.Claims.HoppersRequireBuildTrust", this.config_claims_hoppersRequireBuildTrust);
         outConfig.set("GriefPrevention.Claims.ProtectCreatures", this.config_claims_protectCreatures);
         outConfig.set("GriefPrevention.Claims.PreventButtonsSwitches", this.config_claims_preventButtonsSwitches);
         outConfig.set("GriefPrevention.Claims.LockWoodenDoors", this.config_claims_lockWoodenDoors);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1744,7 +1744,13 @@ class PlayerEventHandler implements Listener
             {
                 playerData.lastClaim = claim;
 
-                Supplier<String> noContainersReason = claim.checkPermission(player, ClaimPermission.Inventory, event);
+                ClaimPermission requiredPermission = ClaimPermission.Inventory;
+                if (instance.config_claims_hoppersRequireBuildTrust && clickedBlockType == Material.HOPPER)
+                {
+                    requiredPermission = ClaimPermission.Build;
+                }
+
+                Supplier<String> noContainersReason = claim.checkPermission(player, requiredPermission, event);
                 if (noContainersReason != null)
                 {
                     event.setCancelled(true);


### PR DESCRIPTION
This adds a new option in the config file that when enabled ensures hoppers require build trust instead of container trust. It allows someone to have container trust while still not being able to open hoppers.

This is good in situations where players are using hoppers as item filters in shop/game machines where they plan to allow public container trust to certain containers while keeping the hopper protected.