### PR TITLE
Allow setting `MinimumY` on a per-world basis

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
@@ -98,9 +98,10 @@ public class AutoExtendClaimTask implements Runnable
         this.chunks = chunks;
         this.worldType = worldType;
         this.lowestExistingY = Math.min(lowestExistingY, claim.getLesserBoundaryCorner().getBlockY());
+        World world = Objects.requireNonNull(claim.getLesserBoundaryCorner().getWorld());
         this.minY = Math.max(
-                Objects.requireNonNull(claim.getLesserBoundaryCorner().getWorld()).getMinHeight(),
-                GriefPrevention.instance.config_claims_minY);
+                world.getMinHeight(),
+                GriefPrevention.instance.getMinY(world));
     }
 
     @Override

--- a/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
@@ -99,9 +99,7 @@ public class AutoExtendClaimTask implements Runnable
         this.worldType = worldType;
         this.lowestExistingY = Math.min(lowestExistingY, claim.getLesserBoundaryCorner().getBlockY());
         World world = Objects.requireNonNull(claim.getLesserBoundaryCorner().getWorld());
-        this.minY = Math.max(
-                world.getMinHeight(),
-                GriefPrevention.instance.getMinY(world));
+        this.minY = Math.max(world.getMinHeight(), GriefPrevention.instance.getMinY(world));
     }
 
     @Override

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -337,7 +337,7 @@ public class BlockEventHandler implements Listener
         else if (GriefPrevention.instance.config_claims_automaticClaimsForNewPlayersRadius > -1 && player.hasPermission("griefprevention.createclaims") && block.getType() == Material.CHEST)
         {
             //if the chest is too deep underground, don't create the claim and explain why
-            if (GriefPrevention.instance.config_claims_preventTheft && block.getY() < GriefPrevention.instance.config_claims_minY)
+            if (GriefPrevention.instance.config_claims_preventTheft && block.getY() < GriefPrevention.instance.getMinY(block.getWorld()))
             {
                 GriefPrevention.sendMessage(player, TextMode.Warn, Messages.TooDeepToClaim);
                 return;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -864,8 +864,8 @@ public abstract class DataStore
         int smallx, bigx, smally, bigy, smallz, bigz;
 
         int worldMinY = world.getMinHeight();
-        y1 = Math.max(worldMinY, Math.max(GriefPrevention.instance.config_claims_minY, y1));
-        y2 = Math.max(worldMinY, Math.max(GriefPrevention.instance.config_claims_minY, y2));
+        y1 = Math.max(worldMinY, Math.max(GriefPrevention.instance.getMinY(world), y1));
+        y2 = Math.max(worldMinY, Math.max(GriefPrevention.instance.getMinY(world), y2));
 
         //determine small versus big inputs
         if (x1 < x2)
@@ -1083,10 +1083,10 @@ public abstract class DataStore
 
         // Use the lowest of the old and new depths.
         newDepth = Math.min(newDepth, oldDepth);
-        // Cap depth to maximum depth allowed by the configuration.
-        newDepth = Math.max(newDepth, GriefPrevention.instance.config_claims_minY);
         // Cap the depth to the world's minimum height.
         World world = Objects.requireNonNull(claim.getLesserBoundaryCorner().getWorld());
+        // Cap depth to maximum depth allowed by the configuration.
+        newDepth = Math.max(newDepth, GriefPrevention.instance.getMinY(world));
         newDepth = Math.max(newDepth, world.getMinHeight());
 
         return newDepth;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -216,6 +216,7 @@ public class GriefPrevention extends JavaPlugin
     public boolean config_silenceBans;                              //whether to remove quit messages on banned players
 
     public HashMap<String, Integer> config_seaLevelOverride;        //override for sea level, because bukkit doesn't report the right value for all situations
+    public HashMap<String, Integer> config_claims_minYOverride;     //per-world override for minimum Y coordinate
 
     public boolean config_limitTreeGrowth;                          //whether trees should be prevented from growing into a claim from outside
     public PistonMode config_pistonMovement;                            //Setting for piston check options
@@ -576,6 +577,24 @@ public class GriefPrevention extends JavaPlugin
                                     minY + ", which may not have been intended.");
                     break; // Show warning once only - minY is a global setting
                 }
+            }
+        }
+
+        //minimum Y per world
+        this.config_claims_minYOverride = new HashMap<>();
+        for (World world : worlds)
+        {
+            String configPath = "GriefPrevention.Claims.MinimumYOverrides." + world.getName();
+            if (config.contains(configPath))
+            {
+                int minYOverride = config.getInt(configPath);
+                outConfig.set(configPath, minYOverride);
+                this.config_claims_minYOverride.put(world.getName(), minYOverride);
+            }
+            else
+            {
+                // Don't write default values to config - absence means "use global setting"
+                outConfig.set(configPath, null);
             }
         }
 
@@ -2984,6 +3003,11 @@ public class GriefPrevention extends JavaPlugin
         {
             return overrideValue;
         }
+    }
+
+    public int getMinY(World world)
+    {
+        return this.config_claims_minYOverride.getOrDefault(world.getName(), this.config_claims_minY);
     }
 
     public boolean containsBlockedIP(String message)


### PR DESCRIPTION
Port of #2527

Adds support for setting different maximum claim depths on a per-world basis. This lets server admins fine-tune claim depth limits for each world instead of using a single global setting everywhere. For example, admins might want claims in the overworld to go down as much as they can, to bedrock level, but in the nether you only want claims down to `Y=127`, so players can build safely on the nether roof while leaving the lower areas available for everyone to explore and mine.

This change will not affect default and existing configs — interested admins will need to **manually add overrides** for the worlds in the config, e.g.:
```
GriefPrevention:
  Claims:
    MinimumY: 16                # Global default
    MinimumYOverrides:
      world_nether: 127              # Nether-specific limit
      creative_world: -2147483648    # No depth limit in creative world
```