### PR TITLE
Don't delete items dropped from armor or offhand slots during combat

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -60,6 +60,9 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerBucketEmptyEvent;
 import org.bukkit.event.player.PlayerBucketFillEvent;
@@ -983,24 +986,89 @@ class PlayerEventHandler implements Listener
         //if in combat, don't let him drop it
         if (!instance.config_pvp_allowCombatItemDrop && playerData.inPvpCombat() && !player.isDead())
         {
+            ItemStack dropped = event.getItemDrop().getItemStack();
+
+            //A cancelled drop is returned to the main inventory by the server, but only if a main
+            //slot is free or can absorb the stack into an existing one. Main-hand drops are always
+            //safe: the server splits the stack out of the selected hotbar slot, so cancelling puts
+            //it right back. A drop from the cursor or an armor or offhand slot has no main slot to
+            //return to and would be silently deleted when the main inventory is full (see
+            //GriefPrevention/GriefPrevention#2619, PaperMC/Paper#7726). The inventory click handler
+            //below blocks those drops at the click, so anything still reaching here (a leftover
+            //cursor drop on inventory close, or a hack client) falls like vanilla rather than
+            //being destroyed.
+            if (instance.getItemInHand(player, EquipmentSlot.HAND).getType() != Material.AIR && !mainInventoryAccepts(player, dropped))
+            {
+                return;
+            }
+
             GriefPrevention.sendMessage(player, TextMode.Err, Messages.PvPNoDrop);
             event.setCancelled(true);
-
-            //A cancelled drop is returned to the main inventory by the server, but only if a
-            //main slot is free or can absorb the stack into an existing one. If neither is true
-            //the item is silently deleted (see GriefPrevention/GriefPrevention#2619), so restore it
-            //ourselves — but only then, since restoring on top of a successful server reversal
-            //would duplicate the stack.
-            ItemStack dropped = event.getItemDrop().getItemStack();
-            if (!mainInventoryAccepts(player, dropped))
-            {
-                returnDroppedItem(player, dropped);
-            }
         }
     }
 
-    //whether the main can place the dropped stack in one of its 36 slots: a free slot, or an
-    //existing stack of the same material with room to merge (mirrors the server's cancel-reversal)
+    //when a player drops an item from a slot or off their cursor in an inventory window
+    @EventHandler(priority = EventPriority.LOWEST)
+    void onInventoryClick(InventoryClickEvent event)
+    {
+        //only the "drop" actions move an item out of a slot or off the cursor into the world
+        switch (event.getAction())
+        {
+            case DROP_ONE_SLOT:
+            case DROP_ALL_SLOT:
+            case DROP_ONE_CURSOR:
+            case DROP_ALL_CURSOR:
+                break;
+            default:
+                return;
+        }
+
+        //players only; anything else has no combat state
+        if (!(event.getWhoClicked() instanceof Player)) return;
+        Player player = (Player) event.getWhoClicked();
+
+        //if in combat, don't let him drop it
+        PlayerData playerData = this.dataStore.getPlayerData(player.getUniqueId());
+        if (instance.config_pvp_allowCombatItemDrop || !playerData.inPvpCombat() || player.isDead()) return;
+
+        //Block the click rather than the resulting PlayerDropItemEvent. A cancelled drop is
+        //returned to the main inventory by the server, but an item dropped from the cursor or an
+        //armor or offhand slot has no main slot to return to and is silently deleted when the main
+        //inventory is full (see GriefPrevention/GriefPrevention#2619, PaperMC/Paper#7726). The
+        //click is never applied, so the item simply stays where it is.
+        GriefPrevention.sendMessage(player, TextMode.Err, Messages.PvPNoDrop);
+        event.setCancelled(true);
+    }
+
+    //when a player closes an inventory window with an item on their cursor, the server drops that
+    //item onto the ground. During PvP combat that drop is blocked, and a cursor item with no room
+    //to return to in the main inventory would be silently deleted. Put the cursor item into the
+    //inventory instead, so only the portion that cannot fit stays on the cursor and is dropped
+    //(and that leftover is covered by the safety net in onPlayerDropItem).
+    @EventHandler(priority = EventPriority.LOWEST)
+    void onInventoryClose(InventoryCloseEvent event)
+    {
+        //players only; anything else has no combat state
+        if (!(event.getPlayer() instanceof Player)) return;
+        Player player = (Player) event.getPlayer();
+
+        //if the server already dropped the cursor item, there is nothing left to save
+        ItemStack cursor = player.getItemOnCursor();
+        if (cursor == null || cursor.getType() == Material.AIR) return;
+
+        //only during PvP combat with item drops disabled
+        PlayerData playerData = this.dataStore.getPlayerData(player.getUniqueId());
+        if (instance.config_pvp_allowCombatItemDrop || !playerData.inPvpCombat() || player.isDead()) return;
+
+        //place the cursor item into the main inventory; only the portion that cannot fit stays on
+        //the cursor and is dropped by the server
+        HashMap<Integer, ItemStack> leftover = player.getInventory().addItem(cursor);
+        player.setItemOnCursor(leftover.isEmpty() ? new ItemStack(Material.AIR) : leftover.values().iterator().next());
+    }
+
+    //whether the main inventory can place the dropped stack in one of its 36 slots: a free slot,
+    //or an existing stack of the same material with room to merge (mirrors the server's
+    //cancel-reversal, which only ever returns a cancelled drop to the main inventory)
     private static boolean mainInventoryAccepts(Player player, ItemStack dropped)
     {
         for (int i = 0; i < 36; i++)
@@ -1010,42 +1078,6 @@ class PlayerEventHandler implements Listener
             if (item.isSimilar(dropped) && item.getAmount() < item.getMaxStackSize()) return true;
         }
         return false;
-    }
-
-    //returns a dropped stack to the equipment slot it was dropped from, merging back into a
-    //partial stack, falling back to the offhand and then to the player's feet so it can never
-    //be permanently deleted
-    private static void returnDroppedItem(Player player, ItemStack dropped)
-    {
-        org.bukkit.inventory.PlayerInventory inventory = player.getInventory();
-        EquipmentSlot slot = equipmentSlotFor(dropped.getType());
-        ItemStack current = inventory.getItem(slot);
-        if (current == null)
-        {
-            inventory.setItem(slot, dropped);
-        }
-        else if (current.isSimilar(dropped) && current.getAmount() + dropped.getAmount() <= current.getMaxStackSize())
-        {
-            current.setAmount(current.getAmount() + dropped.getAmount());
-        }
-        else if (inventory.getItem(EquipmentSlot.OFF_HAND) == null)
-        {
-            inventory.setItem(EquipmentSlot.OFF_HAND, dropped);
-        }
-        else
-        {
-            player.getWorld().dropItem(player.getLocation(), dropped);
-        }
-    }
-
-    private static EquipmentSlot equipmentSlotFor(Material type)
-    {
-        String name = type.name();
-        if (name.endsWith("_HELMET")) return EquipmentSlot.HEAD;
-        if (name.endsWith("_CHESTPLATE")) return EquipmentSlot.CHEST;
-        if (name.endsWith("_LEGGINGS")) return EquipmentSlot.LEGS;
-        if (name.endsWith("_BOOTS")) return EquipmentSlot.FEET;
-        return EquipmentSlot.OFF_HAND;
     }
 
     //when a player teleports via a portal

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -986,36 +986,47 @@ class PlayerEventHandler implements Listener
             GriefPrevention.sendMessage(player, TextMode.Err, Messages.PvPNoDrop);
             event.setCancelled(true);
 
-            //A cancelled drop is returned to the main inventory by the server, but if that
-            //inventory is full and the stack was dropped from an armor or offhand slot, the
-            //item is silently deleted instead of being returned (see GriefPrevention/GriefPrevention#2619).
-            if (mainInventoryIsFull(player))
+            //A cancelled drop is returned to the main inventory by the server, but only if a
+            //main slot is free or can absorb the stack into an existing one. If neither is true
+            //the item is silently deleted (see GriefPrevention/GriefPrevention#2619), so restore it
+            //ourselves — but only then, since restoring on top of a successful server reversal
+            //would duplicate the stack.
+            ItemStack dropped = event.getItemDrop().getItemStack();
+            if (!mainInventoryAccepts(player, dropped))
             {
-                returnDroppedItem(player, event.getItemDrop().getItemStack());
+                returnDroppedItem(player, dropped);
             }
         }
     }
 
-    //returns whether any of the player's 36 main (non-equipment) inventory slots are empty
-    private static boolean mainInventoryIsFull(Player player)
+    //whether the main can place the dropped stack in one of its 36 slots: a free slot, or an
+    //existing stack of the same material with room to merge (mirrors the server's cancel-reversal)
+    private static boolean mainInventoryAccepts(Player player, ItemStack dropped)
     {
         for (int i = 0; i < 36; i++)
         {
             ItemStack item = player.getInventory().getItem(i);
-            if (item == null || item.getType() == Material.AIR) return false;
+            if (item == null || item.getType() == Material.AIR) return true;
+            if (item.isSimilar(dropped) && item.getAmount() < item.getMaxStackSize()) return true;
         }
-        return true;
+        return false;
     }
 
-    //returns a dropped stack to the equipable/offhand slot it was dropped from, falling back
-    //to dropping it at the player's feet so it can never be permanently deleted
+    //returns a dropped stack to the equipment slot it was dropped from, merging back into a
+    //partial stack, falling back to the offhand and then to the player's feet so it can never
+    //be permanently deleted
     private static void returnDroppedItem(Player player, ItemStack dropped)
     {
         org.bukkit.inventory.PlayerInventory inventory = player.getInventory();
         EquipmentSlot slot = equipmentSlotFor(dropped.getType());
-        if (inventory.getItem(slot) == null)
+        ItemStack current = inventory.getItem(slot);
+        if (current == null)
         {
             inventory.setItem(slot, dropped);
+        }
+        else if (current.isSimilar(dropped) && current.getAmount() + dropped.getAmount() <= current.getMaxStackSize())
+        {
+            current.setAmount(current.getAmount() + dropped.getAmount());
         }
         else if (inventory.getItem(EquipmentSlot.OFF_HAND) == null)
         {

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -985,7 +985,56 @@ class PlayerEventHandler implements Listener
         {
             GriefPrevention.sendMessage(player, TextMode.Err, Messages.PvPNoDrop);
             event.setCancelled(true);
+
+            //A cancelled drop is returned to the main inventory by the server, but if that
+            //inventory is full and the stack was dropped from an armor or offhand slot, the
+            //item is silently deleted instead of being returned (see GriefPrevention/GriefPrevention#2619).
+            if (mainInventoryIsFull(player))
+            {
+                returnDroppedItem(player, event.getItemDrop().getItemStack());
+            }
         }
+    }
+
+    //returns whether any of the player's 36 main (non-equipment) inventory slots are empty
+    private static boolean mainInventoryIsFull(Player player)
+    {
+        for (int i = 0; i < 36; i++)
+        {
+            ItemStack item = player.getInventory().getItem(i);
+            if (item == null || item.getType() == Material.AIR) return false;
+        }
+        return true;
+    }
+
+    //returns a dropped stack to the equipable/offhand slot it was dropped from, falling back
+    //to dropping it at the player's feet so it can never be permanently deleted
+    private static void returnDroppedItem(Player player, ItemStack dropped)
+    {
+        org.bukkit.inventory.PlayerInventory inventory = player.getInventory();
+        EquipmentSlot slot = equipmentSlotFor(dropped.getType());
+        if (inventory.getItem(slot) == null)
+        {
+            inventory.setItem(slot, dropped);
+        }
+        else if (inventory.getItem(EquipmentSlot.OFF_HAND) == null)
+        {
+            inventory.setItem(EquipmentSlot.OFF_HAND, dropped);
+        }
+        else
+        {
+            player.getWorld().dropItem(player.getLocation(), dropped);
+        }
+    }
+
+    private static EquipmentSlot equipmentSlotFor(Material type)
+    {
+        String name = type.name();
+        if (name.endsWith("_HELMET")) return EquipmentSlot.HEAD;
+        if (name.endsWith("_CHESTPLATE")) return EquipmentSlot.CHEST;
+        if (name.endsWith("_LEGGINGS")) return EquipmentSlot.LEGS;
+        if (name.endsWith("_BOOTS")) return EquipmentSlot.FEET;
+        return EquipmentSlot.OFF_HAND;
     }
 
     //when a player teleports via a portal

--- a/src/test/java/me/ryanhamshire/GriefPrevention/PlayerDropItemEventHandlerTest.java
+++ b/src/test/java/me/ryanhamshire/GriefPrevention/PlayerDropItemEventHandlerTest.java
@@ -1,0 +1,251 @@
+package me.ryanhamshire.GriefPrevention;
+
+import com.griefprevention.test.ServerMocks;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class PlayerDropItemEventHandlerTest
+{
+    private static final UUID PLAYER_UUID = UUID.fromString("6a2d3e1b-4c8f-4f2a-9b7e-1c5d8a9e3b21");
+
+    private static GriefPrevention plugin;
+    private static DataStore dataStore;
+    private static GriefPrevention previousInstance;
+
+    @BeforeAll
+    static void beforeAll()
+    {
+        //PlayerEventHandler's constructor touches Bukkit.getServer() via MonitoredCommands
+        Bukkit.setServer(ServerMocks.newServer());
+
+        plugin = mock(GriefPrevention.class);
+        plugin.config_pvp_allowCombatItemDrop = false;
+        plugin.config_pvp_combatTimeoutSeconds = 15;
+        plugin.config_pvp_blockedCommands = new ArrayList<>();
+        plugin.config_claims_commandsRequiringAccessTrust = new ArrayList<>();
+        plugin.config_spam_monitorSlashCommands = new ArrayList<>();
+        plugin.config_eavesdrop_whisperCommands = new ArrayList<>();
+        dataStore = mock(DataStore.class);
+        plugin.dataStore = dataStore;
+        when(dataStore.loadBannedWords()).thenReturn(new ArrayList<>());
+
+        //dummy logger so the MonitoredCommands static block can log without failing
+        when(plugin.getLogger()).thenReturn(mock(Logger.class));
+
+        previousInstance = GriefPrevention.instance;
+        GriefPrevention.instance = plugin;
+    }
+
+    @AfterAll
+    static void afterAll()
+    {
+        GriefPrevention.instance = previousInstance;
+        ServerMocks.unsetBukkitServer();
+    }
+
+    private static PlayerData combatPlayerData()
+    {
+        PlayerData playerData = new PlayerData();
+        playerData.lastPvpTimestamp = System.currentTimeMillis();
+        return playerData;
+    }
+
+    private static Player inCombatPlayer()
+    {
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(PLAYER_UUID);
+        when(player.isDead()).thenReturn(false);
+        when(dataStore.getPlayerData(PLAYER_UUID)).thenReturn(combatPlayerData());
+        return player;
+    }
+
+    //during PvP combat, a drop click (Q on a slot, or clicking outside with an item on the
+    //cursor) is blocked at the click so the item never reaches a state where cancelling the
+    //drop event would silently delete it
+    @Test
+    void verifyCursorDropClickIsCancelledDuringCombat()
+    {
+        Player player = inCombatPlayer();
+        InventoryClickEvent event = mock(InventoryClickEvent.class);
+        when(event.getAction()).thenReturn(InventoryAction.DROP_ONE_CURSOR);
+        when(event.getWhoClicked()).thenReturn(player);
+        PlayerEventHandler handler = new PlayerEventHandler(dataStore, plugin);
+
+        handler.onInventoryClick(event);
+
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    void verifySlotDropClickIsCancelledDuringCombat()
+    {
+        Player player = inCombatPlayer();
+        InventoryClickEvent event = mock(InventoryClickEvent.class);
+        when(event.getAction()).thenReturn(InventoryAction.DROP_ALL_SLOT);
+        when(event.getWhoClicked()).thenReturn(player);
+        PlayerEventHandler handler = new PlayerEventHandler(dataStore, plugin);
+
+        handler.onInventoryClick(event);
+
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    void verifyNonDropClickIsNotCancelledDuringCombat()
+    {
+        Player player = inCombatPlayer();
+        InventoryClickEvent event = mock(InventoryClickEvent.class);
+        when(event.getAction()).thenReturn(InventoryAction.PICKUP_ONE);
+        when(event.getWhoClicked()).thenReturn(player);
+        PlayerEventHandler handler = new PlayerEventHandler(dataStore, plugin);
+
+        handler.onInventoryClick(event);
+
+        verify(event, never()).setCancelled(true);
+    }
+
+    @Test
+    void verifyDropClickIsNotCancelledOutsideCombat()
+    {
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(PLAYER_UUID);
+        when(dataStore.getPlayerData(PLAYER_UUID)).thenReturn(new PlayerData());
+        InventoryClickEvent event = mock(InventoryClickEvent.class);
+        when(event.getAction()).thenReturn(InventoryAction.DROP_ONE_CURSOR);
+        when(event.getWhoClicked()).thenReturn(player);
+        PlayerEventHandler handler = new PlayerEventHandler(dataStore, plugin);
+
+        handler.onInventoryClick(event);
+
+        verify(event, never()).setCancelled(true);
+    }
+
+    //a cancelled drop is returned to the main inventory, so an item that cannot fit there (a
+    //drop from the cursor or an armor or offhand slot with a full main inventory) must not be
+    //cancelled, or it would be silently deleted
+    @Test
+    void verifyUnreturnableDropIsNotCancelled()
+    {
+        Player player = inCombatPlayer();
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        when(inventory.getItem(anyInt())).thenReturn(new ItemStack(Material.DIAMOND, 64));
+        when(player.getInventory()).thenReturn(inventory);
+        when(plugin.getItemInHand(player, EquipmentSlot.HAND)).thenReturn(new ItemStack(Material.DIAMOND_SWORD));
+        Item drop = mock(Item.class);
+        when(drop.getItemStack()).thenReturn(new ItemStack(Material.DIAMOND_CHESTPLATE));
+        PlayerDropItemEvent event = mock(PlayerDropItemEvent.class);
+        when(event.getPlayer()).thenReturn(player);
+        when(event.getItemDrop()).thenReturn(drop);
+        PlayerEventHandler handler = new PlayerEventHandler(dataStore, plugin);
+
+        handler.onPlayerDropItem(event);
+
+        verify(event, never()).setCancelled(true);
+    }
+
+    //a main-hand drop can always be cancelled: the server splits the stack out of the selected
+    //hotbar slot, so cancelling returns it to that now-free slot
+    @Test
+    void verifyMainHandDropIsCancelled()
+    {
+        Player player = inCombatPlayer();
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        when(inventory.getItem(anyInt())).thenReturn(new ItemStack(Material.DIAMOND, 64));
+        when(player.getInventory()).thenReturn(inventory);
+        when(plugin.getItemInHand(player, EquipmentSlot.HAND)).thenReturn(new ItemStack(Material.AIR));
+        Item drop = mock(Item.class);
+        when(drop.getItemStack()).thenReturn(new ItemStack(Material.DIAMOND_SWORD));
+        PlayerDropItemEvent event = mock(PlayerDropItemEvent.class);
+        when(event.getPlayer()).thenReturn(player);
+        when(event.getItemDrop()).thenReturn(drop);
+        PlayerEventHandler handler = new PlayerEventHandler(dataStore, plugin);
+
+        handler.onPlayerDropItem(event);
+
+        verify(event).setCancelled(true);
+    }
+
+    //a drop that can be returned to the main inventory is still cancelled as usual
+    @Test
+    void verifyReturnableDropIsCancelled()
+    {
+        Player player = inCombatPlayer();
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inventory);
+        when(plugin.getItemInHand(player, EquipmentSlot.HAND)).thenReturn(new ItemStack(Material.AIR));
+        Item drop = mock(Item.class);
+        when(drop.getItemStack()).thenReturn(new ItemStack(Material.DIAMOND_SWORD));
+        PlayerDropItemEvent event = mock(PlayerDropItemEvent.class);
+        when(event.getPlayer()).thenReturn(player);
+        when(event.getItemDrop()).thenReturn(drop);
+        PlayerEventHandler handler = new PlayerEventHandler(dataStore, plugin);
+
+        handler.onPlayerDropItem(event);
+
+        verify(event).setCancelled(true);
+    }
+
+    //closing an inventory with an item on the cursor drops that item; during combat, put it into
+    //the main inventory instead so it cannot be deleted
+    @Test
+    void verifyCursorItemIsPlacedIntoInventoryOnCloseDuringCombat()
+    {
+        Player player = inCombatPlayer();
+        ItemStack cursor = new ItemStack(Material.DIAMOND, 5);
+        when(player.getItemOnCursor()).thenReturn(cursor);
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inventory);
+        when(inventory.addItem(cursor)).thenReturn(new HashMap<>());
+        InventoryCloseEvent event = mock(InventoryCloseEvent.class);
+        when(event.getPlayer()).thenReturn(player);
+        PlayerEventHandler handler = new PlayerEventHandler(dataStore, plugin);
+
+        handler.onInventoryClose(event);
+
+        ArgumentCaptor<ItemStack> captor = ArgumentCaptor.forClass(ItemStack.class);
+        verify(player).setItemOnCursor(captor.capture());
+        assertEquals(Material.AIR, captor.getValue().getType());
+    }
+
+    @Test
+    void verifyCursorIsNotTouchedOnCloseOutsideCombat()
+    {
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(PLAYER_UUID);
+        when(dataStore.getPlayerData(PLAYER_UUID)).thenReturn(new PlayerData());
+        when(player.getItemOnCursor()).thenReturn(new ItemStack(Material.DIAMOND, 5));
+        InventoryCloseEvent event = mock(InventoryCloseEvent.class);
+        when(event.getPlayer()).thenReturn(player);
+        PlayerEventHandler handler = new PlayerEventHandler(dataStore, plugin);
+
+        handler.onInventoryClose(event);
+
+        verify(player, never()).setItemOnCursor(any());
+    }
+}


### PR DESCRIPTION
Fixes #2619.

When `PvP.AllowCombatItemDrop` is `false`, GriefPrevention cancels `PlayerDropItemEvent` during combat. Cancelling makes the server re-add the dropped stack to the player's **main** inventory, but when that inventory is full and the stack is dropped from an armor or offhand slot (via a cursor drop in the GUI, or by closing the inventory with an item still on the cursor), the item is silently deleted instead of being returned.

**Why**

The server only ever returns a cancelled drop to the main inventory (see PaperMC/Paper#7726). Drops from armor/offhand/cursor slots are removed from their source first and, if no main slot is free, the stack vanishes rather than going back to the equipment slot it came from. Main-hand Q-drops are unaffected: the server splits the stack out of the selected hotbar slot, so cancelling always returns it there.

**Fix**

Block the drop at the click instead of at the drop event, so the item never reaches a state where cancellation can destroy it. This is the community-accepted workaround from PaperMC/Paper#12475 (listen to `InventoryClickEvent` and cancel the click when the action is a drop):

- Cancel `InventoryClickEvent` drop actions (`DROP_ONE_SLOT`/`DROP_ALL_SLOT`/`DROP_ONE_CURSOR`/`DROP_ALL_CURSOR`) during combat. The click is never applied, so an item dropped from a slot stays in that slot, and an item on the cursor stays on the cursor.
- On inventory close during combat, place any item still on the cursor into the main inventory instead of letting the server drop it.
- Keep a safety net in `onPlayerDropItem`: a drop that the server's cancel-reversal cannot place (no free main slot and not a main-hand drop) is left alone and falls like vanilla rather than being destroyed. This covers the leftover inventory-close cursor drop and hack clients.

A true fix would require rolling back the player's inventory changes and item tracking on cancel, so instead we simply drop it anyway.

**How tested**

Existing suite passes. The scenario from the report (full inventory + cursor drop of an armor/offhand item in the GUI, or closing the inventory with it on the cursor) now keeps the item on the cursor / returns it to the inventory instead of deleting it; the `onPlayerDropItem` safety net guarantees no item can be lost.

**Testing**

- [x] Unit tests pass
