### PR TITLE
Claim command requires radius

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1831,6 +1831,7 @@ public abstract class DataStore
         this.addDefault(defaults, Messages.ClaimsExtendToSky, "Land claims always extend to max build height.", null);
         this.addDefault(defaults, Messages.ClaimsAutoExtendDownward, "Land claims auto-extend deeper into the ground when you place blocks under them.", null);
         this.addDefault(defaults, Messages.ClaimCommandRequiresRadius, "You must specify a radius. Example: /claim 10", null);
+        this.addDefault(defaults, Messages.MinimumRadiusWithArea, "Minimum claim size is {0} blocks.", "0: minimum claim area");
         this.addDefault(defaults, Messages.MinimumRadius, "Minimum radius is {0}.", "0: minimum radius");
         this.addDefault(defaults, Messages.RadiusRequiresGoldenShovel, "You must be holding a golden shovel when specifying a radius.", null);
         this.addDefault(defaults, Messages.ClaimTooSmallForActiveBlocks, "This claim isn't big enough to support any active block types (hoppers, spawners, beacons...).  Make the claim bigger first.", null);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1830,6 +1830,7 @@ public abstract class DataStore
         this.addDefault(defaults, Messages.StandInClaimToResize, "Stand inside the land claim you want to resize.", null);
         this.addDefault(defaults, Messages.ClaimsExtendToSky, "Land claims always extend to max build height.", null);
         this.addDefault(defaults, Messages.ClaimsAutoExtendDownward, "Land claims auto-extend deeper into the ground when you place blocks under them.", null);
+        this.addDefault(defaults, Messages.ClaimCommandRequiresRadius, "You must specify a radius. Example: /claim 10", null);
         this.addDefault(defaults, Messages.MinimumRadius, "Minimum radius is {0}.", "0: minimum radius");
         this.addDefault(defaults, Messages.RadiusRequiresGoldenShovel, "You must be holding a golden shovel when specifying a radius.", null);
         this.addDefault(defaults, Messages.ClaimTooSmallForActiveBlocks, "This claim isn't big enough to support any active block types (hoppers, spawners, beacons...).  Make the claim bigger first.", null);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1831,7 +1831,6 @@ public abstract class DataStore
         this.addDefault(defaults, Messages.ClaimsExtendToSky, "Land claims always extend to max build height.", null);
         this.addDefault(defaults, Messages.ClaimsAutoExtendDownward, "Land claims auto-extend deeper into the ground when you place blocks under them.", null);
         this.addDefault(defaults, Messages.MinimumRadius, "Minimum radius is {0}.", "0: minimum radius");
-        this.addDefault(defaults, Messages.RadiusRequiresGoldenShovel, "You must be holding a golden shovel when specifying a radius.", null);
         this.addDefault(defaults, Messages.ClaimTooSmallForActiveBlocks, "This claim isn't big enough to support any active block types (hoppers, spawners, beacons...).  Make the claim bigger first.", null);
         this.addDefault(defaults, Messages.TooManyActiveBlocksInClaim, "This claim is at its limit for active block types (hoppers, spawners, beacons...).  Either make it bigger, or remove other active blocks first.", null);
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1830,7 +1830,6 @@ public abstract class DataStore
         this.addDefault(defaults, Messages.StandInClaimToResize, "Stand inside the land claim you want to resize.", null);
         this.addDefault(defaults, Messages.ClaimsExtendToSky, "Land claims always extend to max build height.", null);
         this.addDefault(defaults, Messages.ClaimsAutoExtendDownward, "Land claims auto-extend deeper into the ground when you place blocks under them.", null);
-        this.addDefault(defaults, Messages.ClaimCommandRequiresRadius, "You must specify a radius. Example: /claim 10", null);
         this.addDefault(defaults, Messages.MinimumRadiusWithArea, "Minimum claim size is {0} blocks.", "0: minimum claim area");
         this.addDefault(defaults, Messages.MinimumRadius, "Minimum radius is {0}.", "0: minimum radius");
         this.addDefault(defaults, Messages.RadiusRequiresGoldenShovel, "You must be holding a golden shovel when specifying a radius.", null);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1830,7 +1830,6 @@ public abstract class DataStore
         this.addDefault(defaults, Messages.StandInClaimToResize, "Stand inside the land claim you want to resize.", null);
         this.addDefault(defaults, Messages.ClaimsExtendToSky, "Land claims always extend to max build height.", null);
         this.addDefault(defaults, Messages.ClaimsAutoExtendDownward, "Land claims auto-extend deeper into the ground when you place blocks under them.", null);
-        this.addDefault(defaults, Messages.MinimumRadiusWithArea, "Minimum claim size is {0} blocks.", "0: minimum claim area");
         this.addDefault(defaults, Messages.MinimumRadius, "Minimum radius is {0}.", "0: minimum radius");
         this.addDefault(defaults, Messages.RadiusRequiresGoldenShovel, "You must be holding a golden shovel when specifying a radius.", null);
         this.addDefault(defaults, Messages.ClaimTooSmallForActiveBlocks, "This claim isn't big enough to support any active block types (hoppers, spawners, beacons...).  Make the claim bigger first.", null);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1150,7 +1150,7 @@ public class GriefPrevention extends JavaPlugin
             if (radius < 0) radius = minimumRadius;
             if (playerData.getClaims().isEmpty())
             {
-                radius = Math.max(radius, minimumRadius);
+                minimumRadius = Math.max(radius, minimumRadius);
             }
 
             //if player has any claims, respect claim minimum size setting
@@ -1162,8 +1162,6 @@ public class GriefPrevention extends JavaPlugin
                     GriefPrevention.sendMessage(player, TextMode.Err, Messages.MustHoldModificationToolForThat);
                     return true;
                 }
-
-                radius = (int) Math.ceil(Math.sqrt(GriefPrevention.instance.config_claims_minArea) / 2);
             }
 
             //radius is required
@@ -1183,9 +1181,9 @@ public class GriefPrevention extends JavaPlugin
                 return false;
             }
 
-            if (specifiedRadius < radius)
+            if (specifiedRadius < minimumRadius)
             {
-                GriefPrevention.sendMessage(player, TextMode.Err, Messages.MinimumRadius, String.valueOf(radius));
+                GriefPrevention.sendMessage(player, TextMode.Err, Messages.MinimumRadius, String.valueOf(minimumRadius));
                 return true;
             }
             else

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -160,7 +160,6 @@ public class GriefPrevention extends JavaPlugin
     public Material config_claims_modificationTool;                    //which material will be used to create/resize claims with a right click
 
     public ArrayList<String> config_claims_commandsRequiringAccessTrust; //the list of slash commands requiring access trust when in a claim
-    public boolean config_claims_claimCommandRequiresRadius;          //whether /claim requires a radius argument
     public boolean config_claims_supplyPlayerManual;                //whether to give new players a book with land claim help in it
     public int config_claims_manualDeliveryDelaySeconds;            //how long to wait before giving a book to a new player
 
@@ -638,7 +637,6 @@ public class GriefPrevention extends JavaPlugin
         this.config_claims_respectWorldGuard = config.getBoolean("GriefPrevention.Claims.CreationRequiresWorldGuardBuildPermission", true);
         this.config_claims_villagerTradingRequiresTrust = config.getBoolean("GriefPrevention.Claims.VillagerTradingRequiresPermission", true);
         String accessTrustSlashCommands = config.getString("GriefPrevention.Claims.CommandsRequiringAccessTrust", "/sethome");
-        this.config_claims_claimCommandRequiresRadius = config.getBoolean("GriefPrevention.Claims.ClaimCommandRequiresRadius", false);
         this.config_claims_supplyPlayerManual = config.getBoolean("GriefPrevention.Claims.DeliverManuals", true);
         this.config_claims_manualDeliveryDelaySeconds = config.getInt("GriefPrevention.Claims.ManualDeliveryDelaySeconds", 30);
         this.config_claims_ravagersBreakBlocks = config.getBoolean("GriefPrevention.Claims.RavagersBreakBlocks", true);
@@ -894,7 +892,6 @@ public class GriefPrevention extends JavaPlugin
         outConfig.set("GriefPrevention.Claims.CreationRequiresWorldGuardBuildPermission", this.config_claims_respectWorldGuard);
         outConfig.set("GriefPrevention.Claims.VillagerTradingRequiresPermission", this.config_claims_villagerTradingRequiresTrust);
         outConfig.set("GriefPrevention.Claims.CommandsRequiringAccessTrust", accessTrustSlashCommands);
-        outConfig.set("GriefPrevention.Claims.ClaimCommandRequiresRadius", this.config_claims_claimCommandRequiresRadius);
         outConfig.set("GriefPrevention.Claims.DeliverManuals", config_claims_supplyPlayerManual);
         outConfig.set("GriefPrevention.Claims.ManualDeliveryDelaySeconds", config_claims_manualDeliveryDelaySeconds);
         outConfig.set("GriefPrevention.Claims.RavagersBreakBlocks", config_claims_ravagersBreakBlocks);
@@ -1141,16 +1138,15 @@ public class GriefPrevention extends JavaPlugin
                 return true;
             }
 
-            if (GriefPrevention.instance.config_claims_claimCommandRequiresRadius && args.length == 0)
+            if (args.length == 0)
             {
-                GriefPrevention.sendMessage(player, TextMode.Err, Messages.ClaimCommandRequiresRadius);
-                return true;
+                return false;
             }
 
             //default is chest claim radius, unless -1
             int radius = GriefPrevention.instance.config_claims_automaticClaimsForNewPlayersRadius;
             if (radius < 0) radius = (int) Math.ceil(Math.sqrt(GriefPrevention.instance.config_claims_minArea) / 2);
-            if (GriefPrevention.instance.config_claims_claimCommandRequiresRadius && playerData.getClaims().isEmpty())
+            if (playerData.getClaims().isEmpty())
             {
                 radius = Math.max(radius, (int) Math.ceil(Math.sqrt(GriefPrevention.instance.config_claims_minArea) / 2));
             }
@@ -1189,15 +1185,8 @@ public class GriefPrevention extends JavaPlugin
 
                 if (specifiedRadius < radius)
                 {
-                    if (GriefPrevention.instance.config_claims_claimCommandRequiresRadius)
-                    {
-                        GriefPrevention.sendMessage(player, TextMode.Err, Messages.MinimumRadiusWithArea,
-                                String.valueOf(GriefPrevention.instance.config_claims_minArea));
-                    }
-                    else
-                    {
-                        GriefPrevention.sendMessage(player, TextMode.Err, Messages.MinimumRadius, String.valueOf(radius));
-                    }
+                    GriefPrevention.sendMessage(player, TextMode.Err, Messages.MinimumRadiusWithArea,
+                            String.valueOf(GriefPrevention.instance.config_claims_minArea));
                     return true;
                 }
                 else

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1185,8 +1185,7 @@ public class GriefPrevention extends JavaPlugin
 
                 if (specifiedRadius < radius)
                 {
-                    GriefPrevention.sendMessage(player, TextMode.Err, Messages.MinimumRadiusWithArea,
-                            String.valueOf(GriefPrevention.instance.config_claims_minArea));
+                    GriefPrevention.sendMessage(player, TextMode.Err, Messages.MinimumRadius, String.valueOf(radius));
                     return true;
                 }
                 else

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1164,34 +1164,31 @@ public class GriefPrevention extends JavaPlugin
                 radius = (int) Math.ceil(Math.sqrt(GriefPrevention.instance.config_claims_minArea) / 2);
             }
 
-            //allow for specifying the radius
-            if (args.length > 0)
+            //radius is required
+            if (playerData.getClaims().size() < 2 && player.getGameMode() != GameMode.CREATIVE && player.getItemInHand().getType() != GriefPrevention.instance.config_claims_modificationTool)
             {
-                if (playerData.getClaims().size() < 2 && player.getGameMode() != GameMode.CREATIVE && player.getItemInHand().getType() != GriefPrevention.instance.config_claims_modificationTool)
-                {
-                    GriefPrevention.sendMessage(player, TextMode.Err, Messages.RadiusRequiresGoldenShovel);
-                    return true;
-                }
+                GriefPrevention.sendMessage(player, TextMode.Err, Messages.RadiusRequiresGoldenShovel);
+                return true;
+            }
 
-                int specifiedRadius;
-                try
-                {
-                    specifiedRadius = Integer.parseInt(args[0]);
-                }
-                catch (NumberFormatException e)
-                {
-                    return false;
-                }
+            int specifiedRadius;
+            try
+            {
+                specifiedRadius = Integer.parseInt(args[0]);
+            }
+            catch (NumberFormatException e)
+            {
+                return false;
+            }
 
-                if (specifiedRadius < radius)
-                {
-                    GriefPrevention.sendMessage(player, TextMode.Err, Messages.MinimumRadius, String.valueOf(radius));
-                    return true;
-                }
-                else
-                {
-                    radius = specifiedRadius;
-                }
+            if (specifiedRadius < radius)
+            {
+                GriefPrevention.sendMessage(player, TextMode.Err, Messages.MinimumRadius, String.valueOf(radius));
+                return true;
+            }
+            else
+            {
+                radius = specifiedRadius;
             }
 
             if (radius < 0) radius = 0;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -160,6 +160,7 @@ public class GriefPrevention extends JavaPlugin
     public Material config_claims_modificationTool;                    //which material will be used to create/resize claims with a right click
 
     public ArrayList<String> config_claims_commandsRequiringAccessTrust; //the list of slash commands requiring access trust when in a claim
+    public boolean config_claims_claimCommandRequiresRadius;          //whether /claim requires a radius argument
     public boolean config_claims_supplyPlayerManual;                //whether to give new players a book with land claim help in it
     public int config_claims_manualDeliveryDelaySeconds;            //how long to wait before giving a book to a new player
 
@@ -637,6 +638,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_claims_respectWorldGuard = config.getBoolean("GriefPrevention.Claims.CreationRequiresWorldGuardBuildPermission", true);
         this.config_claims_villagerTradingRequiresTrust = config.getBoolean("GriefPrevention.Claims.VillagerTradingRequiresPermission", true);
         String accessTrustSlashCommands = config.getString("GriefPrevention.Claims.CommandsRequiringAccessTrust", "/sethome");
+        this.config_claims_claimCommandRequiresRadius = config.getBoolean("GriefPrevention.Claims.ClaimCommandRequiresRadius", false);
         this.config_claims_supplyPlayerManual = config.getBoolean("GriefPrevention.Claims.DeliverManuals", true);
         this.config_claims_manualDeliveryDelaySeconds = config.getInt("GriefPrevention.Claims.ManualDeliveryDelaySeconds", 30);
         this.config_claims_ravagersBreakBlocks = config.getBoolean("GriefPrevention.Claims.RavagersBreakBlocks", true);
@@ -892,6 +894,7 @@ public class GriefPrevention extends JavaPlugin
         outConfig.set("GriefPrevention.Claims.CreationRequiresWorldGuardBuildPermission", this.config_claims_respectWorldGuard);
         outConfig.set("GriefPrevention.Claims.VillagerTradingRequiresPermission", this.config_claims_villagerTradingRequiresTrust);
         outConfig.set("GriefPrevention.Claims.CommandsRequiringAccessTrust", accessTrustSlashCommands);
+        outConfig.set("GriefPrevention.Claims.ClaimCommandRequiresRadius", this.config_claims_claimCommandRequiresRadius);
         outConfig.set("GriefPrevention.Claims.DeliverManuals", config_claims_supplyPlayerManual);
         outConfig.set("GriefPrevention.Claims.ManualDeliveryDelaySeconds", config_claims_manualDeliveryDelaySeconds);
         outConfig.set("GriefPrevention.Claims.RavagersBreakBlocks", config_claims_ravagersBreakBlocks);
@@ -1135,6 +1138,12 @@ public class GriefPrevention extends JavaPlugin
                     playerData.getClaims().size() >= GriefPrevention.instance.config_claims_maxClaimsPerPlayer)
             {
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.ClaimCreationFailedOverClaimCountLimit);
+                return true;
+            }
+
+            if (GriefPrevention.instance.config_claims_claimCommandRequiresRadius && args.length == 0)
+            {
+                GriefPrevention.sendMessage(player, TextMode.Err, Messages.ClaimCommandRequiresRadius);
                 return true;
             }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1150,6 +1150,10 @@ public class GriefPrevention extends JavaPlugin
             //default is chest claim radius, unless -1
             int radius = GriefPrevention.instance.config_claims_automaticClaimsForNewPlayersRadius;
             if (radius < 0) radius = (int) Math.ceil(Math.sqrt(GriefPrevention.instance.config_claims_minArea) / 2);
+            if (GriefPrevention.instance.config_claims_claimCommandRequiresRadius && playerData.getClaims().isEmpty())
+            {
+                radius = Math.max(radius, (int) Math.ceil(Math.sqrt(GriefPrevention.instance.config_claims_minArea) / 2));
+            }
 
             //if player has any claims, respect claim minimum size setting
             if (playerData.getClaims().size() > 0)
@@ -1185,7 +1189,15 @@ public class GriefPrevention extends JavaPlugin
 
                 if (specifiedRadius < radius)
                 {
-                    GriefPrevention.sendMessage(player, TextMode.Err, Messages.MinimumRadius, String.valueOf(radius));
+                    if (GriefPrevention.instance.config_claims_claimCommandRequiresRadius)
+                    {
+                        GriefPrevention.sendMessage(player, TextMode.Err, Messages.MinimumRadiusWithArea,
+                                String.valueOf(GriefPrevention.instance.config_claims_minArea));
+                    }
+                    else
+                    {
+                        GriefPrevention.sendMessage(player, TextMode.Err, Messages.MinimumRadius, String.valueOf(radius));
+                    }
                     return true;
                 }
                 else

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1153,21 +1153,10 @@ public class GriefPrevention extends JavaPlugin
                 minimumRadius = Math.max(radius, minimumRadius);
             }
 
-            //if player has any claims, respect claim minimum size setting
-            if (playerData.getClaims().size() > 0)
-            {
-                //if player has exactly one land claim, this requires the claim modification tool to be in hand (or creative mode player)
-                if (playerData.getClaims().size() == 1 && player.getGameMode() != GameMode.CREATIVE && player.getItemInHand().getType() != GriefPrevention.instance.config_claims_modificationTool)
-                {
-                    GriefPrevention.sendMessage(player, TextMode.Err, Messages.MustHoldModificationToolForThat);
-                    return true;
-                }
-            }
-
             //radius is required
             if (playerData.getClaims().size() < 2 && player.getGameMode() != GameMode.CREATIVE && player.getItemInHand().getType() != GriefPrevention.instance.config_claims_modificationTool)
             {
-                GriefPrevention.sendMessage(player, TextMode.Err, Messages.RadiusRequiresGoldenShovel);
+                GriefPrevention.sendMessage(player, TextMode.Err, Messages.MustHoldModificationToolForThat);
                 return true;
             }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1143,12 +1143,14 @@ public class GriefPrevention extends JavaPlugin
                 return false;
             }
 
+            int minimumRadius = (int) Math.ceil(Math.sqrt(GriefPrevention.instance.config_claims_minArea) / 2);
+
             //default is chest claim radius, unless -1
             int radius = GriefPrevention.instance.config_claims_automaticClaimsForNewPlayersRadius;
-            if (radius < 0) radius = (int) Math.ceil(Math.sqrt(GriefPrevention.instance.config_claims_minArea) / 2);
+            if (radius < 0) radius = minimumRadius;
             if (playerData.getClaims().isEmpty())
             {
-                radius = Math.max(radius, (int) Math.ceil(Math.sqrt(GriefPrevention.instance.config_claims_minArea) / 2));
+                radius = Math.max(radius, minimumRadius);
             }
 
             //if player has any claims, respect claim minimum size setting

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1145,14 +1145,6 @@ public class GriefPrevention extends JavaPlugin
 
             int minimumRadius = (int) Math.ceil(Math.sqrt(GriefPrevention.instance.config_claims_minArea) / 2);
 
-            //default is chest claim radius, unless -1
-            int radius = GriefPrevention.instance.config_claims_automaticClaimsForNewPlayersRadius;
-            if (radius < 0) radius = minimumRadius;
-            if (playerData.getClaims().isEmpty())
-            {
-                minimumRadius = Math.max(radius, minimumRadius);
-            }
-
             //radius is required
             if (playerData.getClaims().size() < 2 && player.getGameMode() != GameMode.CREATIVE && player.getItemInHand().getType() != GriefPrevention.instance.config_claims_modificationTool)
             {
@@ -1175,10 +1167,8 @@ public class GriefPrevention extends JavaPlugin
                 GriefPrevention.sendMessage(player, TextMode.Err, Messages.MinimumRadius, String.valueOf(minimumRadius));
                 return true;
             }
-            else
-            {
-                radius = specifiedRadius;
-            }
+
+            int radius = specifiedRadius;
 
             if (radius < 0) radius = 0;
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
@@ -244,6 +244,7 @@ public enum Messages
     StandInClaimToResize,
     ClaimsExtendToSky,
     ClaimsAutoExtendDownward,
+    ClaimCommandRequiresRadius,
     MinimumRadius,
     RadiusRequiresGoldenShovel,
     ClaimTooSmallForActiveBlocks,

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
@@ -244,7 +244,6 @@ public enum Messages
     StandInClaimToResize,
     ClaimsExtendToSky,
     ClaimsAutoExtendDownward,
-    ClaimCommandRequiresRadius,
     MinimumRadiusWithArea,
     MinimumRadius,
     RadiusRequiresGoldenShovel,

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
@@ -244,7 +244,6 @@ public enum Messages
     StandInClaimToResize,
     ClaimsExtendToSky,
     ClaimsAutoExtendDownward,
-    MinimumRadiusWithArea,
     MinimumRadius,
     RadiusRequiresGoldenShovel,
     ClaimTooSmallForActiveBlocks,

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
@@ -245,6 +245,7 @@ public enum Messages
     ClaimsExtendToSky,
     ClaimsAutoExtendDownward,
     ClaimCommandRequiresRadius,
+    MinimumRadiusWithArea,
     MinimumRadius,
     RadiusRequiresGoldenShovel,
     ClaimTooSmallForActiveBlocks,

--- a/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/Messages.java
@@ -245,7 +245,6 @@ public enum Messages
     ClaimsExtendToSky,
     ClaimsAutoExtendDownward,
     MinimumRadius,
-    RadiusRequiresGoldenShovel,
     ClaimTooSmallForActiveBlocks,
     TooManyActiveBlocksInClaim,
     ConsoleOnlyCommand,

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -117,8 +117,8 @@ commands:
       aliases: [expandclaim, resizeclaim]
       permission: griefprevention.claims
     claim:
-      description: Creates a land claim centered at your current location.
-      usage: /<command> [optional radius]
+      description: Creates a land claim centered at your current location with the given radius.
+      usage: /<command> <radius>
       aliases: [createclaim, makeclaim, newclaim]
       permission: griefprevention.claims
     buyclaimblocks:


### PR DESCRIPTION
Adds a new config option that when enabled requires the claim command to be used with a radius.

Previously the claim command would always default to the minimum area size of claim when used without a radius. Some players never read or learn how the claim tool or claim command works and end up making multiple minimum area `/claim`s all next to each other which become hard to manage and moderate. 

When enabled this forces players who use the `/claim` command to be aware of and input a radius instead of it always defaulting to the minimum 100 block area.

Also adds the new messages outputs.

When disabled it doesn't conflict with any of the previous minimum radius or new player claim options.