### PR TITLE
Prevent adjacent claimed double chests from being split when a single…

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -508,6 +508,9 @@ public class BlockEventHandler implements Listener
                 // and chests inside the same claim should connect (equal)
                 if (Objects.equals(claimOwner, relativeClaimOwner)) break;
 
+                // Ignore existing double chests; only adjacent single chests are handled here.
+                if (relativeChest.getType() != Chest.Type.SINGLE) continue;
+
                 // Change both chests to singular chests
                 chest.setType(Chest.Type.SINGLE);
                 block.setBlockData(chest);


### PR DESCRIPTION
## Summary

Fixes #2606.

This fixes an issue where placing a single chest outside a claim, adjacent to an existing double chest fully inside the claim, could split the existing double chest into two single chests.

The existing logic checks neighboring chests around the newly placed block and splits both chests when they belong to different claim owners. However, not every adjacent chest is a valid candidate for this handling.

When the neighboring chest is already part of a double chest, splitting it modifies an existing valid double chest inside the claim, even though the newly placed chest did not form a cross-claim double chest with that specific block.

## Changes

This change skips neighboring chests that are not `Chest.Type.SINGLE`.

That keeps the existing cross-claim double chest handling intact for adjacent single chests, while avoiding modifications to an existing double chest that is already fully inside a claim.

## Testing

Manually tested the scenario from #2606:

* Created a claim.
* Placed a double chest fully inside the claim, with one side or both on the claim border.
* Placed a single chest outside the claim adjacent to the existing double chest.
* Confirmed the existing double chest is no longer split into two single chests.
