### PR TITLE
Adds a config flag to allow container access during pvp combat timer when the container is in a claim AND the player has access to the claim

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -173,6 +173,7 @@ public class GriefPrevention extends JavaPlugin
     public boolean config_pvp_punishLogout;                            //whether to kill players who log out during PvP combat
     public int config_pvp_combatTimeoutSeconds;                        //how long combat is considered to continue after the most recent damage
     public boolean config_pvp_allowCombatItemDrop;                    //whether a player can drop items during combat to hide them
+    public boolean config_pvp_allowTrustedContainerAccess;          //whether a player can access containers, in allowed claims, during combat
     public ArrayList<String> config_pvp_blockedCommands;            //list of commands which may not be used during pvp combat
     public boolean config_pvp_noCombatInPlayerLandClaims;            //whether players may fight in player-owned land claims
     public boolean config_pvp_noCombatInAdminLandClaims;            //whether players may fight in admin-owned land claims
@@ -631,6 +632,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_pvp_punishLogout = config.getBoolean("GriefPrevention.PvP.PunishLogout", true);
         this.config_pvp_combatTimeoutSeconds = config.getInt("GriefPrevention.PvP.CombatTimeoutSeconds", 15);
         this.config_pvp_allowCombatItemDrop = config.getBoolean("GriefPrevention.PvP.AllowCombatItemDrop", false);
+        this.config_pvp_allowTrustedContainerAccess = config.getBoolean("GriefPrevention.PvP.AllowOwnedContainerAccess", true);
         String bannedPvPCommandsList = config.getString("GriefPrevention.PvP.BlockedSlashCommands", "/home;/vanish;/spawn;/tpa");
 
         this.config_lockDeathDropsInPvpWorlds = config.getBoolean("GriefPrevention.ProtectItemsDroppedOnDeath.PvPWorlds", false);
@@ -792,6 +794,7 @@ public class GriefPrevention extends JavaPlugin
         outConfig.set("GriefPrevention.PvP.PunishLogout", this.config_pvp_punishLogout);
         outConfig.set("GriefPrevention.PvP.CombatTimeoutSeconds", this.config_pvp_combatTimeoutSeconds);
         outConfig.set("GriefPrevention.PvP.AllowCombatItemDrop", this.config_pvp_allowCombatItemDrop);
+        outConfig.set("GriefPrevention.PvP.AllowOwnedContainerAccess", this.config_pvp_allowTrustedContainerAccess);
         outConfig.set("GriefPrevention.PvP.BlockedSlashCommands", bannedPvPCommandsList);
         outConfig.set("GriefPrevention.PvP.ProtectPlayersInLandClaims.PlayerOwnedClaims", this.config_pvp_noCombatInPlayerLandClaims);
         outConfig.set("GriefPrevention.PvP.ProtectPlayersInLandClaims.AdministrativeClaims", this.config_pvp_noCombatInAdminLandClaims);


### PR DESCRIPTION
**AS-IS**
When the pvp timer is active, players are not allowed to access any containers.

**Change**
When a player has a pvp timer active, he is allowed to access container within a claim where he has trust.

**Reason**
When players run inside their claim (eg. to restock supplies), but the pvp timer is still active. They need to wait until it runs out before they can access their chests. With this option enabled, it allows players to quicker access their own chests inside their claim. 
Access to public containers (while in combat) (in non-claimed areas) is still forbidden.

Tested on paper `paper-1.21.10-117`