### PR TITLE
Add COPPER_CHAIN to auto-extend player blocks

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/AutoExtendClaimTask.java
@@ -319,6 +319,7 @@ public class AutoExtendClaimTask implements Runnable
         playerBlocks.add(Material.RAW_GOLD_BLOCK);
         playerBlocks.add(Material.LIGHTNING_ROD);
         playerBlocks.add(Material.DECORATED_POT);
+        playerBlocks.add(Material.COPPER_CHAIN);
     
         //these are unnatural in the nether and end
         if (environment != Environment.NORMAL && environment != Environment.CUSTOM)


### PR DESCRIPTION
Model: claude-opus-4-7

User prompt:
Let's add chain copper to the list of player blocks in the auto-extend task. Read @AGENTS.md, implement, commit, and push the changes.

AI output (caveman):
COPPER_CHAIN player block. AutoExtendClaimTask unconditional list. Near LIGHTNING_ROD. Player crafted, always unnatural. Compile pass.