### PR TITLE
Pass entity interaction event to claim permission checks

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1255,10 +1255,14 @@ class PlayerEventHandler implements Listener
         //don't allow interaction with item frames or armor stands in claimed areas without build permission
         if (entity.getType() == EntityType.ARMOR_STAND || entity instanceof Hanging)
         {
-            String noBuildReason = instance.allowBuild(player, entity.getLocation(), Material.ITEM_FRAME);
+            Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, playerData.lastClaim);
+            if (claim == null) return;
+
+            playerData.lastClaim = claim;
+            Supplier<String> noBuildReason = claim.checkPermission(player, ClaimPermission.Build, event);
             if (noBuildReason != null)
             {
-                GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason);
+                GriefPrevention.sendMessage(player, TextMode.Err, noBuildReason.get());
                 event.setCancelled(true);
                 return;
             }


### PR DESCRIPTION
Updates the item frame / armor stand / hanging entity right click interaction check to pass the original `PlayerInteractEntityEvent` into `ClaimPermissionCheckEvent`.

Previously this path used `allowBuild(...)` which creates a block-place style permission check. That preserves the build trust requirement but addons listening to `ClaimPermissionCheckEvent` do not get the original entity interaction context.

This keeps the same build trust requirement inside claims but checks the claim permission directly so addons can inspect the actual interaction event and clicked entity.

Referenced here: https://github.com/GriefPrevention/GriefPrevention/pull/2594#issuecomment-4365085252