### PR TITLE
4/4 Add /claim subcommand and mode extension registry

### DIFF
--- a/src/main/java/com/griefprevention/api/claimcommand/ClaimCommandContext.java
+++ b/src/main/java/com/griefprevention/api/claimcommand/ClaimCommandContext.java
@@ -1,0 +1,60 @@
+package com.griefprevention.api.claimcommand;
+
+import me.ryanhamshire.GriefPrevention.GriefPrevention;
+import me.ryanhamshire.GriefPrevention.PlayerData;
+import org.bukkit.command.Command;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Context for a {@code /claim} command execution.
+ */
+public final class ClaimCommandContext
+{
+
+    private final @NotNull GriefPrevention plugin;
+    private final @NotNull Player player;
+    private final @NotNull PlayerData playerData;
+    private final @NotNull Command command;
+    private final @NotNull String label;
+
+    public ClaimCommandContext(
+            @NotNull GriefPrevention plugin,
+            @NotNull Player player,
+            @NotNull PlayerData playerData,
+            @NotNull Command command,
+            @NotNull String label)
+    {
+        this.plugin = plugin;
+        this.player = player;
+        this.playerData = playerData;
+        this.command = command;
+        this.label = label;
+    }
+
+    public @NotNull GriefPrevention getPlugin()
+    {
+        return plugin;
+    }
+
+    public @NotNull Player getPlayer()
+    {
+        return player;
+    }
+
+    public @NotNull PlayerData getPlayerData()
+    {
+        return playerData;
+    }
+
+    public @NotNull Command getCommand()
+    {
+        return command;
+    }
+
+    public @NotNull String getLabel()
+    {
+        return label;
+    }
+
+}

--- a/src/main/java/com/griefprevention/api/claimcommand/ClaimCommandExtensionRegistry.java
+++ b/src/main/java/com/griefprevention/api/claimcommand/ClaimCommandExtensionRegistry.java
@@ -1,0 +1,120 @@
+package com.griefprevention.api.claimcommand;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Registry for {@code /claim} command extensions.
+ */
+public final class ClaimCommandExtensionRegistry
+{
+    private static final String MODE_KEYWORD = "mode";
+
+    private final Map<String, ClaimCommandSubcommand> subcommands = new LinkedHashMap<>();
+    private final Map<String, String> subcommandAliases = new LinkedHashMap<>();
+    private final Map<String, ClaimCommandMode> modes = new LinkedHashMap<>();
+    private final Map<String, String> modeAliases = new LinkedHashMap<>();
+
+    public void registerSubcommand(@NotNull ClaimCommandSubcommand subcommand)
+    {
+        String key = normalize(subcommand.getName());
+        if (MODE_KEYWORD.equals(key))
+        {
+            throw new IllegalArgumentException("\"mode\" is reserved by /claim mode.");
+        }
+
+        subcommandAliases.entrySet().removeIf(entry -> key.equals(entry.getValue()));
+        subcommands.put(key, subcommand);
+        subcommandAliases.put(key, key);
+        for (String alias : subcommand.getAliases())
+        {
+            String normalizedAlias = normalize(alias);
+            if (MODE_KEYWORD.equals(normalizedAlias))
+            {
+                throw new IllegalArgumentException("\"mode\" is reserved by /claim mode.");
+            }
+
+            subcommandAliases.put(normalizedAlias, key);
+        }
+    }
+
+    public void unregisterSubcommand(@NotNull String name)
+    {
+        String canonical = subcommandAliases.remove(normalize(name));
+        if (canonical == null)
+        {
+            canonical = normalize(name);
+        }
+
+        ClaimCommandSubcommand removed = subcommands.remove(canonical);
+        if (removed == null)
+        {
+            return;
+        }
+
+        subcommandAliases.values().removeIf(canonical::equals);
+    }
+
+    public @Nullable ClaimCommandSubcommand getSubcommand(@NotNull String name)
+    {
+        String canonical = subcommandAliases.get(normalize(name));
+        return canonical == null ? null : subcommands.get(canonical);
+    }
+
+    public @NotNull List<ClaimCommandSubcommand> getSubcommands()
+    {
+        return new ArrayList<>(subcommands.values());
+    }
+
+    public void registerMode(@NotNull ClaimCommandMode mode)
+    {
+        String key = normalize(mode.getName());
+        modeAliases.entrySet().removeIf(entry -> key.equals(entry.getValue()));
+        modes.put(key, mode);
+        modeAliases.put(key, key);
+        for (String alias : mode.getAliases())
+        {
+            modeAliases.put(normalize(alias), key);
+        }
+    }
+
+    public void unregisterMode(@NotNull String name)
+    {
+        String canonical = modeAliases.remove(normalize(name));
+        if (canonical == null)
+        {
+            canonical = normalize(name);
+        }
+
+        ClaimCommandMode removed = modes.remove(canonical);
+        if (removed == null)
+        {
+            return;
+        }
+
+        modeAliases.values().removeIf(canonical::equals);
+    }
+
+    public @Nullable ClaimCommandMode getMode(@NotNull String name)
+    {
+        String canonical = modeAliases.get(normalize(name));
+        return canonical == null ? null : modes.get(canonical);
+    }
+
+    public @NotNull List<ClaimCommandMode> getModes()
+    {
+        return new ArrayList<>(modes.values());
+    }
+
+    private static @NotNull String normalize(@NotNull String name)
+    {
+        return name.toLowerCase(Locale.ROOT);
+    }
+
+}

--- a/src/main/java/com/griefprevention/api/claimcommand/ClaimCommandMode.java
+++ b/src/main/java/com/griefprevention/api/claimcommand/ClaimCommandMode.java
@@ -1,0 +1,51 @@
+package com.griefprevention.api.claimcommand;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * A mode that can be activated with {@code /claim mode <name>}.
+ */
+public interface ClaimCommandMode
+{
+
+    /**
+     * Get the mode name.
+     *
+     * @return the mode name
+     */
+    @NotNull String getName();
+
+    /**
+     * Get optional aliases for this mode.
+     *
+     * @return the aliases
+     */
+    default @NotNull List<String> getAliases()
+    {
+        return List.of();
+    }
+
+    /**
+     * Activate the mode.
+     *
+     * @param context the command context
+     * @param args any remaining arguments after the mode name
+     * @return true if the command was handled
+     */
+    boolean onCommand(@NotNull ClaimCommandContext context, @NotNull String[] args);
+
+    /**
+     * Get completions for any remaining arguments after the mode name.
+     *
+     * @param context the command context
+     * @param args the remaining arguments after the mode name
+     * @return matching completions
+     */
+    default @NotNull List<String> onTabComplete(@NotNull ClaimCommandContext context, @NotNull String[] args)
+    {
+        return List.of();
+    }
+
+}

--- a/src/main/java/com/griefprevention/api/claimcommand/ClaimCommandSubcommand.java
+++ b/src/main/java/com/griefprevention/api/claimcommand/ClaimCommandSubcommand.java
@@ -1,0 +1,51 @@
+package com.griefprevention.api.claimcommand;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * A custom subcommand available through {@code /claim <subcommand> ...}.
+ */
+public interface ClaimCommandSubcommand
+{
+
+    /**
+     * Get the primary subcommand name.
+     *
+     * @return the subcommand name
+     */
+    @NotNull String getName();
+
+    /**
+     * Get optional aliases for this subcommand.
+     *
+     * @return the aliases
+     */
+    default @NotNull List<String> getAliases()
+    {
+        return List.of();
+    }
+
+    /**
+     * Execute the subcommand.
+     *
+     * @param context the command context
+     * @param args any remaining arguments after the subcommand name
+     * @return true if the command was handled
+     */
+    boolean onCommand(@NotNull ClaimCommandContext context, @NotNull String[] args);
+
+    /**
+     * Get completions for any remaining arguments after the subcommand name.
+     *
+     * @param context the command context
+     * @param args the remaining arguments after the subcommand name
+     * @return matching completions
+     */
+    default @NotNull List<String> onTabComplete(@NotNull ClaimCommandContext context, @NotNull String[] args)
+    {
+        return List.of();
+    }
+
+}

--- a/src/main/java/com/griefprevention/commands/ClaimCommand.java
+++ b/src/main/java/com/griefprevention/commands/ClaimCommand.java
@@ -1,5 +1,9 @@
 package com.griefprevention.commands;
 
+import com.griefprevention.api.claimcommand.ClaimCommandContext;
+import com.griefprevention.api.claimcommand.ClaimCommandExtensionRegistry;
+import com.griefprevention.api.claimcommand.ClaimCommandMode;
+import com.griefprevention.api.claimcommand.ClaimCommandSubcommand;
 import com.griefprevention.visualization.BoundaryVisualization;
 import com.griefprevention.visualization.VisualizationType;
 import me.ryanhamshire.GriefPrevention.AutoExtendClaimTask;
@@ -19,7 +23,10 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 public class ClaimCommand extends CommandHandler
@@ -27,6 +34,7 @@ public class ClaimCommand extends CommandHandler
     public ClaimCommand(@NotNull GriefPrevention plugin)
     {
         super(plugin, "claim");
+        registerBuiltInModes();
     }
 
     @Override
@@ -39,14 +47,19 @@ public class ClaimCommand extends CommandHandler
         if (!(sender instanceof Player player))
             return false;
 
+        PlayerData playerData = plugin.dataStore.getPlayerData(player.getUniqueId());
+        ClaimCommandContext context = new ClaimCommandContext(plugin, player, playerData, command, label);
+        if (dispatchExtension(context, args))
+        {
+            return true;
+        }
+
         World world = player.getWorld();
         if (!plugin.claimsEnabledForWorld(world))
         {
             GriefPrevention.sendMessage(player, TextMode.Err, Messages.ClaimsDisabledWorld);
             return true;
         }
-
-        PlayerData playerData = plugin.dataStore.getPlayerData(player.getUniqueId());
 
         //if he's at the claim count per player limit already and doesn't have permission to bypass, display an error message
         if (plugin.config_claims_maxClaimsPerPlayer > 0 &&
@@ -224,9 +237,229 @@ public class ClaimCommand extends CommandHandler
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args)
     {
-        if (args.length != 1)
+        if (!(sender instanceof Player player))
+        {
             return List.of();
-        return TabCompletions.integer(args, 3, false);
+        }
+
+        PlayerData playerData = plugin.dataStore.getPlayerData(player.getUniqueId());
+        ClaimCommandContext context = new ClaimCommandContext(plugin, player, playerData, command, alias);
+
+        if (args.length >= 1)
+        {
+            String root = args[0];
+            if (equalsIgnoreCase(root, "mode"))
+            {
+                return completeModes(context, args);
+            }
+
+            ClaimCommandSubcommand subcommand = plugin.getClaimCommandExtensionRegistry().getSubcommand(root);
+            if (subcommand != null)
+            {
+                return subcommand.onTabComplete(context, trimArgs(args, 1));
+            }
+        }
+
+        if (args.length == 1)
+        {
+            return completeFirstArgument(args);
+        }
+
+        return List.of();
+    }
+
+    private boolean dispatchExtension(@NotNull ClaimCommandContext context, @NotNull String[] args)
+    {
+        if (args.length == 0)
+        {
+            return false;
+        }
+
+        if (equalsIgnoreCase(args[0], "mode"))
+        {
+            return dispatchMode(context, trimArgs(args, 1));
+        }
+
+        ClaimCommandSubcommand subcommand = plugin.getClaimCommandExtensionRegistry().getSubcommand(args[0]);
+        if (subcommand == null)
+        {
+            return false;
+        }
+
+        return subcommand.onCommand(context, trimArgs(args, 1));
+    }
+
+    private boolean dispatchMode(@NotNull ClaimCommandContext context, @NotNull String[] args)
+    {
+        List<ClaimCommandMode> modes = plugin.getClaimCommandExtensionRegistry().getModes();
+        if (args.length == 0)
+        {
+            if (modes.isEmpty())
+            {
+                context.getPlayer().sendMessage("/claim mode <name>");
+                return true;
+            }
+
+            String modeList = String.join(", ", modes.stream().map(ClaimCommandMode::getName).toList());
+            context.getPlayer().sendMessage("/claim mode <name>  Available: " + modeList);
+            return true;
+        }
+
+        ClaimCommandMode mode = plugin.getClaimCommandExtensionRegistry().getMode(args[0]);
+        if (mode == null)
+        {
+            String modeList = String.join(", ", modes.stream().map(ClaimCommandMode::getName).toList());
+            context.getPlayer().sendMessage("/claim mode <name>  Available: " + modeList);
+            return true;
+        }
+
+        return mode.onCommand(context, trimArgs(args, 1));
+    }
+
+    private @NotNull List<String> completeModes(@NotNull ClaimCommandContext context, @NotNull String[] args)
+    {
+        ClaimCommandExtensionRegistry registry = plugin.getClaimCommandExtensionRegistry();
+        if (args.length == 2)
+        {
+            String prefix = args[1].toLowerCase(Locale.ROOT);
+            List<String> completions = new ArrayList<>();
+            for (ClaimCommandMode mode : registry.getModes())
+            {
+                if (prefix.isEmpty() || mode.getName().toLowerCase(Locale.ROOT).startsWith(prefix))
+                {
+                    completions.add(mode.getName());
+                }
+            }
+            completions.sort(String.CASE_INSENSITIVE_ORDER);
+            return completions;
+        }
+
+        if (args.length > 2)
+        {
+            ClaimCommandMode mode = registry.getMode(args[1]);
+            if (mode != null)
+            {
+                return mode.onTabComplete(context, trimArgs(args, 2));
+            }
+        }
+
+        return List.of();
+    }
+
+    private @NotNull List<String> completeFirstArgument(@NotNull String[] args)
+    {
+        String prefix = args[0].toLowerCase(Locale.ROOT);
+        ArrayList<String> completions = new ArrayList<>(TabCompletions.integer(args, 3, false));
+
+        if ("mode".startsWith(prefix))
+        {
+            completions.add("mode");
+        }
+
+        for (ClaimCommandSubcommand subcommand : plugin.getClaimCommandExtensionRegistry().getSubcommands())
+        {
+            if (prefix.isEmpty() || subcommand.getName().toLowerCase(Locale.ROOT).startsWith(prefix))
+            {
+                completions.add(subcommand.getName());
+            }
+        }
+
+        completions.sort(String.CASE_INSENSITIVE_ORDER);
+        ArrayList<String> unique = new ArrayList<>(completions.size());
+        for (String completion : completions)
+        {
+            if (unique.isEmpty() || !completion.equalsIgnoreCase(unique.getLast()))
+            {
+                unique.add(completion);
+            }
+        }
+        return unique;
+    }
+
+    private void registerBuiltInModes()
+    {
+        ClaimCommandExtensionRegistry registry = plugin.getClaimCommandExtensionRegistry();
+        registry.registerMode(new ClaimCommandMode()
+        {
+            @Override
+            public @NotNull String getName()
+            {
+                return "basic";
+            }
+
+            @Override
+            public boolean onCommand(@NotNull ClaimCommandContext context, @NotNull String[] args)
+            {
+                PlayerData playerData = context.getPlayerData();
+                playerData.shovelMode = ShovelMode.Basic;
+                playerData.claimSubdividing = null;
+                GriefPrevention.sendMessage(context.getPlayer(), TextMode.Success, Messages.BasicClaimsMode);
+                return true;
+            }
+        });
+        registry.registerMode(new ClaimCommandMode()
+        {
+            @Override
+            public @NotNull String getName()
+            {
+                return "admin";
+            }
+
+            @Override
+            public boolean onCommand(@NotNull ClaimCommandContext context, @NotNull String[] args)
+            {
+                Player player = context.getPlayer();
+                if (!player.hasPermission("griefprevention.adminclaims"))
+                {
+                    GriefPrevention.sendMessage(player, TextMode.Err, Messages.NoPermissionForCommand);
+                    return true;
+                }
+
+                context.getPlayerData().shovelMode = ShovelMode.Admin;
+                GriefPrevention.sendMessage(player, TextMode.Success, Messages.AdminClaimsMode);
+                return true;
+            }
+        });
+        registry.registerMode(new ClaimCommandMode()
+        {
+            @Override
+            public @NotNull String getName()
+            {
+                return "subdivide";
+            }
+
+            @Override
+            public @NotNull List<String> getAliases()
+            {
+                return List.of("subdivision");
+            }
+
+            @Override
+            public boolean onCommand(@NotNull ClaimCommandContext context, @NotNull String[] args)
+            {
+                PlayerData playerData = context.getPlayerData();
+                playerData.shovelMode = ShovelMode.Subdivide;
+                playerData.claimSubdividing = null;
+                GriefPrevention.sendMessage(context.getPlayer(), TextMode.Instr, Messages.SubdivisionMode);
+                GriefPrevention.sendMessage(context.getPlayer(), TextMode.Instr, Messages.SubdivisionVideo2, DataStore.SUBDIVISION_VIDEO_URL);
+                return true;
+            }
+        });
+    }
+
+    private static boolean equalsIgnoreCase(@Nullable String left, @Nullable String right)
+    {
+        return left != null && left.equalsIgnoreCase(right);
+    }
+
+    private static @NotNull String[] trimArgs(@NotNull String[] args, int count)
+    {
+        if (count >= args.length)
+        {
+            return new String[0];
+        }
+
+        return Arrays.copyOfRange(args, count, args.length);
     }
 
 }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -20,6 +20,9 @@ package me.ryanhamshire.GriefPrevention;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.griefprevention.api.claimcommand.ClaimCommandContext;
+import com.griefprevention.api.claimcommand.ClaimCommandExtensionRegistry;
+import com.griefprevention.api.claimcommand.ClaimCommandMode;
 import com.griefprevention.commands.ClaimCommand;
 import com.griefprevention.metrics.MetricsHandler;
 import com.griefprevention.platform.knockback.KnockbackProtectionListener;
@@ -87,12 +90,18 @@ public class GriefPrevention extends JavaPlugin
 {
     //for convenience, a reference to the instance of this plugin
     public static GriefPrevention instance;
+    private final ClaimCommandExtensionRegistry claimCommandExtensionRegistry = new ClaimCommandExtensionRegistry();
 
     //for logging to the console and log file
     private static Logger log;
 
     //this handles data storage, like player and region data
     public DataStore dataStore;
+
+    public @NotNull ClaimCommandExtensionRegistry getClaimCommandExtensionRegistry()
+    {
+        return claimCommandExtensionRegistry;
+    }
 
     // Event handlers with common functionality
     EntityEventHandler entityEventHandler;
@@ -1609,34 +1618,19 @@ public class GriefPrevention extends JavaPlugin
         //adminclaims
         else if (cmd.getName().equalsIgnoreCase("adminclaims") && player != null)
         {
-            PlayerData playerData = this.dataStore.getPlayerData(player.getUniqueId());
-            playerData.shovelMode = ShovelMode.Admin;
-            GriefPrevention.sendMessage(player, TextMode.Success, Messages.AdminClaimsMode);
-
-            return true;
+            return activateClaimCommandMode(player, cmd, commandLabel, "admin");
         }
 
         //basicclaims
         else if (cmd.getName().equalsIgnoreCase("basicclaims") && player != null)
         {
-            PlayerData playerData = this.dataStore.getPlayerData(player.getUniqueId());
-            playerData.shovelMode = ShovelMode.Basic;
-            playerData.claimSubdividing = null;
-            GriefPrevention.sendMessage(player, TextMode.Success, Messages.BasicClaimsMode);
-
-            return true;
+            return activateClaimCommandMode(player, cmd, commandLabel, "basic");
         }
 
         //subdivideclaims
         else if (cmd.getName().equalsIgnoreCase("subdivideclaims") && player != null)
         {
-            PlayerData playerData = this.dataStore.getPlayerData(player.getUniqueId());
-            playerData.shovelMode = ShovelMode.Subdivide;
-            playerData.claimSubdividing = null;
-            GriefPrevention.sendMessage(player, TextMode.Instr, Messages.SubdivisionMode);
-            GriefPrevention.sendMessage(player, TextMode.Instr, Messages.SubdivisionVideo2, DataStore.SUBDIVISION_VIDEO_URL);
-
-            return true;
+            return activateClaimCommandMode(player, cmd, commandLabel, "subdivide");
         }
 
         //deleteclaim
@@ -2767,6 +2761,22 @@ public class GriefPrevention extends JavaPlugin
             PvPImmunityValidationTask task = new PvPImmunityValidationTask(player);
             this.getServer().getScheduler().scheduleSyncDelayedTask(this, task, 1200L);
         }
+    }
+
+    private boolean activateClaimCommandMode(
+            @NotNull Player player,
+            @NotNull Command command,
+            @NotNull String label,
+            @NotNull String modeName)
+    {
+        PlayerData playerData = this.dataStore.getPlayerData(player.getUniqueId());
+        ClaimCommandMode mode = this.claimCommandExtensionRegistry.getMode(modeName);
+        if (mode == null)
+        {
+            return false;
+        }
+
+        return mode.onCommand(new ClaimCommandContext(this, player, playerData, command, label), new String[0]);
     }
 
     static boolean isInventoryEmpty(Player player)


### PR DESCRIPTION
## Summary

This PR expands the `/claim` addon API from no real extension surface to a registry-backed command extension model.

It adds support for:

- custom `/claim <subcommand> ...` handlers
- custom `/claim mode <name>` handlers
- delegated tab completion for both

The existing `/claim [radius]` behavior remains the default fallback when no registered extension matches.

## What Changed

- Added `ClaimCommandContext`
- Added `ClaimCommandSubcommand`
- Added `ClaimCommandMode`
- Added `ClaimCommandExtensionRegistry`
- Exposed the claim command extension registry from `GriefPrevention`
- Updated `ClaimCommand` to:
  - dispatch registered subcommands
  - dispatch `/claim mode <name>`
  - delegate tab completion to registered subcommands and modes
  - preserve current numeric radius claim creation behavior as fallback
- Routed built-in `basic`, `admin`, and `subdivide` claim modes through the same mode registry
- Kept legacy `/basicclaims`, `/adminclaims`, and `/subdivideclaims` commands working by forwarding them through the registry-backed mode path

## Scope

This PR is limited to `/claim` command extensibility.

It does **not** change claim geometry, visualization, or tool interaction behavior by itself.

## Why

Previous review feedback on extension-related work was to expose API seams instead of continuing to hard-code feature-specific behavior into core.

This PR adds those seams for the `/claim` command so addons can register real command behavior instead of only relying on core command parsing or dedicated hard-coded commands.

## Compatibility

- Existing `/claim [radius]` behavior still works
- Existing `/basicclaims`, `/adminclaims`, and `/subdivideclaims` commands still work
- Built-in modes now go through the same registry-backed path used by addons
- `mode` is reserved under `/claim mode ...` and cannot be claimed as a custom subcommand

## Testing

Tested locally with:

- `mvn -q -DskipTests compile`
- `mvn -q test`

## AI Disclosure

AI assistance was used for refactoring and drafting code in this PR.

- Model: `GPT-5.4`
- Usage: API extraction, command dispatch refactoring, and PR text drafting
- Review: all changes were reviewed and verified by a human before submission