### PR TITLE
Protect claims from player-caused knockback (wind charges, spears)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <build>
@@ -162,6 +166,14 @@
             <artifactId>spigot-api</artifactId>
             <version>1.21.11-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+        <!-- Paper API for Paper-specific features (optional at runtime) -->
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21.11-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <!-- Annotations for nullity and other behaviors -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.21-R0.1-SNAPSHOT</version>
+            <version>1.21.11-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- Annotations for nullity and other behaviors -->

--- a/src/main/java/com/griefprevention/platform/PlatformDetection.java
+++ b/src/main/java/com/griefprevention/platform/PlatformDetection.java
@@ -1,0 +1,79 @@
+package com.griefprevention.platform;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Central utility for detecting server platform at runtime.
+ * <p>
+ * Detection results are cached to avoid repeated reflection calls.
+ *
+ * @see PlatformListener for adding platform-specific listeners
+ */
+public final class PlatformDetection
+{
+
+    /**
+     * Server platforms that the plugin can detect and adapt to.
+     */
+    public enum Platform
+    {
+        /** Paper and Paper forks (Purpur, Pufferfish, etc.) */
+        PAPER,
+        /** Spigot and Spigot-based servers without Paper API */
+        SPIGOT
+    }
+
+    private static Platform detectedPlatform = null;
+
+    private PlatformDetection()
+    {
+    }
+
+    /**
+     * Detects and returns the server platform.
+     * Result is cached after first detection.
+     *
+     * @return the detected platform
+     */
+    public static @NotNull Platform getPlatform()
+    {
+        if (detectedPlatform == null)
+        {
+            detectedPlatform = detectPlatform();
+        }
+        return detectedPlatform;
+    }
+
+    private static @NotNull Platform detectPlatform()
+    {
+        if (classExists("com.destroystokyo.paper.PaperConfig")
+                || classExists("io.papermc.paper.configuration.Configuration"))
+        {
+            return Platform.PAPER;
+        }
+        return Platform.SPIGOT;
+    }
+
+    /**
+     * Checks if a class exists on the classpath.
+     * <p>
+     * Useful for checking if platform-specific APIs are available
+     * before attempting to use them.
+     *
+     * @param className the fully qualified class name
+     * @return true if the class exists
+     */
+    public static boolean classExists(String className)
+    {
+        try
+        {
+            Class.forName(className);
+            return true;
+        }
+        catch (ClassNotFoundException e)
+        {
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/com/griefprevention/platform/PlatformListener.java
+++ b/src/main/java/com/griefprevention/platform/PlatformListener.java
@@ -1,0 +1,56 @@
+package com.griefprevention.platform;
+
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Interface for platform-specific event listeners.
+ * <p>
+ * Implementations provide support detection and factory logic for listeners
+ * that behave differently on Paper vs Spigot.
+ *
+ * <p>To add a new platform-specific listener:
+ * <ol>
+ *   <li>Create listener implementations for each platform (e.g., PaperXyz, SpigotXyz)</li>
+ *   <li>Create a class implementing this interface</li>
+ *   <li>Call {@link #register(Plugin)} in {@link me.ryanhamshire.GriefPrevention.GriefPrevention#onEnable()}</li>
+ * </ol>
+ *
+ * @see com.griefprevention.platform.knockback.KnockbackProtectionListener
+ */
+public interface PlatformListener
+{
+
+    /**
+     * Checks if this listener is supported on the current server.
+     *
+     * @return true if this listener can be used on the current platform
+     */
+    boolean isSupported();
+
+    /**
+     * Creates the platform-appropriate listener implementation.
+     *
+     * @return the listener, or null if not supported
+     */
+    @Nullable Listener create();
+
+    /**
+     * Registers this listener with the plugin if supported.
+     *
+     * @param plugin the plugin to register with
+     */
+    default void register(Plugin plugin)
+    {
+        if (isSupported())
+        {
+            Listener listener = create();
+            if (listener != null)
+            {
+                plugin.getServer().getPluginManager().registerEvents(listener, plugin);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/griefprevention/platform/knockback/KnockbackProtectionHandler.java
+++ b/src/main/java/com/griefprevention/platform/knockback/KnockbackProtectionHandler.java
@@ -1,0 +1,190 @@
+package com.griefprevention.platform.knockback;
+
+import me.ryanhamshire.GriefPrevention.Claim;
+import me.ryanhamshire.GriefPrevention.ClaimPermission;
+import me.ryanhamshire.GriefPrevention.DataStore;
+import me.ryanhamshire.GriefPrevention.EntityDamageHandler;
+import me.ryanhamshire.GriefPrevention.GriefPrevention;
+import me.ryanhamshire.GriefPrevention.Messages;
+import me.ryanhamshire.GriefPrevention.PlayerData;
+import me.ryanhamshire.GriefPrevention.TextMode;
+import me.ryanhamshire.GriefPrevention.events.PreventPvPEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Creature;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Hanging;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Supplier;
+
+/**
+ * Abstract base class for player-caused knockback protection in claims.
+ * Contains shared logic for both Paper and Spigot implementations.
+ * <p>
+ * Handles knockback from all player sources including melee attacks (spears),
+ * projectiles (wind charges), and other mechanisms (shield blocks).
+ * <p>
+ * Subclasses provide the event listener method that extracts attacker/defender
+ * from platform-specific events, then delegate to the protected handler methods.
+ */
+public abstract class KnockbackProtectionHandler implements Listener
+{
+
+    protected final DataStore dataStore;
+    protected final GriefPrevention instance;
+
+    protected KnockbackProtectionHandler(@NotNull DataStore dataStore, @NotNull GriefPrevention plugin)
+    {
+        this.dataStore = dataStore;
+        this.instance = plugin;
+    }
+
+    /**
+     * Handle player-caused knockback against other players. Uses PVP rules to determine
+     * if knockback should be allowed.
+     *
+     * @param event the knockback event
+     * @param attacker the {@link Player} who caused the knockback
+     * @param defender the {@link Player} being knocked back
+     * @param <T> event type that extends Event and implements Cancellable
+     */
+    protected <T extends Event & Cancellable> void handleKnockbackPlayer(
+            @NotNull T event,
+            @NotNull Player attacker,
+            @NotNull Player defender)
+    {
+        // Always allow self-knockback for mobility.
+        if (attacker.equals(defender)) return;
+
+        PlayerData defenderData = this.dataStore.getPlayerData(defender.getUniqueId());
+        PlayerData attackerData = this.dataStore.getPlayerData(attacker.getUniqueId());
+
+        if (attackerData.ignoreClaims) return;
+
+        // Check if defender is in a claim where attacker has trust.
+        Claim defenderClaim = this.dataStore.getClaimAt(defender.getLocation(), false, defenderData.lastClaim);
+        if (defenderClaim != null)
+        {
+            defenderData.lastClaim = defenderClaim;
+
+            // If the attacker has container trust, allow the knockback.
+            if (defenderClaim.checkPermission(attacker, ClaimPermission.Inventory, null) == null)
+            {
+                return;
+            }
+        }
+
+        // If PVP rules don't apply to this world, prevent knockback.
+        // In PvE worlds, players shouldn't be able to push each other
+        // around (unless in a trusted claim, see previous checks).
+        if (!instance.pvpRulesApply(defender.getWorld()))
+        {
+            event.setCancelled(true);
+            return;
+        }
+
+        // Protect fresh spawns from knockback abuse.
+        if (instance.config_pvp_protectFreshSpawns)
+        {
+            if (attackerData.pvpImmune || defenderData.pvpImmune)
+            {
+                event.setCancelled(true);
+                GriefPrevention.sendMessage(
+                        attacker,
+                        TextMode.Err,
+                        attackerData.pvpImmune ? Messages.CantFightWhileImmune : Messages.ThatPlayerPvPImmune);
+                return;
+            }
+        }
+
+        // Check if defender is in a PVP safezone.
+        if (defenderClaim != null && instance.claimIsPvPSafeZone(defenderClaim))
+        {
+            PreventPvPEvent pvpEvent = new PreventPvPEvent(defenderClaim, attacker, defender);
+            Bukkit.getPluginManager().callEvent(pvpEvent);
+            if (!pvpEvent.isCancelled())
+            {
+                event.setCancelled(true);
+                GriefPrevention.sendMessage(attacker, TextMode.Err, Messages.PlayerInPvPSafeZone);
+            }
+            return;
+        }
+
+        // Check if attacker is in a PVP safezone (prevent shooting from safezone).
+        Claim attackerClaim = this.dataStore.getClaimAt(attacker.getLocation(), false, attackerData.lastClaim);
+        if (attackerClaim != null)
+        {
+            attackerData.lastClaim = attackerClaim;
+            if (instance.claimIsPvPSafeZone(attackerClaim))
+            {
+                PreventPvPEvent pvpEvent = new PreventPvPEvent(attackerClaim, attacker, defender);
+                Bukkit.getPluginManager().callEvent(pvpEvent);
+                if (!pvpEvent.isCancelled())
+                {
+                    event.setCancelled(true);
+                    GriefPrevention.sendMessage(attacker, TextMode.Err, Messages.CantFightWhileImmune);
+                }
+            }
+        }
+    }
+
+    /**
+     * Handle player-caused knockback against non-player entities. Prevents moving protected
+     * entities out of claims.
+     *
+     * @param event the knockback event
+     * @param attacker the {@link Player} who caused the knockback
+     * @param entity the {@link Entity} being knocked back
+     * @param <T> event type that extends Event and implements Cancellable
+     */
+    protected <T extends Event & Cancellable> void handleKnockbackEntity(
+            @NotNull T event,
+            @NotNull Player attacker,
+            @NotNull Entity entity)
+    {
+        if (!instance.claimsEnabledForWorld(entity.getWorld())) return;
+
+        // Determine protection type and required permission.
+        ClaimPermission requiredPermission;
+        if (entity instanceof ArmorStand || entity instanceof Hanging)
+        {
+            // These require build trust, matching handleClaimedBuildTrustDamageByEntity.
+            requiredPermission = ClaimPermission.Build;
+        }
+        else if (entity instanceof Creature && instance.config_claims_protectCreatures)
+        {
+            // Creatures require container trust, matching handleCreatureDamageByEntity,
+            // but skip monsters - they are never protected.
+            if (EntityDamageHandler.isHostile(entity)) return;
+            requiredPermission = ClaimPermission.Inventory;
+        }
+        else
+        {
+            // Entity type not protected.
+            return;
+        }
+
+        PlayerData attackerData = this.dataStore.getPlayerData(attacker.getUniqueId());
+
+        if (attackerData.ignoreClaims) return;
+
+        Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, attackerData.lastClaim);
+
+        if (claim == null) return;
+
+        attackerData.lastClaim = claim;
+
+        Supplier<String> noPermissionReason = claim.checkPermission(attacker, requiredPermission, event);
+        if (noPermissionReason != null)
+        {
+            event.setCancelled(true);
+            GriefPrevention.sendMessage(attacker, TextMode.Err, noPermissionReason.get());
+        }
+    }
+
+}

--- a/src/main/java/com/griefprevention/platform/knockback/KnockbackProtectionHandler.java
+++ b/src/main/java/com/griefprevention/platform/knockback/KnockbackProtectionHandler.java
@@ -72,8 +72,8 @@ public abstract class KnockbackProtectionHandler implements Listener
         {
             defenderData.lastClaim = defenderClaim;
 
-            // If the attacker has container trust, allow the knockback.
-            if (defenderClaim.checkPermission(attacker, ClaimPermission.Inventory, null) == null)
+            // If the attacker has access trust, allow the knockback.
+            if (defenderClaim.checkPermission(attacker, ClaimPermission.Access, null) == null)
             {
                 return;
             }

--- a/src/main/java/com/griefprevention/platform/knockback/KnockbackProtectionHandler.java
+++ b/src/main/java/com/griefprevention/platform/knockback/KnockbackProtectionHandler.java
@@ -156,7 +156,7 @@ public abstract class KnockbackProtectionHandler implements Listener
             // These require build trust, matching handleClaimedBuildTrustDamageByEntity.
             requiredPermission = ClaimPermission.Build;
         }
-        else if (entity instanceof Creature && instance.config_claims_protectCreatures)
+        else if (entity instanceof Creature && instance.config_claims_preventTheft)
         {
             // Creatures require container trust, matching handleCreatureDamageByEntity,
             // but skip monsters - they are never protected.

--- a/src/main/java/com/griefprevention/platform/knockback/KnockbackProtectionListener.java
+++ b/src/main/java/com/griefprevention/platform/knockback/KnockbackProtectionListener.java
@@ -1,0 +1,54 @@
+package com.griefprevention.platform.knockback;
+
+import com.griefprevention.platform.PlatformDetection;
+import com.griefprevention.platform.PlatformListener;
+import me.ryanhamshire.GriefPrevention.DataStore;
+import me.ryanhamshire.GriefPrevention.GriefPrevention;
+import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Platform-specific listener for handling player-caused knockback in claims.
+ * <p>
+ * Uses Paper-specific or Spigot event depending on the detected platform.
+ * This prevents players from using melee attacks (spears), projectiles
+ * (wind charges), or other mechanisms to knock entities around in protected
+ * claims where such interaction is restricted.
+ */
+public class KnockbackProtectionListener implements PlatformListener
+{
+
+    private final DataStore dataStore;
+    private final GriefPrevention plugin;
+
+    public KnockbackProtectionListener(@NotNull DataStore dataStore, @NotNull GriefPrevention plugin)
+    {
+        this.dataStore = dataStore;
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean isSupported()
+    {
+        // Example check if the required event class exists for the current
+        // platform. In this case, both Paper and Spigot support these events,
+        // but this pattern is useful for listeners that depend on classes
+        // which may not exist on all servers.
+        return switch (PlatformDetection.getPlatform())
+        {
+            case PAPER -> PlatformDetection.classExists("com.destroystokyo.paper.event.entity.EntityKnockbackByEntityEvent");
+            case SPIGOT -> PlatformDetection.classExists("org.bukkit.event.entity.EntityKnockbackByEntityEvent");
+        };
+    }
+
+    @Override
+    public @NotNull Listener create()
+    {
+        return switch (PlatformDetection.getPlatform())
+        {
+            case PAPER -> new PaperKnockbackProtectionHandler(dataStore, plugin);
+            case SPIGOT -> new SpigotKnockbackProtectionHandler(dataStore, plugin);
+        };
+    }
+
+}

--- a/src/main/java/com/griefprevention/platform/knockback/PaperKnockbackProtectionHandler.java
+++ b/src/main/java/com/griefprevention/platform/knockback/PaperKnockbackProtectionHandler.java
@@ -1,0 +1,90 @@
+package com.griefprevention.platform.knockback;
+
+import com.destroystokyo.paper.event.entity.EntityKnockbackByEntityEvent;
+import io.papermc.paper.event.entity.EntityPushedByEntityAttackEvent;
+import me.ryanhamshire.GriefPrevention.DataStore;
+import me.ryanhamshire.GriefPrevention.GriefPrevention;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Paper implementation of knockback protection handling.
+ * Uses Paper's {@link EntityKnockbackByEntityEvent} and {@link EntityPushedByEntityAttackEvent}.
+ * <p>
+ * Handles all player-caused knockback including melee attacks (spears),
+ * projectiles (wind charges), mace smash AoE, and other mechanisms (shield blocks).
+ * <p>
+ * Paper resolves projectiles to their shooter, so {@code getHitBy()} returns
+ * the player directly for both direct attacks and projectile-caused knockback.
+ * <p>
+ * This event is preferred over Bukkit's version on Paper servers because it fires
+ * first and is not deprecated on Paper.
+ * <p>
+ * <b>Known limitation:</b> Wind Burst enchantment knockback cannot be blocked due to
+ * a Paper bug where cancelling {@link EntityPushedByEntityAttackEvent} does not prevent
+ * the knockback. See <a href="https://github.com/PaperMC/Paper/issues/13079">Paper #13079</a>.
+ */
+public class PaperKnockbackProtectionHandler extends KnockbackProtectionHandler
+{
+
+    public PaperKnockbackProtectionHandler(@NotNull DataStore dataStore, @NotNull GriefPrevention plugin)
+    {
+        super(dataStore, plugin);
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    public void onEntityKnockbackByEntity(@NotNull EntityKnockbackByEntityEvent event)
+    {
+        if (!(event.getHitBy() instanceof Player attacker)) return;
+
+        if (event.getEntity() instanceof Player defender)
+        {
+            handleKnockbackPlayer(event, attacker, defender);
+        }
+        else
+        {
+            handleKnockbackEntity(event, attacker, event.getEntity());
+        }
+    }
+
+    /**
+     * Handle push events from AoE attacks like mace smash.
+     * This is Paper-specific and handles knockback that doesn't go through
+     * the normal {@link EntityKnockbackByEntityEvent}.
+     * <p>
+     * Note: Wind Burst enchantment knockback bypasses this due to Paper bug #13079.
+     */
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    public void onEntityPushedByEntityAttack(@NotNull EntityPushedByEntityAttackEvent event)
+    {
+        Entity pusher = event.getPushedBy();
+
+        Player attacker;
+        if (pusher instanceof Player player)
+        {
+            attacker = player;
+        }
+        else if (pusher instanceof Projectile projectile && projectile.getShooter() instanceof Player shooter)
+        {
+            attacker = shooter;
+        }
+        else
+        {
+            return;
+        }
+
+        if (event.getEntity() instanceof Player defender)
+        {
+            handleKnockbackPlayer(event, attacker, defender);
+        }
+        else
+        {
+            handleKnockbackEntity(event, attacker, event.getEntity());
+        }
+    }
+
+}

--- a/src/main/java/com/griefprevention/platform/knockback/SpigotKnockbackProtectionHandler.java
+++ b/src/main/java/com/griefprevention/platform/knockback/SpigotKnockbackProtectionHandler.java
@@ -1,0 +1,65 @@
+package com.griefprevention.platform.knockback;
+
+import me.ryanhamshire.GriefPrevention.DataStore;
+import me.ryanhamshire.GriefPrevention.GriefPrevention;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.EntityKnockbackByEntityEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Spigot/Bukkit implementation of knockback protection handling.
+ * Uses {@link EntityKnockbackByEntityEvent} from the Bukkit API.
+ * <p>
+ * Handles all player-caused knockback including melee attacks (spears),
+ * projectiles (wind charges), and other mechanisms (shield blocks).
+ * <p>
+ * Unlike Paper, Bukkit does not resolve projectiles to their shooter in this event,
+ * so this handler must check for {@link Projectile} sources and extract the shooter.
+ */
+public class SpigotKnockbackProtectionHandler extends KnockbackProtectionHandler
+{
+
+    public SpigotKnockbackProtectionHandler(@NotNull DataStore dataStore, @NotNull GriefPrevention plugin)
+    {
+        super(dataStore, plugin);
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    public void onEntityKnockbackByEntity(@NotNull EntityKnockbackByEntityEvent event)
+    {
+        Entity sourceEntity = event.getSourceEntity();
+        Entity knockedEntity = event.getEntity();
+
+        Player attacker;
+
+        // Handle projectiles (wind charges, etc.) - must extract shooter
+        if (sourceEntity instanceof Projectile projectile)
+        {
+            if (!(projectile.getShooter() instanceof Player shooter)) return;
+            attacker = shooter;
+        }
+        // Handle direct player knockback (melee, shield block, etc.)
+        else if (sourceEntity instanceof Player player)
+        {
+            attacker = player;
+        }
+        else
+        {
+            return;
+        }
+
+        if (knockedEntity instanceof Player defender)
+        {
+            handleKnockbackPlayer(event, attacker, defender);
+        }
+        else
+        {
+            handleKnockbackEntity(event, attacker, knockedEntity);
+        }
+    }
+
+}

--- a/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
@@ -345,7 +345,7 @@ public class AutoExtendClaimTask implements Runnable
             playerBlocks.add(Material.NETHER_BRICK);
             playerBlocks.add(Material.MAGMA_BLOCK);
             playerBlocks.add(Material.ANCIENT_DEBRIS);
-            playerBlocks.add(Material.CHAIN);
+            playerBlocks.add(Material.IRON_CHAIN);
             playerBlocks.add(Material.SHROOMLIGHT);
             playerBlocks.add(Material.NETHER_GOLD_ORE);
             playerBlocks.add(Material.NETHER_SPROUTS);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
@@ -77,15 +77,15 @@ public class EntityDamageHandler implements Listener
             EntityType.PANDA
     );
 
+    private static final NamespacedKey LURED_BY_PLAYER = NamespacedKey.fromString("griefprevention:lured_by_player");
+
     private final @NotNull DataStore dataStore;
     private final @NotNull GriefPrevention instance;
-    private final @NotNull NamespacedKey luredByPlayer;
 
     EntityDamageHandler(@NotNull DataStore dataStore, @NotNull GriefPrevention plugin)
     {
         this.dataStore = dataStore;
         instance = plugin;
-        luredByPlayer = new NamespacedKey(plugin, "lured_by_player");
     }
 
     // Tag passive animals that can become aggressive so that we can tell whether they are hostile later
@@ -99,9 +99,9 @@ public class EntityDamageHandler implements Listener
             return;
 
         if (event.getReason() == EntityTargetEvent.TargetReason.TEMPT)
-            event.getEntity().getPersistentDataContainer().set(luredByPlayer, PersistentDataType.BYTE, (byte) 1);
+            event.getEntity().getPersistentDataContainer().set(LURED_BY_PLAYER, PersistentDataType.BYTE, (byte) 1);
         else
-            event.getEntity().getPersistentDataContainer().remove(luredByPlayer);
+            event.getEntity().getPersistentDataContainer().remove(LURED_BY_PLAYER);
 
     }
 
@@ -207,12 +207,15 @@ public class EntityDamageHandler implements Listener
     }
 
     /**
-     * Check if an {@link Entity} is considered hostile.
+     * Checks if the given entity is considered hostile.
+     * <p>
+     * Used to determine whether an entity should be protected in claims.
+     * Hostile entities are never protected.
      *
      * @param entity the {@code Entity}
      * @return true if the {@code Entity} is hostile
      */
-    private boolean isHostile(@NotNull Entity entity)
+    public static boolean isHostile(@NotNull Entity entity)
     {
         if (entity instanceof Monster) return true;
 
@@ -233,7 +236,7 @@ public class EntityDamageHandler implements Listener
             return rabbit.getRabbitType() == Rabbit.Type.THE_KILLER_BUNNY;
 
         if ((TEMPTABLE_SEMI_HOSTILES.contains(type)) && entity instanceof Mob mob)
-            return !entity.getPersistentDataContainer().has(luredByPlayer, PersistentDataType.BYTE) && mob.getTarget() != null;
+            return !entity.getPersistentDataContainer().has(LURED_BY_PLAYER, PersistentDataType.BYTE) && mob.getTarget() != null;
 
         return false;
     }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -22,6 +22,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.griefprevention.commands.ClaimCommand;
 import com.griefprevention.metrics.MetricsHandler;
+import com.griefprevention.platform.knockback.KnockbackProtectionListener;
 import com.griefprevention.protection.InteractionProtectionHandler;
 import com.griefprevention.protection.ProtectionHelper;
 import me.ryanhamshire.GriefPrevention.DataStore.NoTransferException;
@@ -371,6 +372,9 @@ public class GriefPrevention extends JavaPlugin
         //combat/damage-specific entity events
         entityDamageHandler = new EntityDamageHandler(this.dataStore, this);
         pluginManager.registerEvents(entityDamageHandler, this);
+
+        //knockback protection - handles melee, projectile, and other player-caused knockback in claims
+        new KnockbackProtectionListener(this.dataStore, this).register(this);
 
         //special interaction-related events
         pluginManager.registerEvents(new InteractionProtectionHandler(), this);

--- a/src/test/java/com/griefprevention/platform/PlatformDetectionTest.java
+++ b/src/test/java/com/griefprevention/platform/PlatformDetectionTest.java
@@ -1,0 +1,45 @@
+package com.griefprevention.platform;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PlatformDetectionTest
+{
+
+    @Test
+    void classExists_returnsTrue_forExistingClass()
+    {
+        assertTrue(PlatformDetection.classExists("java.lang.String"));
+        assertTrue(PlatformDetection.classExists("java.util.List"));
+        assertTrue(PlatformDetection.classExists("org.bukkit.Bukkit"));
+    }
+
+    @Test
+    void classExists_returnsFalse_forNonExistentClass()
+    {
+        assertFalse(PlatformDetection.classExists("com.example.NonExistentClass"));
+        assertFalse(PlatformDetection.classExists("org.bukkit.NotARealClass"));
+        assertFalse(PlatformDetection.classExists(""));
+    }
+
+    @Test
+    void getPlatform_returnsNonNull()
+    {
+        PlatformDetection.Platform platform = PlatformDetection.getPlatform();
+        assertNotNull(platform);
+    }
+
+    @Test
+    void getPlatform_returnsCachedValue()
+    {
+        // Call twice to verify caching (same instance should be returned)
+        PlatformDetection.Platform first = PlatformDetection.getPlatform();
+        PlatformDetection.Platform second = PlatformDetection.getPlatform();
+        assertEquals(first, second);
+    }
+
+}

--- a/src/test/java/me/ryanhamshire/GriefPrevention/BlockEventHandlerTest.java
+++ b/src/test/java/me/ryanhamshire/GriefPrevention/BlockEventHandlerTest.java
@@ -44,6 +44,11 @@ public class BlockEventHandlerTest
         }).when(server).getTag(notNull(), notNull(), notNull());
         Bukkit.setServer(server);
 
+        // Force initialization of InventoryType before tests run.
+        // In 1.21.10+, InventoryType depends on MenuType which requires registry lookups.
+        // Initializing here ensures this happens with proper mocks, not mid-stubbing.
+        InventoryType.values();
+
         // Touch class to load material list.
         //noinspection ResultOfMethodCallIgnored
         BlockEventHandler.class.getName();


### PR DESCRIPTION
Port of #2537

Same approach to platform-specific handler, but placed under `com.griefprevention` namespace