### PR TITLE
Respect claim borders when placing chests between two targets

### DIFF
--- a/src/main/java/com/griefprevention/protection/ChestProtectionHandler.java
+++ b/src/main/java/com/griefprevention/protection/ChestProtectionHandler.java
@@ -1,0 +1,181 @@
+package com.griefprevention.protection;
+
+import me.ryanhamshire.GriefPrevention.Claim;
+import me.ryanhamshire.GriefPrevention.DataStore;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.Chest;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
+
+public final class ChestProtectionHandler
+{
+
+    private ChestProtectionHandler()
+    {
+        throw new AssertionError("Utility class must not be instantiated.");
+    }
+
+    public static void denyConnectingDoubleChestsAcrossClaimBoundary(DataStore dataStore, Claim claim, Block block, Player player)
+    {
+        // Only apply this logic to placed chests.
+        if (!(block.getBlockData() instanceof Chest chest)) return;
+
+        // Only interfere when Minecraft already connected this chest to a side
+        // that should not be allowed by the claim ownership rule.
+        BlockFace connectedFace = getConnectedFace(chest);
+        if (connectedFace == null) return;
+
+        Block connectedBlock = block.getRelative(connectedFace);
+        if (!(connectedBlock.getBlockData() instanceof Chest connectedChest)) return;
+        if (block.getType() != connectedBlock.getType()) return;
+
+        Claim connectedClaim = dataStore.getClaimAt(connectedBlock.getLocation(), true, claim);
+
+        if (ProtectionHelper.sameClaimOwner(claim, connectedClaim)) return;
+
+        // Avoid fallback chest connections when sneaking
+        if (player.isSneaking())
+        {
+            splitDoubleChest(block, chest, connectedBlock, connectedChest, player);
+            return;
+        }
+
+        // Vanilla connected to a side that should not be allowed. Look for another
+        // allowed side that Minecraft could naturally connect to instead.
+        BlockFace allowedFace = findAllowedSingleChestConnectionFace(dataStore, claim, block, chest, connectedFace);
+
+        // Always undo the invalid vanilla connection first.
+        splitDoubleChest(block, chest, connectedBlock, connectedChest, player);
+
+        if (allowedFace == null) return;
+
+        Block allowedBlock = block.getRelative(allowedFace);
+        if (!(allowedBlock.getBlockData() instanceof Chest allowedChest)) return;
+        if (block.getType() != allowedBlock.getType()) return;
+
+        connectDoubleChest(chest, block, allowedChest, allowedBlock, allowedFace, player);
+    }
+
+    // Checks whether the opposite side of the denied connection has an allowed,
+    // naturally connectable single chest.
+    private static @Nullable BlockFace findAllowedSingleChestConnectionFace(DataStore dataStore, Claim claim, Block block,
+                                                                            Chest chest, BlockFace deniedFace)
+    {
+        // A normal double chest can only connect on the left/right axis.
+        // Since vanilla already connected one side and that side was denied,
+        // the only remaining possible vanilla-style alternative is the opposite side.
+        BlockFace face = deniedFace.getOppositeFace();
+
+        Block relative = block.getRelative(face);
+        if (!(relative.getBlockData() instanceof Chest relativeChest)) return null;
+        if (block.getType() != relative.getType()) return null;
+        if (relativeChest.getType() != Chest.Type.SINGLE) return null;
+
+        // Do not treat claim permission as enough to force a connection.
+        // The neighboring chest must also be naturally connectable.
+        if (cannotNaturallyConnectChests(chest, relativeChest, face)) return null;
+
+        Claim relativeClaim = dataStore.getClaimAt(relative.getLocation(), true, claim);
+        if (!ProtectionHelper.sameClaimOwner(claim, relativeClaim)) return null;
+
+        return face;
+    }
+
+    // Splits a double chest back into two single chests.
+    private static void splitDoubleChest(Block placedBlock, Chest placedChest, Block connectedBlock, Chest connectedChest,
+                                         Player player)
+    {
+        placedChest.setType(Chest.Type.SINGLE);
+        placedBlock.setBlockData(placedChest);
+
+        connectedChest.setType(Chest.Type.SINGLE);
+        connectedBlock.setBlockData(connectedChest);
+
+        player.sendBlockChange(placedBlock.getLocation(), placedChest);
+        player.sendBlockChange(connectedBlock.getLocation(), connectedChest);
+    }
+
+    // Checks whether two chests could naturally form a double chest.
+    // This prevents the plugin from rotating an existing neighboring chest.
+    private static boolean cannotNaturallyConnectChests(Chest placedChest, Chest relativeChest, BlockFace relativeFace)
+    {
+        // Minecraft only forms a normal double chest when both chests face the same direction.
+        if (placedChest.getFacing() != relativeChest.getFacing()) return true;
+
+        // The placed chest must be able to connect on the relative side,
+        // and the relative chest must be able to connect back on the opposite side.
+        return isInvalidChestConnectionFace(placedChest, relativeFace) ||
+                isInvalidChestConnectionFace(relativeChest, relativeFace.getOppositeFace());
+    }
+
+    // Checks whether the neighbor is on a side where this chest cannot form a double chest.
+    private static boolean isInvalidChestConnectionFace(Chest chest, BlockFace face)
+    {
+        BlockFace facing = chest.getFacing();
+        return face != rotateClockwise(facing) && face != rotateCounterClockwise(facing);
+    }
+
+    // Connects two allowed single chests to become one double chest.
+    // This method never changes the facing of the neighboring chest.
+    private static void connectDoubleChest(Chest placedChest, Block placedBlock, Chest relativeChest, Block relativeBlock,
+                                           BlockFace relativeFace, Player player)
+    {
+        // Safety check: only connect if this would be a natural double chest.
+        if (cannotNaturallyConnectChests(placedChest, relativeChest, relativeFace)) return;
+
+        BlockFace facing = placedChest.getFacing();
+
+        // Calculate the correct LEFT/RIGHT type for both chest blocks.
+        Chest.Type placedType = getChestTypeForConnection(facing, relativeFace);
+        Chest.Type relativeType = getChestTypeForConnection(facing, relativeFace.getOppositeFace());
+
+        if (placedType == Chest.Type.SINGLE || relativeType == Chest.Type.SINGLE) return;
+
+        placedChest.setType(placedType);
+        placedBlock.setBlockData(placedChest);
+
+        relativeChest.setType(relativeType);
+        relativeBlock.setBlockData(relativeChest);
+
+        // Resend both blocks to prevent visual desync.
+        player.sendBlockChange(placedBlock.getLocation(), placedChest);
+        player.sendBlockChange(relativeBlock.getLocation(), relativeChest);
+    }
+
+    // Returns the side where the chest is currently connected.
+    private static @Nullable BlockFace getConnectedFace(Chest chest)
+    {
+        if (chest.getType() == Chest.Type.LEFT) return rotateClockwise(chest.getFacing());
+        if (chest.getType() == Chest.Type.RIGHT) return rotateCounterClockwise(chest.getFacing());
+        return null;
+    }
+
+    // Converts a connected side into the correct chest half type.
+    private static Chest.Type getChestTypeForConnection(BlockFace facing, BlockFace connectedFace)
+    {
+        if (connectedFace == rotateClockwise(facing)) return Chest.Type.LEFT;
+        if (connectedFace == rotateCounterClockwise(facing)) return Chest.Type.RIGHT;
+        return Chest.Type.SINGLE;
+    }
+
+    // Rotates a horizontal direction clockwise.
+    private static BlockFace rotateClockwise(BlockFace face)
+    {
+        if (face == BlockFace.NORTH) return BlockFace.EAST;
+        if (face == BlockFace.EAST) return BlockFace.SOUTH;
+        if (face == BlockFace.SOUTH) return BlockFace.WEST;
+        if (face == BlockFace.WEST) return BlockFace.NORTH;
+        return face;
+    }
+
+    // Rotates a horizontal direction counter-clockwise.
+    private static BlockFace rotateCounterClockwise(BlockFace face)
+    {
+        if (face == BlockFace.NORTH) return BlockFace.WEST;
+        if (face == BlockFace.WEST) return BlockFace.SOUTH;
+        if (face == BlockFace.SOUTH) return BlockFace.EAST;
+        if (face == BlockFace.EAST) return BlockFace.NORTH;
+        return face;
+    }
+}

--- a/src/main/java/com/griefprevention/protection/ChestProtectionHandler.java
+++ b/src/main/java/com/griefprevention/protection/ChestProtectionHandler.java
@@ -21,8 +21,6 @@ public final class ChestProtectionHandler
         // Only apply this logic to placed chests.
         if (!(block.getBlockData() instanceof Chest chest)) return;
 
-        // Only interfere when Minecraft already connected this chest to a side
-        // that should not be allowed by the claim ownership rule.
         BlockFace connectedFace = getConnectedFace(chest);
         if (connectedFace == null) return;
 
@@ -34,20 +32,14 @@ public final class ChestProtectionHandler
 
         if (ProtectionHelper.sameClaimOwner(claim, connectedClaim)) return;
 
-        // Avoid fallback chest connections when sneaking
-        if (player.isSneaking())
-        {
-            splitDoubleChest(block, chest, connectedBlock, connectedChest, player);
-            return;
-        }
-
-        // Vanilla connected to a side that should not be allowed. Look for another
-        // allowed side that Minecraft could naturally connect to instead.
-        BlockFace allowedFace = findAllowedSingleChestConnectionFace(dataStore, claim, block, chest, connectedFace);
-
-        // Always undo the invalid vanilla connection first.
+        // Split the disallowed connection.
         splitDoubleChest(block, chest, connectedBlock, connectedChest, player);
 
+        // Chests placed while sneaking only attempt connection on the clicked chest.
+        if (player.isSneaking()) return;
+        
+        // Look for another allowed side that Minecraft could naturally connect to instead.
+        BlockFace allowedFace = findAllowedSingleChestConnectionFace(dataStore, claim, block, chest, connectedFace);
         if (allowedFace == null) return;
 
         Block allowedBlock = block.getRelative(allowedFace);

--- a/src/main/java/com/griefprevention/protection/ChestProtectionHandler.java
+++ b/src/main/java/com/griefprevention/protection/ChestProtectionHandler.java
@@ -66,7 +66,7 @@ public final class ChestProtectionHandler
 
         // Do not treat claim permission as enough to force a connection.
         // The neighboring chest must also be naturally connectable.
-        if (cannotNaturallyConnectChests(chest, relativeChest, face)) return null;
+        if (!canNaturallyConnectChests(chest, relativeChest, face)) return null;
 
         Claim relativeClaim = dataStore.getClaimAt(relative.getLocation(), true, claim);
         if (!ProtectionHelper.sameClaimOwner(claim, relativeClaim)) return null;
@@ -90,22 +90,22 @@ public final class ChestProtectionHandler
 
     // Checks whether two chests could naturally form a double chest.
     // This prevents the plugin from rotating an existing neighboring chest.
-    private static boolean cannotNaturallyConnectChests(Chest placedChest, Chest relativeChest, BlockFace relativeFace)
+    private static boolean canNaturallyConnectChests(Chest placedChest, Chest relativeChest, BlockFace relativeFace)
     {
         // Minecraft only forms a normal double chest when both chests face the same direction.
-        if (placedChest.getFacing() != relativeChest.getFacing()) return true;
+        if (placedChest.getFacing() != relativeChest.getFacing()) return false;
 
         // The placed chest must be able to connect on the relative side,
         // and the relative chest must be able to connect back on the opposite side.
-        return isInvalidChestConnectionFace(placedChest, relativeFace) ||
-                isInvalidChestConnectionFace(relativeChest, relativeFace.getOppositeFace());
+        return isValidChestConnectionFace(placedChest, relativeFace) &&
+                isValidChestConnectionFace(relativeChest, relativeFace.getOppositeFace());
     }
 
-    // Checks whether the neighbor is on a side where this chest cannot form a double chest.
-    private static boolean isInvalidChestConnectionFace(Chest chest, BlockFace face)
+    // Checks whether the neighbor is on a side where this chest can form a double chest.
+    private static boolean isValidChestConnectionFace(Chest chest, BlockFace face)
     {
         BlockFace facing = chest.getFacing();
-        return face != rotateClockwise(facing) && face != rotateCounterClockwise(facing);
+        return face == rotateClockwise(facing) || face == rotateCounterClockwise(facing);
     }
 
     // Connects two allowed single chests to become one double chest.
@@ -114,7 +114,7 @@ public final class ChestProtectionHandler
                                            BlockFace relativeFace, Player player)
     {
         // Safety check: only connect if this would be a natural double chest.
-        if (cannotNaturallyConnectChests(placedChest, relativeChest, relativeFace)) return;
+        if (!canNaturallyConnectChests(placedChest, relativeChest, relativeFace)) return;
 
         BlockFace facing = placedChest.getFacing();
 

--- a/src/main/java/com/griefprevention/protection/ProtectionHelper.java
+++ b/src/main/java/com/griefprevention/protection/ProtectionHelper.java
@@ -19,6 +19,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
@@ -105,4 +106,14 @@ public final class ProtectionHelper
         return cancel;
     }
 
+    // Compares claim ownership while keeping wilderness and admin claims separate.
+    public static boolean sameClaimOwner(@Nullable Claim first, @Nullable Claim second)
+    {
+        // Important: wilderness and admin claims must not be treated as the same
+        // just because both may have a null owner ID.
+        if (first == null || second == null)
+            return first == second;
+
+        return Objects.equals(first.getOwnerID(), second.getOwnerID());
+    }
 }

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -481,13 +481,6 @@ public class BlockEventHandler implements Listener
         }
     }
 
-    private static final BlockFace[] HORIZONTAL_DIRECTIONS = new BlockFace[] {
-            BlockFace.NORTH,
-            BlockFace.EAST,
-            BlockFace.SOUTH,
-            BlockFace.WEST
-    };
-
     private void denyConnectingDoubleChestsAcrossClaimBoundary(Claim claim, Block block, Player player)
     {
         // Only apply this logic to placed chests.
@@ -529,7 +522,8 @@ public class BlockEventHandler implements Listener
         connectDoubleChest(chest, block, allowedChest, allowedBlock, allowedFace, player);
     }
 
-    // Finds a neighboring single chest that is allowed and naturally connectable.
+    // Checks whether the opposite side of the denied connection has an allowed,
+    // naturally connectable single chest.
     private @Nullable BlockFace findAllowedSingleChestConnectionFace(Claim claim, Block block, Chest chest,
                                                                      BlockFace deniedFace)
     {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -496,13 +496,10 @@ public class BlockEventHandler implements Listener
         // Only interfere when Minecraft already connected this chest to a side
         // that should not be allowed by the claim ownership rule.
         BlockFace connectedFace = getConnectedFace(chest);
-
         if (connectedFace == null) return;
 
         Block connectedBlock = block.getRelative(connectedFace);
-
         if (!(connectedBlock.getBlockData() instanceof Chest connectedChest)) return;
-
         if (block.getType() != connectedBlock.getType()) return;
 
         Claim connectedClaim = this.dataStore.getClaimAt(connectedBlock.getLocation(), true, claim);
@@ -521,9 +518,7 @@ public class BlockEventHandler implements Listener
         if (allowedFace == null) return;
 
         Block allowedBlock = block.getRelative(allowedFace);
-
         if (!(allowedBlock.getBlockData() instanceof Chest allowedChest)) return;
-
         if (block.getType() != allowedBlock.getType()) return;
 
         connectDoubleChest(chest, block, allowedChest, allowedBlock, allowedFace, player);
@@ -539,11 +534,8 @@ public class BlockEventHandler implements Listener
             if (face == ignoredFace) continue;
 
             Block relative = block.getRelative(face);
-
             if (!(relative.getBlockData() instanceof Chest relativeChest)) continue;
-
             if (block.getType() != relative.getType()) continue;
-
             if (relativeChest.getType() != Chest.Type.SINGLE) continue;
 
             // Do not treat claim permission as enough to force a connection.
@@ -551,7 +543,6 @@ public class BlockEventHandler implements Listener
             if (cannotNaturallyConnectChests(chest, relativeChest, face)) continue;
 
             Claim relativeClaim = this.dataStore.getClaimAt(relative.getLocation(), true, claim);
-
             if (sameClaimOwner(claim, relativeClaim)) return face;
         }
         return null;
@@ -660,7 +651,6 @@ public class BlockEventHandler implements Listener
         // Important: wilderness and admin claims must not be treated as the same
         // just because both may have a null owner ID.
         if (first == null || second == null) return first == second;
-
         return Objects.equals(first.getOwnerID(), second.getOwnerID());
     }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -504,9 +504,14 @@ public class BlockEventHandler implements Listener
 
         Claim connectedClaim = this.dataStore.getClaimAt(connectedBlock.getLocation(), true, claim);
 
-        // If vanilla connected to an allowed side, do not interfere.
-        // This preserves Minecraft's natural behavior.
         if (sameClaimOwner(claim, connectedClaim)) return;
+
+        // Avoid fallback chest connections when sneaking
+        if (player.isSneaking())
+        {
+            splitDoubleChest(block, chest, connectedBlock, connectedChest, player);
+            return;
+        }
 
         // Vanilla connected to a side that should not be allowed. Look for another
         // allowed side that Minecraft could naturally connect to instead.
@@ -526,26 +531,26 @@ public class BlockEventHandler implements Listener
 
     // Finds a neighboring single chest that is allowed and naturally connectable.
     private @Nullable BlockFace findAllowedSingleChestConnectionFace(Claim claim, Block block, Chest chest,
-                                                                     @Nullable BlockFace ignoredFace)
+                                                                     BlockFace deniedFace)
     {
-        for (BlockFace face : HORIZONTAL_DIRECTIONS)
-        {
-            // Skip the side already handled from vanilla connection.
-            if (face == ignoredFace) continue;
+        // A normal double chest can only connect on the left/right axis.
+        // Since vanilla already connected one side and that side was denied,
+        // the only remaining possible vanilla-style alternative is the opposite side.
+        BlockFace face = deniedFace.getOppositeFace();
 
-            Block relative = block.getRelative(face);
-            if (!(relative.getBlockData() instanceof Chest relativeChest)) continue;
-            if (block.getType() != relative.getType()) continue;
-            if (relativeChest.getType() != Chest.Type.SINGLE) continue;
+        Block relative = block.getRelative(face);
+        if (!(relative.getBlockData() instanceof Chest relativeChest)) return null;
+        if (block.getType() != relative.getType()) return null;
+        if (relativeChest.getType() != Chest.Type.SINGLE) return null;
 
-            // Do not treat claim permission as enough to force a connection.
-            // The neighboring chest must also be naturally connectable.
-            if (cannotNaturallyConnectChests(chest, relativeChest, face)) continue;
+        // Do not treat claim permission as enough to force a connection.
+        // The neighboring chest must also be naturally connectable.
+        if (cannotNaturallyConnectChests(chest, relativeChest, face)) return null;
 
-            Claim relativeClaim = this.dataStore.getClaimAt(relative.getLocation(), true, claim);
-            if (sameClaimOwner(claim, relativeClaim)) return face;
-        }
-        return null;
+        Claim relativeClaim = this.dataStore.getClaimAt(relative.getLocation(), true, claim);
+        if (!sameClaimOwner(claim, relativeClaim)) return null;
+
+        return face;
     }
 
     // Splits a double chest back into two single chests.
@@ -650,7 +655,9 @@ public class BlockEventHandler implements Listener
     {
         // Important: wilderness and admin claims must not be treated as the same
         // just because both may have a null owner ID.
-        if (first == null || second == null) return first == second;
+        if (first == null || second == null)
+            return first == second;
+
         return Objects.equals(first.getOwnerID(), second.getOwnerID());
     }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -18,10 +18,10 @@
 
 package me.ryanhamshire.GriefPrevention;
 
+import com.griefprevention.protection.ProtectionHelper;
 import com.griefprevention.visualization.BoundaryVisualization;
 import com.griefprevention.visualization.VisualizationType;
 import me.ryanhamshire.GriefPrevention.util.BoundingBox;
-import com.griefprevention.protection.ProtectionHelper;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
@@ -488,18 +488,21 @@ public class BlockEventHandler implements Listener
             BlockFace.WEST
     };
 
-    // Custom check for chest connections across claim boundaries.
-    private void denyConnectingDoubleChestsAcrossClaimBoundary(Claim claim, Block block, Player player) {
+    private void denyConnectingDoubleChestsAcrossClaimBoundary(Claim claim, Block block, Player player)
+    {
         // Only apply this logic to placed chests.
         if (!(block.getBlockData() instanceof Chest chest)) return;
 
         // Only interfere when Minecraft already connected this chest to a side
         // that should not be allowed by the claim ownership rule.
         BlockFace connectedFace = getConnectedFace(chest);
+
         if (connectedFace == null) return;
 
         Block connectedBlock = block.getRelative(connectedFace);
+
         if (!(connectedBlock.getBlockData() instanceof Chest connectedChest)) return;
+
         if (block.getType() != connectedBlock.getType()) return;
 
         Claim connectedClaim = this.dataStore.getClaimAt(connectedBlock.getLocation(), true, claim);
@@ -518,7 +521,9 @@ public class BlockEventHandler implements Listener
         if (allowedFace == null) return;
 
         Block allowedBlock = block.getRelative(allowedFace);
+
         if (!(allowedBlock.getBlockData() instanceof Chest allowedChest)) return;
+
         if (block.getType() != allowedBlock.getType()) return;
 
         connectDoubleChest(chest, block, allowedChest, allowedBlock, allowedFace, player);
@@ -526,14 +531,19 @@ public class BlockEventHandler implements Listener
 
     // Finds a neighboring single chest that is allowed and naturally connectable.
     private @Nullable BlockFace findAllowedSingleChestConnectionFace(Claim claim, Block block, Chest chest,
-                                                                     @Nullable BlockFace ignoredFace) {
-        for (BlockFace face : HORIZONTAL_DIRECTIONS) {
+                                                                     @Nullable BlockFace ignoredFace)
+    {
+        for (BlockFace face : HORIZONTAL_DIRECTIONS)
+        {
             // Skip the side already handled from vanilla connection.
             if (face == ignoredFace) continue;
 
             Block relative = block.getRelative(face);
+
             if (!(relative.getBlockData() instanceof Chest relativeChest)) continue;
+
             if (block.getType() != relative.getType()) continue;
+
             if (relativeChest.getType() != Chest.Type.SINGLE) continue;
 
             // Do not treat claim permission as enough to force a connection.
@@ -541,6 +551,7 @@ public class BlockEventHandler implements Listener
             if (cannotNaturallyConnectChests(chest, relativeChest, face)) continue;
 
             Claim relativeClaim = this.dataStore.getClaimAt(relative.getLocation(), true, claim);
+
             if (sameClaimOwner(claim, relativeClaim)) return face;
         }
         return null;
@@ -548,7 +559,8 @@ public class BlockEventHandler implements Listener
 
     // Splits a double chest back into two single chests.
     private void splitDoubleChest(Block placedBlock, Chest placedChest, Block connectedBlock, Chest connectedChest,
-                                  Player player) {
+                                  Player player)
+    {
         placedChest.setType(Chest.Type.SINGLE);
         placedBlock.setBlockData(placedChest);
 
@@ -561,7 +573,8 @@ public class BlockEventHandler implements Listener
 
     // Checks whether two chests could naturally form a double chest.
     // This prevents the plugin from rotating an existing neighboring chest.
-    private boolean cannotNaturallyConnectChests(Chest placedChest, Chest relativeChest, BlockFace relativeFace) {
+    private boolean cannotNaturallyConnectChests(Chest placedChest, Chest relativeChest, BlockFace relativeFace)
+    {
         // Minecraft only forms a normal double chest when both chests face the same direction.
         if (placedChest.getFacing() != relativeChest.getFacing()) return true;
 
@@ -572,7 +585,8 @@ public class BlockEventHandler implements Listener
     }
 
     // Checks whether the neighbor is on a side where this chest cannot form a double chest.
-    private boolean isInvalidChestConnectionFace(Chest chest, BlockFace face) {
+    private boolean isInvalidChestConnectionFace(Chest chest, BlockFace face)
+    {
         BlockFace facing = chest.getFacing();
         return face != rotateClockwise(facing) && face != rotateCounterClockwise(facing);
     }
@@ -580,7 +594,8 @@ public class BlockEventHandler implements Listener
     // Connects two allowed single chests to become one double chest.
     // This method never changes the facing of the neighboring chest.
     private void connectDoubleChest(Chest placedChest, Block placedBlock, Chest relativeChest, Block relativeBlock,
-                                    BlockFace relativeFace, Player player) {
+                                    BlockFace relativeFace, Player player)
+    {
         // Safety check: only connect if this would be a natural double chest.
         if (cannotNaturallyConnectChests(placedChest, relativeChest, relativeFace)) return;
 
@@ -604,21 +619,24 @@ public class BlockEventHandler implements Listener
     }
 
     // Returns the side where the chest is currently connected.
-    private @Nullable BlockFace getConnectedFace(Chest chest) {
+    private @Nullable BlockFace getConnectedFace(Chest chest)
+    {
         if (chest.getType() == Chest.Type.LEFT) return rotateClockwise(chest.getFacing());
         if (chest.getType() == Chest.Type.RIGHT) return rotateCounterClockwise(chest.getFacing());
         return null;
     }
 
     // Converts a connected side into the correct chest half type.
-    private Chest.Type getChestTypeForConnection(BlockFace facing, BlockFace connectedFace) {
+    private Chest.Type getChestTypeForConnection(BlockFace facing, BlockFace connectedFace)
+    {
         if (connectedFace == rotateClockwise(facing)) return Chest.Type.LEFT;
         if (connectedFace == rotateCounterClockwise(facing)) return Chest.Type.RIGHT;
         return Chest.Type.SINGLE;
     }
 
     // Rotates a horizontal direction clockwise.
-    private BlockFace rotateClockwise(BlockFace face) {
+    private BlockFace rotateClockwise(BlockFace face)
+    {
         if (face == BlockFace.NORTH) return BlockFace.EAST;
         if (face == BlockFace.EAST) return BlockFace.SOUTH;
         if (face == BlockFace.SOUTH) return BlockFace.WEST;
@@ -627,7 +645,8 @@ public class BlockEventHandler implements Listener
     }
 
     // Rotates a horizontal direction counter-clockwise.
-    private BlockFace rotateCounterClockwise(BlockFace face) {
+    private BlockFace rotateCounterClockwise(BlockFace face)
+    {
         if (face == BlockFace.NORTH) return BlockFace.WEST;
         if (face == BlockFace.WEST) return BlockFace.SOUTH;
         if (face == BlockFace.SOUTH) return BlockFace.EAST;
@@ -636,10 +655,12 @@ public class BlockEventHandler implements Listener
     }
 
     // Compares claim ownership while keeping wilderness and admin claims separate.
-    private boolean sameClaimOwner(@Nullable Claim first, @Nullable Claim second) {
+    private boolean sameClaimOwner(@Nullable Claim first, @Nullable Claim second)
+    {
         // Important: wilderness and admin claims must not be treated as the same
         // just because both may have a null owner ID.
         if (first == null || second == null) return first == second;
+
         return Objects.equals(first.getOwnerID(), second.getOwnerID());
     }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -487,46 +487,159 @@ public class BlockEventHandler implements Listener
             BlockFace.SOUTH,
             BlockFace.WEST
     };
-    private void denyConnectingDoubleChestsAcrossClaimBoundary(Claim claim, Block block, Player player)
-    {
 
-        // Check for double chests placed just outside the claim boundary
-        if (block.getBlockData() instanceof Chest chest)
-        {
-            for (BlockFace face : HORIZONTAL_DIRECTIONS)
-            {
-                Block relative = block.getRelative(face);
-                if (!(relative.getBlockData() instanceof Chest relativeChest)) continue;
+    // Custom check for chest connections across claim boundaries.
+    private void denyConnectingDoubleChestsAcrossClaimBoundary(Claim claim, Block block, Player player) {
+        // Only apply this logic to placed chests.
+        if (!(block.getBlockData() instanceof Chest chest)) return;
 
-                Claim relativeClaim = this.dataStore.getClaimAt(relative.getLocation(), true, claim);
+        // Only interfere when Minecraft already connected this chest to a side
+        // that should not be allowed by the claim ownership rule.
+        BlockFace connectedFace = getConnectedFace(chest);
+        if (connectedFace == null) return;
 
-                // Chests outside claims should connect, and chests in claims owned by the same owner should connect.
-                if (sameClaimOwner(claim, relativeClaim)) break;
+        Block connectedBlock = block.getRelative(connectedFace);
+        if (!(connectedBlock.getBlockData() instanceof Chest connectedChest)) return;
+        if (block.getType() != connectedBlock.getType()) return;
 
-                // Ignore existing double chests; only adjacent single chests are handled here.
-                if (relativeChest.getType() != Chest.Type.SINGLE) continue;
+        Claim connectedClaim = this.dataStore.getClaimAt(connectedBlock.getLocation(), true, claim);
 
-                // Change both chests to singular chests
-                chest.setType(Chest.Type.SINGLE);
-                block.setBlockData(chest);
+        // If vanilla connected to an allowed side, do not interfere.
+        // This preserves Minecraft's natural behavior.
+        if (sameClaimOwner(claim, connectedClaim)) return;
 
-                relativeChest.setType(Chest.Type.SINGLE);
-                relative.setBlockData(relativeChest);
+        // Vanilla connected to a side that should not be allowed. Look for another
+        // allowed side that Minecraft could naturally connect to instead.
+        BlockFace allowedFace = findAllowedSingleChestConnectionFace(claim, block, chest, connectedFace);
 
-                // Resend relative chest block to prevent visual bug
-                player.sendBlockChange(relative.getLocation(), relativeChest);
-                break;
-            }
-        }
+        // Always undo the invalid vanilla connection first.
+        splitDoubleChest(block, chest, connectedBlock, connectedChest, player);
+
+        if (allowedFace == null) return;
+
+        Block allowedBlock = block.getRelative(allowedFace);
+        if (!(allowedBlock.getBlockData() instanceof Chest allowedChest)) return;
+        if (block.getType() != allowedBlock.getType()) return;
+
+        connectDoubleChest(chest, block, allowedChest, allowedBlock, allowedFace, player);
     }
 
-    private boolean sameClaimOwner(Claim first, Claim second)
-    {
+    // Finds a neighboring single chest that is allowed and naturally connectable.
+    private @Nullable BlockFace findAllowedSingleChestConnectionFace(Claim claim, Block block, Chest chest,
+                                                                     @Nullable BlockFace ignoredFace) {
+        for (BlockFace face : HORIZONTAL_DIRECTIONS) {
+            // Skip the side already handled from vanilla connection.
+            if (face == ignoredFace) continue;
+
+            Block relative = block.getRelative(face);
+            if (!(relative.getBlockData() instanceof Chest relativeChest)) continue;
+            if (block.getType() != relative.getType()) continue;
+            if (relativeChest.getType() != Chest.Type.SINGLE) continue;
+
+            // Do not treat claim permission as enough to force a connection.
+            // The neighboring chest must also be naturally connectable.
+            if (cannotNaturallyConnectChests(chest, relativeChest, face)) continue;
+
+            Claim relativeClaim = this.dataStore.getClaimAt(relative.getLocation(), true, claim);
+            if (sameClaimOwner(claim, relativeClaim)) return face;
+        }
+        return null;
+    }
+
+    // Splits a double chest back into two single chests.
+    private void splitDoubleChest(Block placedBlock, Chest placedChest, Block connectedBlock, Chest connectedChest,
+                                  Player player) {
+        placedChest.setType(Chest.Type.SINGLE);
+        placedBlock.setBlockData(placedChest);
+
+        connectedChest.setType(Chest.Type.SINGLE);
+        connectedBlock.setBlockData(connectedChest);
+
+        player.sendBlockChange(placedBlock.getLocation(), placedChest);
+        player.sendBlockChange(connectedBlock.getLocation(), connectedChest);
+    }
+
+    // Checks whether two chests could naturally form a double chest.
+    // This prevents the plugin from rotating an existing neighboring chest.
+    private boolean cannotNaturallyConnectChests(Chest placedChest, Chest relativeChest, BlockFace relativeFace) {
+        // Minecraft only forms a normal double chest when both chests face the same direction.
+        if (placedChest.getFacing() != relativeChest.getFacing()) return true;
+
+        // The placed chest must be able to connect on the relative side,
+        // and the relative chest must be able to connect back on the opposite side.
+        return isInvalidChestConnectionFace(placedChest, relativeFace) ||
+                isInvalidChestConnectionFace(relativeChest, relativeFace.getOppositeFace());
+    }
+
+    // Checks whether the neighbor is on a side where this chest cannot form a double chest.
+    private boolean isInvalidChestConnectionFace(Chest chest, BlockFace face) {
+        BlockFace facing = chest.getFacing();
+        return face != rotateClockwise(facing) && face != rotateCounterClockwise(facing);
+    }
+
+    // Connects two allowed single chests to become one double chest.
+    // This method never changes the facing of the neighboring chest.
+    private void connectDoubleChest(Chest placedChest, Block placedBlock, Chest relativeChest, Block relativeBlock,
+                                    BlockFace relativeFace, Player player) {
+        // Safety check: only connect if this would be a natural double chest.
+        if (cannotNaturallyConnectChests(placedChest, relativeChest, relativeFace)) return;
+
+        BlockFace facing = placedChest.getFacing();
+
+        // Calculate the correct LEFT/RIGHT type for both chest blocks.
+        Chest.Type placedType = getChestTypeForConnection(facing, relativeFace);
+        Chest.Type relativeType = getChestTypeForConnection(facing, relativeFace.getOppositeFace());
+
+        if (placedType == Chest.Type.SINGLE || relativeType == Chest.Type.SINGLE) return;
+
+        placedChest.setType(placedType);
+        placedBlock.setBlockData(placedChest);
+
+        relativeChest.setType(relativeType);
+        relativeBlock.setBlockData(relativeChest);
+
+        // Resend both blocks to prevent visual desync.
+        player.sendBlockChange(placedBlock.getLocation(), placedChest);
+        player.sendBlockChange(relativeBlock.getLocation(), relativeChest);
+    }
+
+    // Returns the side where the chest is currently connected.
+    private @Nullable BlockFace getConnectedFace(Chest chest) {
+        if (chest.getType() == Chest.Type.LEFT) return rotateClockwise(chest.getFacing());
+        if (chest.getType() == Chest.Type.RIGHT) return rotateCounterClockwise(chest.getFacing());
+        return null;
+    }
+
+    // Converts a connected side into the correct chest half type.
+    private Chest.Type getChestTypeForConnection(BlockFace facing, BlockFace connectedFace) {
+        if (connectedFace == rotateClockwise(facing)) return Chest.Type.LEFT;
+        if (connectedFace == rotateCounterClockwise(facing)) return Chest.Type.RIGHT;
+        return Chest.Type.SINGLE;
+    }
+
+    // Rotates a horizontal direction clockwise.
+    private BlockFace rotateClockwise(BlockFace face) {
+        if (face == BlockFace.NORTH) return BlockFace.EAST;
+        if (face == BlockFace.EAST) return BlockFace.SOUTH;
+        if (face == BlockFace.SOUTH) return BlockFace.WEST;
+        if (face == BlockFace.WEST) return BlockFace.NORTH;
+        return face;
+    }
+
+    // Rotates a horizontal direction counter-clockwise.
+    private BlockFace rotateCounterClockwise(BlockFace face) {
+        if (face == BlockFace.NORTH) return BlockFace.WEST;
+        if (face == BlockFace.WEST) return BlockFace.SOUTH;
+        if (face == BlockFace.SOUTH) return BlockFace.EAST;
+        if (face == BlockFace.EAST) return BlockFace.NORTH;
+        return face;
+    }
+
+    // Compares claim ownership while keeping wilderness and admin claims separate.
+    private boolean sameClaimOwner(@Nullable Claim first, @Nullable Claim second) {
         // Important: wilderness and admin claims must not be treated as the same
         // just because both may have a null owner ID.
-        if (first == null || second == null)
-            return first == second;
-
+        if (first == null || second == null) return first == second;
         return Objects.equals(first.getOwnerID(), second.getOwnerID());
     }
 

--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -18,6 +18,7 @@
 
 package me.ryanhamshire.GriefPrevention;
 
+import com.griefprevention.protection.ChestProtectionHandler;
 import com.griefprevention.protection.ProtectionHelper;
 import com.griefprevention.visualization.BoundaryVisualization;
 import com.griefprevention.visualization.VisualizationType;
@@ -36,7 +37,6 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Lightable;
-import org.bukkit.block.data.type.Chest;
 import org.bukkit.block.data.type.Dispenser;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Fireball;
@@ -483,176 +483,7 @@ public class BlockEventHandler implements Listener
 
     private void denyConnectingDoubleChestsAcrossClaimBoundary(Claim claim, Block block, Player player)
     {
-        // Only apply this logic to placed chests.
-        if (!(block.getBlockData() instanceof Chest chest)) return;
-
-        // Only interfere when Minecraft already connected this chest to a side
-        // that should not be allowed by the claim ownership rule.
-        BlockFace connectedFace = getConnectedFace(chest);
-        if (connectedFace == null) return;
-
-        Block connectedBlock = block.getRelative(connectedFace);
-        if (!(connectedBlock.getBlockData() instanceof Chest connectedChest)) return;
-        if (block.getType() != connectedBlock.getType()) return;
-
-        Claim connectedClaim = this.dataStore.getClaimAt(connectedBlock.getLocation(), true, claim);
-
-        if (sameClaimOwner(claim, connectedClaim)) return;
-
-        // Avoid fallback chest connections when sneaking
-        if (player.isSneaking())
-        {
-            splitDoubleChest(block, chest, connectedBlock, connectedChest, player);
-            return;
-        }
-
-        // Vanilla connected to a side that should not be allowed. Look for another
-        // allowed side that Minecraft could naturally connect to instead.
-        BlockFace allowedFace = findAllowedSingleChestConnectionFace(claim, block, chest, connectedFace);
-
-        // Always undo the invalid vanilla connection first.
-        splitDoubleChest(block, chest, connectedBlock, connectedChest, player);
-
-        if (allowedFace == null) return;
-
-        Block allowedBlock = block.getRelative(allowedFace);
-        if (!(allowedBlock.getBlockData() instanceof Chest allowedChest)) return;
-        if (block.getType() != allowedBlock.getType()) return;
-
-        connectDoubleChest(chest, block, allowedChest, allowedBlock, allowedFace, player);
-    }
-
-    // Checks whether the opposite side of the denied connection has an allowed,
-    // naturally connectable single chest.
-    private @Nullable BlockFace findAllowedSingleChestConnectionFace(Claim claim, Block block, Chest chest,
-                                                                     BlockFace deniedFace)
-    {
-        // A normal double chest can only connect on the left/right axis.
-        // Since vanilla already connected one side and that side was denied,
-        // the only remaining possible vanilla-style alternative is the opposite side.
-        BlockFace face = deniedFace.getOppositeFace();
-
-        Block relative = block.getRelative(face);
-        if (!(relative.getBlockData() instanceof Chest relativeChest)) return null;
-        if (block.getType() != relative.getType()) return null;
-        if (relativeChest.getType() != Chest.Type.SINGLE) return null;
-
-        // Do not treat claim permission as enough to force a connection.
-        // The neighboring chest must also be naturally connectable.
-        if (cannotNaturallyConnectChests(chest, relativeChest, face)) return null;
-
-        Claim relativeClaim = this.dataStore.getClaimAt(relative.getLocation(), true, claim);
-        if (!sameClaimOwner(claim, relativeClaim)) return null;
-
-        return face;
-    }
-
-    // Splits a double chest back into two single chests.
-    private void splitDoubleChest(Block placedBlock, Chest placedChest, Block connectedBlock, Chest connectedChest,
-                                  Player player)
-    {
-        placedChest.setType(Chest.Type.SINGLE);
-        placedBlock.setBlockData(placedChest);
-
-        connectedChest.setType(Chest.Type.SINGLE);
-        connectedBlock.setBlockData(connectedChest);
-
-        player.sendBlockChange(placedBlock.getLocation(), placedChest);
-        player.sendBlockChange(connectedBlock.getLocation(), connectedChest);
-    }
-
-    // Checks whether two chests could naturally form a double chest.
-    // This prevents the plugin from rotating an existing neighboring chest.
-    private boolean cannotNaturallyConnectChests(Chest placedChest, Chest relativeChest, BlockFace relativeFace)
-    {
-        // Minecraft only forms a normal double chest when both chests face the same direction.
-        if (placedChest.getFacing() != relativeChest.getFacing()) return true;
-
-        // The placed chest must be able to connect on the relative side,
-        // and the relative chest must be able to connect back on the opposite side.
-        return isInvalidChestConnectionFace(placedChest, relativeFace) ||
-                isInvalidChestConnectionFace(relativeChest, relativeFace.getOppositeFace());
-    }
-
-    // Checks whether the neighbor is on a side where this chest cannot form a double chest.
-    private boolean isInvalidChestConnectionFace(Chest chest, BlockFace face)
-    {
-        BlockFace facing = chest.getFacing();
-        return face != rotateClockwise(facing) && face != rotateCounterClockwise(facing);
-    }
-
-    // Connects two allowed single chests to become one double chest.
-    // This method never changes the facing of the neighboring chest.
-    private void connectDoubleChest(Chest placedChest, Block placedBlock, Chest relativeChest, Block relativeBlock,
-                                    BlockFace relativeFace, Player player)
-    {
-        // Safety check: only connect if this would be a natural double chest.
-        if (cannotNaturallyConnectChests(placedChest, relativeChest, relativeFace)) return;
-
-        BlockFace facing = placedChest.getFacing();
-
-        // Calculate the correct LEFT/RIGHT type for both chest blocks.
-        Chest.Type placedType = getChestTypeForConnection(facing, relativeFace);
-        Chest.Type relativeType = getChestTypeForConnection(facing, relativeFace.getOppositeFace());
-
-        if (placedType == Chest.Type.SINGLE || relativeType == Chest.Type.SINGLE) return;
-
-        placedChest.setType(placedType);
-        placedBlock.setBlockData(placedChest);
-
-        relativeChest.setType(relativeType);
-        relativeBlock.setBlockData(relativeChest);
-
-        // Resend both blocks to prevent visual desync.
-        player.sendBlockChange(placedBlock.getLocation(), placedChest);
-        player.sendBlockChange(relativeBlock.getLocation(), relativeChest);
-    }
-
-    // Returns the side where the chest is currently connected.
-    private @Nullable BlockFace getConnectedFace(Chest chest)
-    {
-        if (chest.getType() == Chest.Type.LEFT) return rotateClockwise(chest.getFacing());
-        if (chest.getType() == Chest.Type.RIGHT) return rotateCounterClockwise(chest.getFacing());
-        return null;
-    }
-
-    // Converts a connected side into the correct chest half type.
-    private Chest.Type getChestTypeForConnection(BlockFace facing, BlockFace connectedFace)
-    {
-        if (connectedFace == rotateClockwise(facing)) return Chest.Type.LEFT;
-        if (connectedFace == rotateCounterClockwise(facing)) return Chest.Type.RIGHT;
-        return Chest.Type.SINGLE;
-    }
-
-    // Rotates a horizontal direction clockwise.
-    private BlockFace rotateClockwise(BlockFace face)
-    {
-        if (face == BlockFace.NORTH) return BlockFace.EAST;
-        if (face == BlockFace.EAST) return BlockFace.SOUTH;
-        if (face == BlockFace.SOUTH) return BlockFace.WEST;
-        if (face == BlockFace.WEST) return BlockFace.NORTH;
-        return face;
-    }
-
-    // Rotates a horizontal direction counter-clockwise.
-    private BlockFace rotateCounterClockwise(BlockFace face)
-    {
-        if (face == BlockFace.NORTH) return BlockFace.WEST;
-        if (face == BlockFace.WEST) return BlockFace.SOUTH;
-        if (face == BlockFace.SOUTH) return BlockFace.EAST;
-        if (face == BlockFace.EAST) return BlockFace.NORTH;
-        return face;
-    }
-
-    // Compares claim ownership while keeping wilderness and admin claims separate.
-    private boolean sameClaimOwner(@Nullable Claim first, @Nullable Claim second)
-    {
-        // Important: wilderness and admin claims must not be treated as the same
-        // just because both may have a null owner ID.
-        if (first == null || second == null)
-            return first == second;
-
-        return Objects.equals(first.getOwnerID(), second.getOwnerID());
+        ChestProtectionHandler.denyConnectingDoubleChestsAcrossClaimBoundary(this.dataStore, claim, block, player);
     }
 
     // Prevent pistons pushing blocks into or out of claims.


### PR DESCRIPTION
## Summary

Fixes #2611.

Fixes inconsistent double chest connection behavior near claim borders when a newly placed chest has multiple possible single chest connection targets.

When placing a chest near a claim border, the selected connection target could differ depending on placement direction. In some cases, a valid connection inside the claim was incorrectly prevented. In other cases, a chest outside the claim could connect to a claimed chest across the claim boundary.

This change makes the chest connection validation respect the claim boundary consistently when multiple connection targets are possible.

## Changes

- Prevents double chest connections from crossing a claim boundary.
- Allows valid double chest connections when both chests are inside the same valid claim context.
- Handles cases where the newly placed chest has more than one possible single chest target.
- Keeps the protection behavior consistent regardless of placement direction or claim side.

## Testing

Tested the scenario described in #2611:

1. Created a claim owned by the player.
2. Placed one single chest inside the claim near the border.
3. Placed another single chest outside the claim near the same border.
4. Placed a new chest between the two single chests, where it had multiple possible connection targets.
5. Verified that the new chest does not connect claimed and unclaimed chests across the claim border.
6. Verified that valid in-claim chest connections are still allowed.

Build [a972ed1](https://github.com/thiagorigonatti/GriefPrevention/releases/tag/a972ed1) for testing.

