### PR TITLE
Add AI section in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,19 @@
 Thank you for considering contributing to GriefPrevention! This document outlines the guidelines for contributing to this repository.
 
 ## Branches
+
 - **legacy/v16** branch: This branch will only accept bugfixes for the legacy version 16 of GriefPrevention. Small features may also be considered, but it's recommended you help implement those into master.
 - **master** branch: This branch follows the roadmap. Please refer to the [roadmap](https://github.com/orgs/TechFortress/projects/6) for more information. You may propose additional features, but the roadmap takes precedence. Discussion of the roadmap can be found in this [discussion thread.](https://github.com/TechFortress/GriefPrevention/discussions/2065)
 
 ## Pull Requests
+
 <!--- Please ensure that your pull request adheres to the [pull request template](https://github.com/TechFortress/GriefPrevention/blob/master/.github/PULL_REQUEST_TEMPLATE.md).-->
 - Please ensure that your pull request has a descriptive title and summary.
 - Please ensure that your pull request is tested and does not break any existing functionality.
+
+### AI
+
+- All commits that use AI or are copied directly from AI must be attributed (ideally with model and method used) in the commit message.
+- All comments that contain text from AI must be attributed, ideally with model and method used.
 
 Thank you for your contribution!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Thank you for considering contributing to GriefPrevention! This document outline
 
 ### AI
 
-- All commits that use AI (or contain sections of code copied directly from AI) must be attributed (ideally with model and method used) in the commit message.
+- All commits that use AI (or contain sections of AI-generated code) must be attributed (ideally with model and method used) in the commit message.
 - All comments that contain text from AI must be attributed, ideally with model and method used.
 - Including the prompt used is optional, but recommended.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,14 @@ Thank you for considering contributing to GriefPrevention! This document outline
 ## Pull Requests
 
 <!--- Please ensure that your pull request adheres to the [pull request template](https://github.com/TechFortress/GriefPrevention/blob/master/.github/PULL_REQUEST_TEMPLATE.md).-->
-- Please ensure that your pull request has a descriptive title and summary.
-- Please ensure that your pull request is tested and does not break any existing functionality.
+- Title your pull request to match the style of our commit messages.
+- Include a descriptive summary of the changes made in your pull request and its rationale.
+- Test your pull request; it should not break any existing functionality.
 
 ### AI
 
-- All commits that use AI or are copied directly from AI must be attributed (ideally with model and method used) in the commit message.
+- All commits that use AI (or contain sections of code copied directly from AI) must be attributed (ideally with model and method used) in the commit message.
 - All comments that contain text from AI must be attributed, ideally with model and method used.
+- Including the prompt used is optional.
 
 Thank you for your contribution!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,6 @@ Thank you for considering contributing to GriefPrevention! This document outline
 
 - All commits that use AI (or contain sections of code copied directly from AI) must be attributed (ideally with model and method used) in the commit message.
 - All comments that contain text from AI must be attributed, ideally with model and method used.
-- Including the prompt used is optional.
+- Including the prompt used is optional, but recommended.
 
 Thank you for your contribution!


### PR DESCRIPTION
- Require attribution to AI for use of AI in PR commits and comments
- Use active voice for existing bullet points (I think I copied the existing bullet points from a template some time ago?)

Eventually will have a guideline for PR titles/commit messages; let's save that conversation for elsewhere like a discussion.