### PR TITLE
Allow container trust for item frame contents

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
@@ -738,7 +738,7 @@ public class EntityDamageHandler implements Listener
 
     private ClaimPermission getRequiredPermissionForEntityDamage(@NotNull Entity entity)
     {
-        if (entity instanceof ItemFrame itemFrame)
+        if (instance.config_claims_itemFrameContentsRequireContainerTrust && entity instanceof ItemFrame itemFrame)
         {
             ItemStack item = itemFrame.getItem();
             if (item != null && item.getType() != Material.AIR)

--- a/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/EntityDamageHandler.java
@@ -3,6 +3,7 @@ package me.ryanhamshire.GriefPrevention;
 import me.ryanhamshire.GriefPrevention.events.PreventPvPEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.AnimalTamer;
 import org.bukkit.entity.Creature;
@@ -12,6 +13,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.EvokerFangs;
 import org.bukkit.entity.Explosive;
 import org.bukkit.entity.Horse;
+import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Llama;
@@ -37,6 +39,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.vehicle.VehicleDamageEvent;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -722,7 +725,8 @@ public class EntityDamageHandler implements Listener
             return true;
         }
 
-        Supplier<String> failureReason = claim.checkPermission(attacker, ClaimPermission.Build, event);
+        ClaimPermission requiredPermission = this.getRequiredPermissionForEntityDamage(event.getEntity());
+        Supplier<String> failureReason = claim.checkPermission(attacker, requiredPermission, event);
 
         // If player has build trust, fall through to next checks.
         if (failureReason == null) return false;
@@ -731,6 +735,21 @@ public class EntityDamageHandler implements Listener
         if (sendMessages) GriefPrevention.sendMessage(attacker, TextMode.Err, failureReason.get());
         return true;
     }
+
+    private ClaimPermission getRequiredPermissionForEntityDamage(@NotNull Entity entity)
+    {
+        if (entity instanceof ItemFrame itemFrame)
+        {
+            ItemStack item = itemFrame.getItem();
+            if (item != null && item.getType() != Material.AIR)
+            {
+                return ClaimPermission.Container;
+            }
+        }
+
+        return ClaimPermission.Build;
+    }
+
     private boolean handleClaimedBuildTrustDamageByEntity(
             @NotNull EntityCombustByEntityEvent event,
             @Nullable Player attacker,

--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -118,6 +118,7 @@ public class GriefPrevention extends JavaPlugin
     public boolean config_claims_preventGlobalMonsterEggs; //whether monster eggs can be placed regardless of trust.
     public boolean config_claims_preventTheft;                        //whether containers and crafting blocks are protectable
     public boolean config_claims_hoppersRequireBuildTrust;            //whether hoppers require build trust instead of container trust
+    public boolean config_claims_itemFrameContentsRequireContainerTrust; //whether item frame contents require container trust
     public boolean config_claims_protectCreatures;                    //whether claimed animals may be injured by players without permission
     public boolean config_claims_protectHorses;                        //whether horses on a claim should be protected by that claim's rules
     public boolean config_claims_protectDonkeys;                    //whether donkeys on a claim should be protected by that claim's rules
@@ -572,6 +573,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_claims_preventGlobalMonsterEggs = config.getBoolean("GriefPrevention.Claims.PreventGlobalMonsterEggs", true);
         this.config_claims_preventTheft = config.getBoolean("GriefPrevention.Claims.PreventTheft", true);
         this.config_claims_hoppersRequireBuildTrust = config.getBoolean("GriefPrevention.Claims.HoppersRequireBuildTrust", false);
+        this.config_claims_itemFrameContentsRequireContainerTrust = config.getBoolean("GriefPrevention.Claims.ItemFrameContentsRequireContainerTrust", false);
         this.config_claims_protectCreatures = config.getBoolean("GriefPrevention.Claims.ProtectCreatures", true);
         this.config_claims_protectHorses = config.getBoolean("GriefPrevention.Claims.ProtectHorses", true);
         this.config_claims_protectDonkeys = config.getBoolean("GriefPrevention.Claims.ProtectDonkeys", true);
@@ -856,6 +858,7 @@ public class GriefPrevention extends JavaPlugin
         outConfig.set("GriefPrevention.Claims.PreventGlobalMonsterEggs", this.config_claims_preventGlobalMonsterEggs);
         outConfig.set("GriefPrevention.Claims.PreventTheft", this.config_claims_preventTheft);
         outConfig.set("GriefPrevention.Claims.HoppersRequireBuildTrust", this.config_claims_hoppersRequireBuildTrust);
+        outConfig.set("GriefPrevention.Claims.ItemFrameContentsRequireContainerTrust", this.config_claims_itemFrameContentsRequireContainerTrust);
         outConfig.set("GriefPrevention.Claims.ProtectCreatures", this.config_claims_protectCreatures);
         outConfig.set("GriefPrevention.Claims.PreventButtonsSwitches", this.config_claims_preventButtonsSwitches);
         outConfig.set("GriefPrevention.Claims.LockWoodenDoors", this.config_claims_lockWoodenDoors);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -48,6 +48,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Fish;
 import org.bukkit.entity.Hanging;
+import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Llama;
 import org.bukkit.entity.Mule;
 import org.bukkit.entity.Player;
@@ -1253,7 +1254,17 @@ class PlayerEventHandler implements Listener
         }
 
         //don't allow interaction with item frames or armor stands in claimed areas without build permission
-        if (entity.getType() == EntityType.ARMOR_STAND || entity instanceof Hanging)
+        if (entity instanceof ItemFrame)
+        {
+            String noContainerReason = this.allowItemFrameContentInteraction(player, entity, event);
+            if (noContainerReason != null)
+            {
+                GriefPrevention.sendMessage(player, TextMode.Err, noContainerReason);
+                event.setCancelled(true);
+                return;
+            }
+        }
+        else if (entity.getType() == EntityType.ARMOR_STAND || entity instanceof Hanging)
         {
             String noBuildReason = instance.allowBuild(player, entity.getLocation(), Material.ITEM_FRAME);
             if (noBuildReason != null)
@@ -1394,6 +1405,21 @@ class PlayerEventHandler implements Listener
             event.setCancelled(true);
             GriefPrevention.sendMessage(player, TextMode.Err, noContainersReason.get());
         }
+    }
+
+    private String allowItemFrameContentInteraction(Player player, Entity entity, PlayerInteractEntityEvent event)
+    {
+        PlayerData playerData = this.dataStore.getPlayerData(player.getUniqueId());
+        Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, playerData.lastClaim);
+
+        if (claim == null)
+        {
+            return instance.allowBuild(player, entity.getLocation(), Material.ITEM_FRAME);
+        }
+
+        playerData.lastClaim = claim;
+        Supplier<String> noContainerReason = claim.checkPermission(player, ClaimPermission.Container, event);
+        return noContainerReason == null ? null : noContainerReason.get();
     }
 
     //when a player throws an egg

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1254,7 +1254,7 @@ class PlayerEventHandler implements Listener
         }
 
         //don't allow interaction with item frames or armor stands in claimed areas without build permission
-        if (entity instanceof ItemFrame)
+        if (instance.config_claims_itemFrameContentsRequireContainerTrust && entity instanceof ItemFrame)
         {
             String noContainerReason = this.allowItemFrameContentInteraction(player, entity, event);
             if (noContainerReason != null)


### PR DESCRIPTION
Currently item frames are treated like other hanging entities, so players need full /trust access to place an item into a frame, rotate it, or remove it. This makes it hard to use item frames for player-run games or interactive setups inside claims, since giving  someone /trust also lets them build/break in the claim. 

With this change:
- /containertrust allows placing an item into an existing item frame.
- /containertrust allows rotating an item already in an item frame.
- /containertrust allows removing an item from a non-empty item frame.
- /containertrust does not allow placing new item frames.
- /containertrust does not allow breaking empty item frames.
- Breaking/removing the frame itself still requires normal build trust.

The use case I had in mind is players building interactive board games with item frames, such as chess boards using custom maps. They want other players to be able to move the pieces around, but not break the item frames or modify the claim.

One thing I am not sure about is whether this should be tied to a new config option. This does technically change existing claim behaviour, because servers may already have claims where players granted container trust without expecting that to include item frames. If preferred, I can update this PR so the new behaviour is disabled by default and only applies when a server owner enables something like treating item frame contents as containers.