### PR TITLE
Update required api-version

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: me.ryanhamshire.GriefPrevention.GriefPrevention
 softdepend: [Vault, Multiverse-Core, My_Worlds, MystCraft, Transporter, WorldGuard, WorldEdit, RoyalCommands, MultiWorld, Denizen, CommandHelper, Iris]
 dev-url: https://dev.bukkit.org/projects/grief-prevention
 version: '${git.commit.id.describe}'
-api-version: '1.21'
+api-version: '1.21.10'
 commands:
     abandonclaim:
       description: Deletes a claim.


### PR DESCRIPTION
Copper golems require 1.21.9/10 per #2535. `api-version` has been capable of handling revision since 1.20.4 if memory serves, so the error produced by outdated servers should be pretty comprehensible for most people.

You can tell I did this in the web editor because I forgot to make a feature branch after having to redo it because it wouldn't let me commit to my own fork from here. Whoopsies.

Closes #2573