### PR TITLE
Add player to trapped rescue event

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -2595,7 +2595,7 @@ public class GriefPrevention extends JavaPlugin
             }
 
             //rescue destination may be set by GPFlags or other plugin, ask to find out
-            SaveTrappedPlayerEvent event = new SaveTrappedPlayerEvent(claim);
+            SaveTrappedPlayerEvent event = new SaveTrappedPlayerEvent(player, claim);
             Bukkit.getPluginManager().callEvent(event);
 
             //if the player is in the nether or end, he's screwed (there's no way to programmatically find a safe place for him)

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/SaveTrappedPlayerEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/SaveTrappedPlayerEvent.java
@@ -26,7 +26,8 @@ public class SaveTrappedPlayerEvent extends ClaimEvent implements Cancellable
     @Deprecated
     public SaveTrappedPlayerEvent(@NotNull Claim claim)
     {
-        this(null, claim);
+        super(claim);
+        this.player = null;
     }
 
     /**
@@ -35,7 +36,7 @@ public class SaveTrappedPlayerEvent extends ClaimEvent implements Cancellable
      * @param player {@link Player} to be rescued
      * @param claim {@link Claim} the user is to be rescued from
      */
-    public SaveTrappedPlayerEvent(@Nullable Player player, @NotNull Claim claim)
+    public SaveTrappedPlayerEvent(@NotNull Player player, @NotNull Claim claim)
     {
         super(claim);
         this.player = player;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/SaveTrappedPlayerEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/SaveTrappedPlayerEvent.java
@@ -18,7 +18,7 @@ public class SaveTrappedPlayerEvent extends ClaimEvent implements Cancellable
     private @Nullable Location destination = null;
 
     /**
-     * Construct a new {@code ClaimChangeEvent}.
+     * Construct a new {@code SaveTrappedPlayerEvent}.
      *
      * @param claim {@link Claim} the user is to be rescued from
      * @deprecated use {@link #SaveTrappedPlayerEvent(Player, Claim)}

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/SaveTrappedPlayerEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/SaveTrappedPlayerEvent.java
@@ -2,6 +2,7 @@ package me.ryanhamshire.GriefPrevention.events;
 
 import me.ryanhamshire.GriefPrevention.Claim;
 import org.bukkit.Location;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
@@ -13,16 +14,41 @@ import org.jetbrains.annotations.Nullable;
 public class SaveTrappedPlayerEvent extends ClaimEvent implements Cancellable
 {
 
+    private final @Nullable Player player;
     private @Nullable Location destination = null;
 
     /**
      * Construct a new {@code ClaimChangeEvent}.
      *
      * @param claim {@link Claim} the user is to be rescued from
+     * @deprecated use {@link #SaveTrappedPlayerEvent(Player, Claim)}
      */
+    @Deprecated
     public SaveTrappedPlayerEvent(@NotNull Claim claim)
     {
+        this(null, claim);
+    }
+
+    /**
+     * Construct a new {@code ClaimChangeEvent}.
+     *
+     * @param player {@link Player} to be rescued
+     * @param claim {@link Claim} the user is to be rescued from
+     */
+    public SaveTrappedPlayerEvent(@Nullable Player player, @NotNull Claim claim)
+    {
         super(claim);
+        this.player = player;
+    }
+
+    /**
+     * Get the player to be rescued.
+     *
+     * @return the {@code Player}, or {@code null} if constructed without one
+     */
+    public @Nullable Player getPlayer()
+    {
+        return player;
     }
 
     /**

--- a/src/main/java/me/ryanhamshire/GriefPrevention/events/SaveTrappedPlayerEvent.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/events/SaveTrappedPlayerEvent.java
@@ -31,7 +31,7 @@ public class SaveTrappedPlayerEvent extends ClaimEvent implements Cancellable
     }
 
     /**
-     * Construct a new {@code ClaimChangeEvent}.
+     * Construct a new {@code SaveTrappedPlayerEvent}.
      *
      * @param player {@link Player} to be rescued
      * @param claim {@link Claim} the user is to be rescued from


### PR DESCRIPTION
Adds the trapped player to `SaveTrappedPlayerEvent` and marks the old claimonly constructor as deprecated for legacy