### PR TITLE
Require container trust for allays

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
@@ -5,7 +5,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.AnimalTamer;
-import org.bukkit.entity.Animals;
 import org.bukkit.entity.Creature;
 import org.bukkit.entity.Donkey;
 import org.bukkit.entity.Entity;
@@ -1199,7 +1198,7 @@ public class EntityDamageHandler implements Listener
                     // Always impact the thrower.
                     if (affected == thrower) continue;
 
-                    if (affected.getType() == EntityType.VILLAGER || affected instanceof Animals)
+                    if (affected.getType() == EntityType.VILLAGER || EntityEventHandler.isProtectedAnimal(affected))
                     {
                         Claim claim = this.dataStore.getClaimAt(affected.getLocation(), false, cachedClaim);
                         if (claim != null)

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -27,9 +27,13 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Allay;
+import org.bukkit.entity.Animals;
+import org.bukkit.entity.CopperGolem;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.FallingBlock;
+import org.bukkit.entity.Fish;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Mob;
@@ -239,6 +243,21 @@ public class EntityEventHandler implements Listener
                 }
             }
         }
+    }
+
+    /**
+     * Check if an entity is a protected "animal" type for container trust purposes.
+     * Includes animals, fish, allays, copper golems, and similar passive/utility mobs.
+     *
+     * @param entity the {@code Entity}
+     * @return true if the {@code Entity} is a protected animal type
+     */
+    public static boolean isProtectedAnimal(@NotNull Entity entity)
+    {
+        return entity instanceof Animals
+            || entity instanceof Fish
+            || entity instanceof Allay
+            || entity instanceof CopperGolem;
     }
 
     private void handleProjectileChangeBlock(EntityChangeBlockEvent event, Projectile projectile)

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1327,7 +1327,7 @@ class PlayerEventHandler implements Listener
         }
 
         //if the entity is an animal, apply container rules
-        if ((instance.config_claims_preventTheft && (entity instanceof Animals || entity instanceof Fish || entity instanceof CopperGolem)) || (entity.getType() == EntityType.VILLAGER && instance.config_claims_villagerTradingRequiresTrust))
+        if ((instance.config_claims_preventTheft && EntityEventHandler.isProtectedAnimal(entity)) || (entity.getType() == EntityType.VILLAGER && instance.config_claims_villagerTradingRequiresTrust))
         {
             //if the entity is in a claim
             Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, null);
@@ -1437,7 +1437,7 @@ class PlayerEventHandler implements Listener
         if (entity == null) return;  //if nothing pulled, uninteresting event
 
         //if should be protected from pulling in land claims without permission
-        if (entity.getType() == EntityType.ARMOR_STAND || entity instanceof Animals)
+        if (entity.getType() == EntityType.ARMOR_STAND || EntityEventHandler.isProtectedAnimal(entity))
         {
             Player player = event.getPlayer();
             PlayerData playerData = instance.dataStore.getPlayerData(player.getUniqueId());


### PR DESCRIPTION
Allays weren't included in the theft protection check since they extend Creature, not Animals. Also refactored the repeated instanceof checks into a shared helper.