### PR TITLE
2/4 Add block renderer hooks to VisualizationType

### DIFF
--- a/src/main/java/com/griefprevention/visualization/BlockBoundaryRenderer.java
+++ b/src/main/java/com/griefprevention/visualization/BlockBoundaryRenderer.java
@@ -1,0 +1,28 @@
+package com.griefprevention.visualization;
+
+import org.bukkit.block.data.BlockData;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Supplies fake block data for block-based boundary visualizations.
+ */
+public interface BlockBoundaryRenderer
+{
+
+    /**
+     * Create the block data used for corners in a boundary visualization.
+     *
+     * @param boundary the boundary being visualized
+     * @return the block data to display
+     */
+    @NotNull BlockData createCornerBlockData(@NotNull Boundary boundary);
+
+    /**
+     * Create the block data used for sides in a boundary visualization.
+     *
+     * @param boundary the boundary being visualized
+     * @return the block data to display
+     */
+    @NotNull BlockData createSideBlockData(@NotNull Boundary boundary);
+
+}

--- a/src/main/java/com/griefprevention/visualization/VisualizationType.java
+++ b/src/main/java/com/griefprevention/visualization/VisualizationType.java
@@ -1,5 +1,12 @@
 package com.griefprevention.visualization;
 
+import org.bukkit.Material;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Lightable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Supplier;
+
 /**
  * Constants for types of boundaries.
  */
@@ -7,14 +14,60 @@ public enum VisualizationType
 {
 
     /** Boundaries for a user claim. */
-    CLAIM,
+    CLAIM(blockRenderer(
+            () -> Material.GLOWSTONE.createBlockData(),
+            () -> Material.GOLD_BLOCK.createBlockData())),
     /** Boundaries for an administrative claim. */
-    ADMIN_CLAIM,
+    ADMIN_CLAIM(blockRenderer(
+            () -> Material.GLOWSTONE.createBlockData(),
+            () -> Material.PUMPKIN.createBlockData())),
     /** Boundaries for a claim subdivision. */
-    SUBDIVISION,
+    SUBDIVISION(blockRenderer(
+            () -> Material.IRON_BLOCK.createBlockData(),
+            () -> Material.WHITE_WOOL.createBlockData())),
     /** Boundaries for a new claim area. */
-    INITIALIZE_ZONE,
+    INITIALIZE_ZONE(blockRenderer(
+            () -> Material.DIAMOND_BLOCK.createBlockData(),
+            () -> Material.DIAMOND_BLOCK.createBlockData())),
     /** Boundaries for a conflicting area. */
-    CONFLICT_ZONE
+    CONFLICT_ZONE(blockRenderer(
+            () -> {
+                BlockData fakeData = Material.REDSTONE_ORE.createBlockData();
+                ((Lightable) fakeData).setLit(true);
+                return fakeData;
+            },
+            () -> Material.NETHERRACK.createBlockData()));
+
+    private final @NotNull BlockBoundaryRenderer blockRenderer;
+
+    VisualizationType(@NotNull BlockBoundaryRenderer blockRenderer)
+    {
+        this.blockRenderer = blockRenderer;
+    }
+
+    public @NotNull BlockBoundaryRenderer getBlockRenderer()
+    {
+        return blockRenderer;
+    }
+
+    private static @NotNull BlockBoundaryRenderer blockRenderer(
+            @NotNull Supplier<BlockData> cornerSupplier,
+            @NotNull Supplier<BlockData> sideSupplier)
+    {
+        return new BlockBoundaryRenderer()
+        {
+            @Override
+            public @NotNull BlockData createCornerBlockData(@NotNull Boundary boundary)
+            {
+                return cornerSupplier.get();
+            }
+
+            @Override
+            public @NotNull BlockData createSideBlockData(@NotNull Boundary boundary)
+            {
+                return sideSupplier.get();
+            }
+        };
+    }
 
 }

--- a/src/main/java/com/griefprevention/visualization/impl/FakeBlockVisualization.java
+++ b/src/main/java/com/griefprevention/visualization/impl/FakeBlockVisualization.java
@@ -10,7 +10,6 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.block.data.Lightable;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Consumer;
@@ -41,32 +40,14 @@ public class FakeBlockVisualization extends BlockBoundaryVisualization
     @Override
     protected @NotNull Consumer<@NotNull IntVector> addCornerElements(@NotNull Boundary boundary)
     {
-        return addBlockElement(switch (boundary.type())
-        {
-            case SUBDIVISION -> Material.IRON_BLOCK.createBlockData();
-            case INITIALIZE_ZONE -> Material.DIAMOND_BLOCK.createBlockData();
-            case CONFLICT_ZONE -> {
-                BlockData fakeData = Material.REDSTONE_ORE.createBlockData();
-                ((Lightable) fakeData).setLit(true);
-                yield fakeData;
-            }
-            default -> Material.GLOWSTONE.createBlockData();
-        });
+        return addBlockElement(boundary.type().getBlockRenderer().createCornerBlockData(boundary));
     }
 
 
     @Override
     protected @NotNull Consumer<@NotNull IntVector> addSideElements(@NotNull Boundary boundary)
     {
-        // Determine BlockData from boundary type to cache for reuse in function.
-        return addBlockElement(switch (boundary.type())
-        {
-            case ADMIN_CLAIM -> Material.PUMPKIN.createBlockData();
-            case SUBDIVISION -> Material.WHITE_WOOL.createBlockData();
-            case INITIALIZE_ZONE -> Material.DIAMOND_BLOCK.createBlockData();
-            case CONFLICT_ZONE -> Material.NETHERRACK.createBlockData();
-            default -> Material.GOLD_BLOCK.createBlockData();
-        });
+        return addBlockElement(boundary.type().getBlockRenderer().createSideBlockData(boundary));
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR moves the built-in fake-block rendering data for `VisualizationType` into the enum itself through block renderer hooks.

`FakeBlockVisualization` now uses the renderer defined by each built-in visualization type instead of switching on enum values locally.

## What Changed

- Added `BlockBoundaryRenderer`
- Added built-in block renderer definitions to `VisualizationType`
- Updated `FakeBlockVisualization` to render through `VisualizationType` block renderer hooks instead of local enum switches

## Scope

This PR is limited to the built-in visualization rendering path.

It does **not** add a visualization style registry, addon-defined style API, new visualization providers, or new claim behavior.

## Why

This keeps the built-in renderer behavior attached to the built-in visualization types instead of duplicating that mapping inside `FakeBlockVisualization`.

It improves the current in-tree rendering path without introducing broader extensibility plumbing that is not yet used.

## Compatibility

Existing `VisualizationType` call sites still work.
Existing visualization provider customization through `BoundaryVisualizationEvent` remains unchanged.

## Testing

Tested locally with:

- `mvn -q -DskipTests compile`
- `mvn -q test`

## AI Disclosure

AI assistance was used for refactoring and drafting code in this PR.

- Model: `GPT-5.4`
- Usage: refactoring and PR text drafting
- Review: all changes were reviewed and verified by a human before submission