### PR TITLE
Prevent claimed single chests from being extended outside claims

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -489,9 +489,6 @@ public class BlockEventHandler implements Listener
     };
     private void denyConnectingDoubleChestsAcrossClaimBoundary(Claim claim, Block block, Player player)
     {
-        UUID claimOwner = null;
-        if (claim != null)
-            claimOwner = claim.getOwnerID();
 
         // Check for double chests placed just outside the claim boundary
         if (block.getBlockData() instanceof Chest chest)
@@ -502,11 +499,9 @@ public class BlockEventHandler implements Listener
                 if (!(relative.getBlockData() instanceof Chest relativeChest)) continue;
 
                 Claim relativeClaim = this.dataStore.getClaimAt(relative.getLocation(), true, claim);
-                UUID relativeClaimOwner = relativeClaim == null ? null : relativeClaim.getOwnerID();
 
-                // Chests outside claims should connect (both null)
-                // and chests inside the same claim should connect (equal)
-                if (Objects.equals(claimOwner, relativeClaimOwner)) break;
+                // Chests outside claims should connect, and chests in claims owned by the same owner should connect.
+                if (sameClaimOwner(claim, relativeClaim)) break;
 
                 // Change both chests to singular chests
                 chest.setType(Chest.Type.SINGLE);
@@ -520,6 +515,16 @@ public class BlockEventHandler implements Listener
                 break;
             }
         }
+    }
+
+    private boolean sameClaimOwner(Claim first, Claim second)
+    {
+        // Important: wilderness and admin claims must not be treated as the same
+        // just because both may have a null owner ID.
+        if (first == null || second == null)
+            return first == second;
+
+        return Objects.equals(first.getOwnerID(), second.getOwnerID());
     }
 
     // Prevent pistons pushing blocks into or out of claims.


### PR DESCRIPTION
## Summary

Fixes #2609.

This fixes an issue where a single chest placed on the border of a claim could be extended into a double chest from outside the claim.

A player without build/access permission in the claim could place another chest outside the claim, next to the claimed single chest, causing the claimed chest to become part of a double chest crossing the claim boundary.

## Changes

This change improves the double chest boundary handling so that a chest placed outside a claim cannot modify a claimed single chest into a cross-claim double chest.

When a newly placed chest would connect to a chest in a claim where the player does not have permission, the chests are kept as separate single chests instead.

## Testing

Manually tested the reported admin claim scenario:

* Enabled admin claims mode using `/adminclaims`.
* Created an admin claim.
* Placed a single chest on the border of the admin claim.
* Used a player without build permission in the admin claim.
* Stood outside the admin claim.
* Placed another chest next to the claimed single chest.
* Confirmed the chest inside the admin claim is no longer extended into a double chest crossing the claim boundary.
