### PR TITLE
Fix `GRASS`/`SHORT_GRASS` checks that should be `GRASS_BLOCK`

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -414,16 +414,7 @@ public class BlockEventHandler implements Listener
             Block earthBlock = placeEvent.getBlockAgainst();
 
 
-            // in Minecraft 1.20.3 GRASS was renamed to SHORT_GRASS
-            // This will support both before/after the change
-            Material grassMaterial;
-            try{
-                grassMaterial = Material.valueOf("GRASS");
-            } catch(IllegalArgumentException e){
-                grassMaterial = Material.valueOf("SHORT_GRASS");
-            }
-
-            if (earthBlock.getType() != grassMaterial)
+            if (earthBlock.getType() != Material.GRASS_BLOCK)
             {
                 if (earthBlock.getRelative(BlockFace.DOWN).getType() == Material.AIR ||
                         earthBlock.getRelative(BlockFace.DOWN).getRelative(BlockFace.DOWN).getType() == Material.AIR)

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -2204,14 +2204,7 @@ class PlayerEventHandler implements Listener
                 else
                 {
 
-                    // in Minecraft 1.20.3 GRASS was renamed to SHORT_GRASS
-                    // This will support both before/after the change
-                    try{
-                        allowedFillBlocks.add(Material.valueOf("GRASS"));
-                    } catch(IllegalArgumentException e){
-                        allowedFillBlocks.add(Material.valueOf("SHORT_GRASS"));
-                    }
-
+                    allowedFillBlocks.add(Material.GRASS_BLOCK);
                     allowedFillBlocks.add(Material.DIRT);
                     allowedFillBlocks.add(Material.STONE);
                     allowedFillBlocks.add(Material.SAND);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/RestoreNatureProcessingTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/RestoreNatureProcessingTask.java
@@ -95,15 +95,7 @@ class RestoreNatureProcessingTask implements Runnable
 
         this.notAllowedToHang = new HashSet<>();
         this.notAllowedToHang.add(Material.DIRT);
-
-//        in Minecraft 1.20.3 GRASS was renamed to SHORT_GRASS
-//        This will support both before/after the change
-        try{
-            this.notAllowedToHang.add(Material.valueOf("GRASS"));
-        } catch(IllegalArgumentException e){
-            this.notAllowedToHang.add(Material.valueOf("SHORT_GRASS"));
-        }
-
+        this.notAllowedToHang.add(Material.GRASS_BLOCK);
         this.notAllowedToHang.add(Material.SNOW);
         this.notAllowedToHang.add(Material.OAK_LOG);
         this.notAllowedToHang.add(Material.SPRUCE_LOG);
@@ -114,14 +106,6 @@ class RestoreNatureProcessingTask implements Runnable
 
         if (this.aggressiveMode)
         {
-            //  in Minecraft 1.20.3 GRASS was renamed to SHORT_GRASS
-            //  This will support both before/after the change
-            try{
-                this.notAllowedToHang.add(Material.valueOf("GRASS"));
-            } catch(IllegalArgumentException e){
-                this.notAllowedToHang.add(Material.valueOf("SHORT_GRASS"));
-            }
-
             this.notAllowedToHang.add(Material.STONE);
         }
 


### PR DESCRIPTION
As Jikoo pointed out while reviewing #2556, some usages of `SHORT_GRASS` didn't make a lot of sense:

- `notAllowedToHang`: should be a solid block like DIRT, not a plant
- `notAllowedToHang` (aggressive mode): duplicate add of the same wrong material, removed entirely
- `blockSkyTrees` sapling check: saplings are placed on the block
- `allowedFillBlocks`: fill materials are solid blocks