### PR TITLE
Adds option config_pvp_allowTrustedContainerAccess

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -186,6 +186,8 @@ public class GriefPrevention extends JavaPlugin
     public boolean config_pvp_punishLogout;                            //whether to kill players who log out during PvP combat
     public int config_pvp_combatTimeoutSeconds;                        //how long combat is considered to continue after the most recent damage
     public boolean config_pvp_allowCombatItemDrop;                    //whether a player can drop items during combat to hide them
+    public boolean config_pvp_allowTrustedContainerAccess;          //whether a player can access containers, in allowed claims, during combat
+    
     public ArrayList<String> config_pvp_blockedCommands;            //list of commands which may not be used during pvp combat
     public boolean config_pvp_noCombatInPlayerLandClaims;            //whether players may fight in player-owned land claims
     public boolean config_pvp_noCombatInAdminLandClaims;            //whether players may fight in admin-owned land claims
@@ -656,6 +658,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_pvp_punishLogout = config.getBoolean("GriefPrevention.PvP.PunishLogout", true);
         this.config_pvp_combatTimeoutSeconds = config.getInt("GriefPrevention.PvP.CombatTimeoutSeconds", 15);
         this.config_pvp_allowCombatItemDrop = config.getBoolean("GriefPrevention.PvP.AllowCombatItemDrop", false);
+        this.config_pvp_allowTrustedContainerAccess = config.getBoolean("GriefPrevention.PvP.AllowTrustedContainerAccess", false);
         String bannedPvPCommandsList = config.getString("GriefPrevention.PvP.BlockedSlashCommands", "/home;/vanish;/spawn;/tpa");
 
         this.config_economy_claimBlocksMaxBonus = config.getInt("GriefPrevention.Economy.ClaimBlocksMaxBonus", 0);
@@ -915,6 +918,7 @@ public class GriefPrevention extends JavaPlugin
         outConfig.set("GriefPrevention.PvP.PunishLogout", this.config_pvp_punishLogout);
         outConfig.set("GriefPrevention.PvP.CombatTimeoutSeconds", this.config_pvp_combatTimeoutSeconds);
         outConfig.set("GriefPrevention.PvP.AllowCombatItemDrop", this.config_pvp_allowCombatItemDrop);
+        outConfig.set("GriefPrevention.PvP.AllowTrustedContainerAccess", this.config_pvp_allowTrustedContainerAccess);
         outConfig.set("GriefPrevention.PvP.BlockedSlashCommands", bannedPvPCommandsList);
         outConfig.set("GriefPrevention.PvP.ProtectPlayersInLandClaims.PlayerOwnedClaims", this.config_pvp_noCombatInPlayerLandClaims);
         outConfig.set("GriefPrevention.PvP.ProtectPlayersInLandClaims.AdministrativeClaims", this.config_pvp_noCombatInAdminLandClaims);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1283,7 +1283,7 @@ class PlayerEventHandler implements Listener
         //always allow interactions when player is in ignore claims mode
         if (playerData.ignoreClaims) return;
 
-        //don't allow container access during pvp combat
+        //check allow container access during pvp combat
         if ((entity instanceof StorageMinecart || entity instanceof PoweredMinecart))
         {
             if (playerData.siegeData != null)
@@ -1293,7 +1293,11 @@ class PlayerEventHandler implements Listener
                 return;
             }
 
-            if (playerData.inPvpCombat())
+            //allow the access if the entity is in a claim AND the user has access to the claim AND container access is allowed during PvP.
+            Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, null);
+            Supplier<String> noContainersReason = claim != null ? claim.checkPermission(player, ClaimPermission.Inventory, event) : null;
+            boolean allowcontainerAccess = claim != null && noContainersReason == null && instance.config_pvp_allowTrustedContainerAccess; 
+            if (!allowcontainerAccess && playerData.inPvpCombat())
             {
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.PvPNoContainers);
                 event.setCancelled(true);
@@ -1757,15 +1761,7 @@ class PlayerEventHandler implements Listener
                 return;
             }
 
-            //block container use during pvp combat, same reason
-            if (playerData.inPvpCombat())
-            {
-                GriefPrevention.sendMessage(player, TextMode.Err, Messages.PvPNoContainers);
-                event.setCancelled(true);
-                return;
-            }
-
-            //otherwise check permissions for the claim the player is in
+            //check permissions for the claim the player is in
             Claim claim = this.dataStore.getClaimAt(clickedBlock.getLocation(), false, playerData.lastClaim);
             if (claim != null)
             {
@@ -1785,6 +1781,17 @@ class PlayerEventHandler implements Listener
                     return;
                 }
             }
+            
+            //block container use during pvp combat, unless configured to allow access to containers in claims with permissions
+            //the permissions are implied by the check above.
+            boolean allowContainerAccess = claim != null && instance.config_pvp_allowTrustedContainerAccess;
+            if (!allowContainerAccess && playerData.inPvpCombat())
+            {
+                GriefPrevention.sendMessage(player, TextMode.Err, Messages.PvPNoContainers);
+                event.setCancelled(true);
+                return;
+            }
+
 
             //if the event hasn't been cancelled, then the player is allowed to use the container
             //so drop any pvp protection

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1296,8 +1296,8 @@ class PlayerEventHandler implements Listener
             //allow the access if the entity is in a claim AND the user has access to the claim AND container access is allowed during PvP.
             Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, null);
             Supplier<String> noContainersReason = claim != null ? claim.checkPermission(player, ClaimPermission.Inventory, event) : null;
-            boolean allowcontainerAccess = claim != null && noContainersReason == null && instance.config_pvp_allowTrustedContainerAccess; 
-            if (!allowcontainerAccess && playerData.inPvpCombat())
+            boolean allowContainerAccess = claim != null && noContainersReason == null && instance.config_pvp_allowTrustedContainerAccess; 
+            if (!allowContainerAccess && playerData.inPvpCombat())
             {
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.PvPNoContainers);
                 event.setCancelled(true);
@@ -1791,7 +1791,6 @@ class PlayerEventHandler implements Listener
                 event.setCancelled(true);
                 return;
             }
-
 
             //if the event hasn't been cancelled, then the player is allowed to use the container
             //so drop any pvp protection


### PR DESCRIPTION
**As-IS**
When a player has a active pvp-timer, he is unable to open chests within a trusted claim.


**Change**
Option added to allow players to access containers within trusted claims with pvp timer active.
(Public containers still can't be accessed)

**Reason**
A player runs from combat into his house to restock his inventory. He has to wait for his timer to run out, before he can access his chests. 
With this option enabled, a player can restock his inventory faster, and the pvp timer gets less in the way. 



Tested on `Paper v1.21.10`.
