### PR TITLE
Don't process knockback events twice on Paper

### DIFF
--- a/src/main/java/com/griefprevention/platform/knockback/PaperKnockbackProtectionHandler.java
+++ b/src/main/java/com/griefprevention/platform/knockback/PaperKnockbackProtectionHandler.java
@@ -61,6 +61,12 @@ public class PaperKnockbackProtectionHandler extends KnockbackProtectionHandler
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
     public void onEntityPushedByEntityAttack(@NotNull EntityPushedByEntityAttackEvent event)
     {
+        // EntityKnockbackByEntityEvent extends this event, and the whole hierarchy shares the
+        // single HandlerList declared by EntityKnockbackEvent, so both listeners in this class
+        // are invoked for every EntityKnockbackByEntityEvent. Let the more specific handler
+        // above own those instead of processing them twice.
+        if (event instanceof EntityKnockbackByEntityEvent) return;
+
         Entity pusher = event.getPushedBy();
 
         Player attacker;


### PR DESCRIPTION
Removes duplicate processing in `PaperKnockbackProtectionHandler`, where a single
`EntityKnockbackByEntityEvent` currently runs the full protection path twice.

The class registers handlers for both:

```java
@EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
public void onEntityPushedByEntityAttack(@NotNull EntityPushedByEntityAttackEvent event)
{
    Entity pusher = event.getPushedBy();
```

and `EntityKnockbackByEntityEvent`.

`com.destroystokyo.paper.event.entity.EntityKnockbackByEntityEvent` extends
`io.papermc.paper.event.entity.EntityPushedByEntityAttackEvent`, while only the base
`io.papermc.paper.event.entity.EntityKnockbackEvent` declares a `HandlerList`.
As a result, both `@EventHandler` methods are registered against the same handler list.

## Why

`JavaPluginLoader`'s event executor checks whether the listener method's declared
parameter type is assignable from the event being fired.

This makes the reverse case safe: a plain `EntityPushedByEntityAttackEvent` does not
reach `onEntityKnockbackByEntity`, because it is not assignable to
`EntityKnockbackByEntityEvent`.

However, an `EntityKnockbackByEntityEvent` *is* assignable to both handler parameter
types. Therefore, every applicable melee hit runs the protection logic twice,
including:

* `getClaimAt`
* `checkPermission`
* `PreventPvPEvent` dispatch

When the first pass cancels the event, `ignoreCancelled = true` prevents the second
handler from running, which makes the duplicate processing easy to miss. When the
first pass does not cancel, other plugins can receive a second `PreventPvPEvent` for
the same hit.

## Verification

Verified against `paper-api 26.2`:

```text
$ javap -cp paper-api-26.2.jar com.destroystokyo.paper.event.entity.EntityKnockbackByEntityEvent

public class com.destroystokyo.paper.event.entity.EntityKnockbackByEntityEvent
    extends io.papermc.paper.event.entity.EntityPushedByEntityAttackEvent
```

`javap` against the same API jar confirms that neither subclass declares its own
`getHandlerList()`. Inspection of the anonymous `EventExecutor` generated by
`JavaPluginLoader` also confirms the `isAssignableFrom` guard described above.

## How found

This was discovered while investigating a report that the mace's Wind Burst
enchantment does not launch the attacker while inside claims.

That issue turned out to be unrelated to this change and specific to the
GriefPrevention3D fork. Its `BlockExplodeEventHandler` cancels the entire
`BlockExplodeEvent` inside claims, which suppresses the explosion's player knockback
along with its block damage.

Upstream does not have that behavior: `BlockExplodeEvent` is routed through the same
shared `handleExplosion` / `handleExplodeInteract` logic used for entity explosions,
so upstream is unaffected by the Wind Burst issue.

The duplicate knockback-event processing described above was discovered during that
investigation and is independently an upstream issue.

## Testing

* [x] Tested on Paper
* [x] `mvn test` — no new failures

Two pre-existing test errors remain in `BlockEventHandlerTest` and
`MonitoredCommandsTest` because Mockito cannot mock `java.util.logging.Logger` under
JDK 26. Both reproduce identically on an unmodified checkout and are unrelated to
this change.
